### PR TITLE
[#16793] Add Spotless Maven Plugin for auto-formatting

### DIFF
--- a/build/bom/pom.xml
+++ b/build/bom/pom.xml
@@ -46,6 +46,7 @@
       <version.maven.gpg>3.2.8</version.maven.gpg>
       <version.maven.javadoc>3.12.0</version.maven.javadoc>
       <version.maven.sonatype.central>0.10.0</version.maven.sonatype.central>
+      <version.maven.spotless>3.2.1</version.maven.spotless>
    </properties>
 
    <dependencyManagement>
@@ -408,6 +409,31 @@
          </dependency>
       </dependencies>
    </dependencyManagement>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <version>${version.maven.spotless}</version>
+            <configuration>
+               <java>
+                  <importOrder>
+                     <order>\#,java,javax,org,com,</order>
+                  </importOrder>
+                  <indent>
+                     <spaces>true</spaces>
+                     <spacesPerTab>3</spacesPerTab>
+                  </indent>
+                  <removeUnusedImports/>
+                  <trimTrailingWhitespace/>
+                  <endWithNewline/>
+                  <toggleOffOn/>
+               </java>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 
    <profiles>
       <profile>

--- a/build/component-processor/src/main/java/org/infinispan/component/processor/AnnotationTypeValuesExtractor.java
+++ b/build/component-processor/src/main/java/org/infinispan/component/processor/AnnotationTypeValuesExtractor.java
@@ -3,6 +3,7 @@ package org.infinispan.component.processor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.ExecutableElement;

--- a/build/logging-annotations/src/main/java/org/infinispan/logging/annotations/Description.java
+++ b/build/logging-annotations/src/main/java/org/infinispan/logging/annotations/Description.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 
 /**
  * Description.
- * 
+ *
  * @author Durgesh Anaokar
  * @since 13.0
  */
@@ -19,9 +19,9 @@ import java.lang.annotation.Target;
 public @interface Description {
 
    /**
-    * 
+    *
     * Return the Description for the log message.
-    * 
+    *
     * @return String
     */
    String value();

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/DataType.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/DataType.java
@@ -12,7 +12,7 @@ public enum DataType {
    COLLECTION(InfinispanProperties.COLLECTION, InfinispanProperties.DEF_ENTITY_RESOURCE, DataType::noValidation),
    IMMUTABLE_ENTITY(InfinispanProperties.IMMUTABLE_ENTITY, InfinispanProperties.DEF_ENTITY_RESOURCE, DataType::noValidation),
    TIMESTAMPS(InfinispanProperties.TIMESTAMPS, InfinispanProperties.DEF_TIMESTAMPS_RESOURCE, c -> {
-      if ( c.clustering().cacheMode().isInvalidation() ) {
+      if (c.clustering().cacheMode().isInvalidation()) {
          throw log().timestampsMustNotUseInvalidation();
       }
       if (c.memory().isEvictionEnabled()) {

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/DefaultCacheManagerProvider.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/DefaultCacheManagerProvider.java
@@ -95,8 +95,7 @@ public class DefaultCacheManagerProvider implements EmbeddedCacheManagerProvider
          // Workaround Infinispan's ClassLoader strategies to bend to our will:
          builderHolder.getGlobalConfigurationBuilder().classLoader(classLoader);
          return builderHolder;
-      }
-      finally {
+      } finally {
          currentThread.setContextClassLoader(originalClassLoader);
       }
    }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/JndiCacheManagerProvider.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/JndiCacheManagerProvider.java
@@ -16,7 +16,7 @@ import org.kohsuke.MetaInfServices;
 
 @MetaInfServices(EmbeddedCacheManagerProvider.class)
 public class JndiCacheManagerProvider implements EmbeddedCacheManagerProvider {
-   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( JndiCacheManagerProvider.class );
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(JndiCacheManagerProvider.class);
 
    @Override
    public EmbeddedCacheManager getEmbeddedCacheManager(Properties properties) {

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/AccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/AccessDelegate.java
@@ -9,152 +9,151 @@ import org.hibernate.cache.spi.access.SoftLock;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public interface AccessDelegate {
-	Object get(Object session, Object key, long txTimestamp) throws CacheException;
+   Object get(Object session, Object key, long txTimestamp) throws CacheException;
 
-	/**
-	 * Attempt to cache an object, after loading from the database.
-	 *
-	 * @param session Current session
-	 * @param key The item key
-	 * @param value The item
-	 * @param txTimestamp a timestamp prior to the transaction start time
-	 * @param version the item version number
-	 * @return <code>true</code> if the object was successfully cached
-	 */
-	boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version);
+   /**
+    * Attempt to cache an object, after loading from the database.
+    *
+    * @param session     Current session
+    * @param key         The item key
+    * @param value       The item
+    * @param txTimestamp a timestamp prior to the transaction start time
+    * @param version     the item version number
+    * @return <code>true</code> if the object was successfully cached
+    */
+   boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version);
 
-	/**
-	 * Attempt to cache an object, after loading from the database, explicitly
-	 * specifying the minimalPut behavior.
-	 *
-	 * @param session Current session.
-	 * @param key The item key
-	 * @param value The item
-	 * @param txTimestamp a timestamp prior to the transaction start time
-	 * @param version the item version number
-	 * @param minimalPutOverride Explicit minimalPut flag
-	 * @return <code>true</code> if the object was successfully cached
-	 * @throws org.hibernate.cache.CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
-	 */
-	boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
-			throws CacheException;
+   /**
+    * Attempt to cache an object, after loading from the database, explicitly
+    * specifying the minimalPut behavior.
+    *
+    * @param session            Current session.
+    * @param key                The item key
+    * @param value              The item
+    * @param txTimestamp        a timestamp prior to the transaction start time
+    * @param version            the item version number
+    * @param minimalPutOverride Explicit minimalPut flag
+    * @return <code>true</code> if the object was successfully cached
+    * @throws org.hibernate.cache.CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
+    */
+   boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+         throws CacheException;
 
-	/**
-	 * Called after an item has been inserted (before the transaction completes),
-	 * instead of calling evict().
-	 *
-	 * @param session Current session
-	 * @param key The item key
-	 * @param value The item
-	 * @param version The item's version value
-	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException if the insert fails
-	 */
-	boolean insert(Object session, Object key, Object value, Object version) throws CacheException;
+   /**
+    * Called after an item has been inserted (before the transaction completes),
+    * instead of calling evict().
+    *
+    * @param session Current session
+    * @param key     The item key
+    * @param value   The item
+    * @param version The item's version value
+    * @return Were the contents of the cache actual changed by this operation?
+    * @throws CacheException if the insert fails
+    */
+   boolean insert(Object session, Object key, Object value, Object version) throws CacheException;
 
-	/**
-	 * Called after an item has been updated (before the transaction completes),
-	 * instead of calling evict().
-	 *
-	 * @param session Current session
-	 * @param key The item key
-	 * @param value The item
-	 * @param currentVersion The item's current version value
-	 * @param previousVersion The item's previous version value
-	 * @return Whether the contents of the cache actual changed by this operation
-	 * @throws CacheException if the update fails
-	 */
-	boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion)
-			throws CacheException;
+   /**
+    * Called after an item has been updated (before the transaction completes),
+    * instead of calling evict().
+    *
+    * @param session         Current session
+    * @param key             The item key
+    * @param value           The item
+    * @param currentVersion  The item's current version value
+    * @param previousVersion The item's previous version value
+    * @return Whether the contents of the cache actual changed by this operation
+    * @throws CacheException if the update fails
+    */
+   boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion)
+         throws CacheException;
 
-	/**
-	 * Called after an item has become stale (before the transaction completes).
-	 *
-	 * @param session Current session
-	 * @param key The key of the item to remove
-	 * @throws CacheException if removing the cached item fails
-	 */
-	void remove(Object session, Object key) throws CacheException;
+   /**
+    * Called after an item has become stale (before the transaction completes).
+    *
+    * @param session Current session
+    * @param key     The key of the item to remove
+    * @throws CacheException if removing the cached item fails
+    */
+   void remove(Object session, Object key) throws CacheException;
 
-	/**
-	 * Called just before the delegate will have all entries removed. Any work to prevent concurrent modifications
-	 * while this occurs should happen here
-	 * @throws CacheException if locking had an issue
-	 */
-	void lockAll() throws CacheException;
+   /**
+    * Called just before the delegate will have all entries removed. Any work to prevent concurrent modifications
+    * while this occurs should happen here
+    *
+    * @throws CacheException if locking had an issue
+    */
+   void lockAll() throws CacheException;
 
-	/**
-	 * Called just after the delegate had all entries removed via {@link #removeAll()}. Any work required to allow
-	 * for new modifications to happen should be done here
-	 * @throws CacheException if unlocking had an issue
-	 */
-	void unlockAll() throws CacheException;
+   /**
+    * Called just after the delegate had all entries removed via {@link #removeAll()}. Any work required to allow
+    * for new modifications to happen should be done here
+    *
+    * @throws CacheException if unlocking had an issue
+    */
+   void unlockAll() throws CacheException;
 
-	/**
-	 * Called to evict data from the entire region
-	 *
-	 * @throws CacheException if eviction the region fails
-	 */
-	void removeAll() throws CacheException;
+   /**
+    * Called to evict data from the entire region
+    *
+    * @throws CacheException if eviction the region fails
+    */
+   void removeAll() throws CacheException;
 
-	/**
-	 * Forcibly evict an item from the cache immediately without regard for transaction
-	 * isolation.
-	 *
-	 * @param key The key of the item to remove
-	 * @throws CacheException if evicting the item fails
-	 */
-	void evict(Object key) throws CacheException;
+   /**
+    * Forcibly evict an item from the cache immediately without regard for transaction
+    * isolation.
+    *
+    * @param key The key of the item to remove
+    * @throws CacheException if evicting the item fails
+    */
+   void evict(Object key) throws CacheException;
 
-	/**
-	 * Forcibly evict all items from the cache immediately without regard for transaction
-	 * isolation.
-	 *
-	 * @throws CacheException if evicting items fails
-	 */
-	void evictAll() throws CacheException;
+   /**
+    * Forcibly evict all items from the cache immediately without regard for transaction
+    * isolation.
+    *
+    * @throws CacheException if evicting items fails
+    */
+   void evictAll() throws CacheException;
 
-	/**
-	 * Called when we have finished the attempted update/delete (which may or
-	 * may not have been successful), after transaction completion.  This method
-	 * is used by "asynchronous" concurrency strategies.
-	 *
-	 *
-	 * @param session
-	 * @param key The item key
-	 * @throws org.hibernate.cache.CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
-	 */
-	void unlockItem(Object session, Object key) throws CacheException;
+   /**
+    * Called when we have finished the attempted update/delete (which may or
+    * may not have been successful), after transaction completion.  This method
+    * is used by "asynchronous" concurrency strategies.
+    *
+    * @param session
+    * @param key     The item key
+    * @throws org.hibernate.cache.CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
+    */
+   void unlockItem(Object session, Object key) throws CacheException;
 
-	/**
-	 * Called after an item has been inserted (after the transaction completes),
-	 * instead of calling release().
-	 * This method is used by "asynchronous" concurrency strategies.
-	 *
-	 *
-	 * @param session
-	 * @param key The item key
-	 * @param value The item
-	 * @param version The item's version value
-	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
-	 */
-	boolean afterInsert(Object session, Object key, Object value, Object version);
+   /**
+    * Called after an item has been inserted (after the transaction completes),
+    * instead of calling release().
+    * This method is used by "asynchronous" concurrency strategies.
+    *
+    * @param session
+    * @param key     The item key
+    * @param value   The item
+    * @param version The item's version value
+    * @return Were the contents of the cache actual changed by this operation?
+    * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
+    */
+   boolean afterInsert(Object session, Object key, Object value, Object version);
 
-	/**
-	 * Called after an item has been updated (after the transaction completes),
-	 * instead of calling release().  This method is used by "asynchronous"
-	 * concurrency strategies.
-	 *
-	 *
-	 * @param session
-	 * @param key The item key
-	 * @param value The item
-	 * @param currentVersion The item's current version value
-	 * @param previousVersion The item's previous version value
-	 * @param lock The lock
-	 * @return Were the contents of the cache actual changed by this operation?
-	 * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
-	 */
-	boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock);
+   /**
+    * Called after an item has been updated (after the transaction completes),
+    * instead of calling release().  This method is used by "asynchronous"
+    * concurrency strategies.
+    *
+    * @param session
+    * @param key             The item key
+    * @param value           The item
+    * @param currentVersion  The item's current version value
+    * @param previousVersion The item's previous version value
+    * @param lock            The lock
+    * @return Were the contents of the cache actual changed by this operation?
+    * @throws CacheException Propagated from underlying {@link org.hibernate.cache.spi.Region}
+    */
+   boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock);
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/BaseInvalidationInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/BaseInvalidationInterceptor.java
@@ -23,65 +23,68 @@ import org.infinispan.util.ByteString;
 
 @MBean
 public abstract class BaseInvalidationInterceptor extends BaseRpcInterceptor implements JmxStatisticsExposer {
-	private final AtomicLong invalidations = new AtomicLong(0);
+   private final AtomicLong invalidations = new AtomicLong(0);
 
-	@Inject protected CommandsFactory commandsFactory;
-	@Inject protected DistributionManager distributionManager;
-	@Inject protected Cache cache;
+   @Inject
+   protected CommandsFactory commandsFactory;
+   @Inject
+   protected DistributionManager distributionManager;
+   @Inject
+   protected Cache cache;
 
-	protected ByteString cacheName;
-	protected boolean statisticsEnabled;
-	protected RpcOptions syncRpcOptions;
+   protected ByteString cacheName;
+   protected boolean statisticsEnabled;
+   protected RpcOptions syncRpcOptions;
 
-	@Start
+   @Start
    void start() {
-		this.cacheName = ByteString.fromString(cache.getName());
-		this.setStatisticsEnabled(cacheConfiguration.statistics().enabled());
-		syncRpcOptions = rpcManager.getSyncRpcOptions();
-	}
+      this.cacheName = ByteString.fromString(cache.getName());
+      this.setStatisticsEnabled(cacheConfiguration.statistics().enabled());
+      syncRpcOptions = rpcManager.getSyncRpcOptions();
+   }
 
-	@ManagedOperation(
-			description = "Resets statistics gathered by this component",
-			displayName = "Reset statistics"
-	)
-	public void resetStatistics() {
-		invalidations.set(0);
-	}
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset statistics"
+   )
+   public void resetStatistics() {
+      invalidations.set(0);
+   }
 
-	@ManagedAttribute(
-			displayName = "Statistics enabled",
-			description = "Enables or disables the gathering of statistics by this component",
-			dataType = DataType.TRAIT,
-			writable = true
-	)
-	public boolean getStatisticsEnabled() {
-		return this.statisticsEnabled;
-	}
+   @ManagedAttribute(
+         displayName = "Statistics enabled",
+         description = "Enables or disables the gathering of statistics by this component",
+         dataType = DataType.TRAIT,
+         writable = true
+   )
+   public boolean getStatisticsEnabled() {
+      return this.statisticsEnabled;
+   }
 
-	public void setStatisticsEnabled(boolean enabled) {
-		this.statisticsEnabled = enabled;
-	}
+   public void setStatisticsEnabled(boolean enabled) {
+      this.statisticsEnabled = enabled;
+   }
 
-	@ManagedAttribute(
-			description = "Number of invalidations",
-			displayName = "Number of invalidations",
-			measurementType = MeasurementType.TRENDSUP
-	)
-	public long getInvalidations() {
-		return invalidations.get();
-	}
+   @ManagedAttribute(
+         description = "Number of invalidations",
+         displayName = "Number of invalidations",
+         measurementType = MeasurementType.TRENDSUP
+   )
+   public long getInvalidations() {
+      return invalidations.get();
+   }
 
-	protected void incrementInvalidations() {
-		if (statisticsEnabled) {
-			invalidations.incrementAndGet();
-		}
-	}
+   protected void incrementInvalidations() {
+      if (statisticsEnabled) {
+         invalidations.incrementAndGet();
+      }
+   }
 
-	protected List<Address> getMembers() {
-		return distributionManager.getCacheTopology().getMembers();
-	}
+   protected List<Address> getMembers() {
+      return distributionManager.getCacheTopology().getMembers();
+   }
 
-	protected boolean isPutForExternalRead(FlagAffectedCommand command) {
+   protected boolean isPutForExternalRead(FlagAffectedCommand command) {
       return command.hasAnyFlag(FlagBitSets.PUT_FOR_EXTERNAL_READ);
    }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/FutureUpdateSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/FutureUpdateSynchronization.java
@@ -4,8 +4,8 @@ import java.util.UUID;
 
 import org.infinispan.commons.util.Util;
 import org.infinispan.functional.FunctionalMap;
-import org.infinispan.hibernate.cache.commons.access.SessionAccess.TransactionCoordinatorAccess;
 import org.infinispan.hibernate.cache.commons.InfinispanDataRegion;
+import org.infinispan.hibernate.cache.commons.access.SessionAccess.TransactionCoordinatorAccess;
 import org.infinispan.hibernate.cache.commons.util.FutureUpdate;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 import org.infinispan.hibernate.cache.commons.util.InvocationAfterCompletion;
@@ -14,52 +14,51 @@ import org.infinispan.hibernate.cache.commons.util.InvocationAfterCompletion;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class FutureUpdateSynchronization extends InvocationAfterCompletion {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( FutureUpdateSynchronization.class );
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(FutureUpdateSynchronization.class);
 
-	private final UUID uuid = Util.threadLocalRandomUUID();
-	private final Object key;
-	private final Object value;
-	private final InfinispanDataRegion region;
-	private final long sessionTimestamp;
-	private final FunctionalMap.ReadWriteMap<Object, Object> rwMap;
+   private final UUID uuid = Util.threadLocalRandomUUID();
+   private final Object key;
+   private final Object value;
+   private final InfinispanDataRegion region;
+   private final long sessionTimestamp;
+   private final FunctionalMap.ReadWriteMap<Object, Object> rwMap;
 
-	public FutureUpdateSynchronization(TransactionCoordinatorAccess tc, FunctionalMap.ReadWriteMap<Object, Object> rwMap, boolean requiresTransaction,
-												  Object key, Object value, InfinispanDataRegion region, long sessionTimestamp) {
+   public FutureUpdateSynchronization(TransactionCoordinatorAccess tc, FunctionalMap.ReadWriteMap<Object, Object> rwMap, boolean requiresTransaction,
+                                      Object key, Object value, InfinispanDataRegion region, long sessionTimestamp) {
 
-		super(tc, requiresTransaction);
-		this.rwMap = rwMap;
-		this.key = key;
-		this.value = value;
-		this.region = region;
-		this.sessionTimestamp = sessionTimestamp;
-	}
+      super(tc, requiresTransaction);
+      this.rwMap = rwMap;
+      this.key = key;
+      this.value = value;
+      this.region = region;
+      this.sessionTimestamp = sessionTimestamp;
+   }
 
-	public UUID getUuid() {
-		return uuid;
-	}
+   public UUID getUuid() {
+      return uuid;
+   }
 
-	@Override
-	protected void invoke(boolean success) {
-		// If the region was invalidated during this session, we can't know that the value we're inserting is valid
-		// so we'll just null the tombstone
-		if (sessionTimestamp < region.getLastRegionInvalidation()) {
-			success = false;
-		}
-		// Exceptions in #afterCompletion() are silently ignored, since the transaction
-		// is already committed in DB. However we must not return until we update the cache.
-		FutureUpdate futureUpdate = new FutureUpdate(uuid, region.nextTimestamp(), success ? this.value : null);
-		for (;;) {
-			try {
-				// We expect that when the transaction completes further reads from cache will return the updated value.
-				// UnorderedDistributionInterceptor makes sure that the update is executed on the node first, and here
-				// we're waiting for the local update. The remote update does not concern us - the cache is async and
-				// we won't wait for that.
-				rwMap.eval(key, futureUpdate).join();
-				return;
-			}
-			catch (Exception e) {
-				log.failureInAfterCompletion(e);
-			}
-		}
-	}
+   @Override
+   protected void invoke(boolean success) {
+      // If the region was invalidated during this session, we can't know that the value we're inserting is valid
+      // so we'll just null the tombstone
+      if (sessionTimestamp < region.getLastRegionInvalidation()) {
+         success = false;
+      }
+      // Exceptions in #afterCompletion() are silently ignored, since the transaction
+      // is already committed in DB. However we must not return until we update the cache.
+      FutureUpdate futureUpdate = new FutureUpdate(uuid, region.nextTimestamp(), success ? this.value : null);
+      for (; ; ) {
+         try {
+            // We expect that when the transaction completes further reads from cache will return the updated value.
+            // UnorderedDistributionInterceptor makes sure that the update is executed on the node first, and here
+            // we're waiting for the local update. The remote update does not concern us - the cache is async and
+            // we won't wait for that.
+            rwMap.eval(key, futureUpdate).join();
+            return;
+         } catch (Exception e) {
+            log.failureInAfterCompletion(e);
+         }
+      }
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/InvalidationCacheAccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/InvalidationCacheAccessDelegate.java
@@ -1,11 +1,10 @@
 package org.infinispan.hibernate.cache.commons.access;
 
 import org.hibernate.cache.CacheException;
+import org.infinispan.AdvancedCache;
 import org.infinispan.hibernate.cache.commons.InfinispanDataRegion;
 import org.infinispan.hibernate.cache.commons.util.Caches;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
-
-import org.infinispan.AdvancedCache;
 
 /**
  *
@@ -14,152 +13,149 @@ import org.infinispan.AdvancedCache;
  * @since 3.5
  */
 public abstract class InvalidationCacheAccessDelegate implements AccessDelegate {
-	protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( InvalidationCacheAccessDelegate.class );
-	protected final AdvancedCache cache;
-	protected final InfinispanDataRegion region;
-	protected final PutFromLoadValidator putValidator;
-	protected final AdvancedCache<Object, Object> writeCache;
+   protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationCacheAccessDelegate.class);
+   protected final AdvancedCache cache;
+   protected final InfinispanDataRegion region;
+   protected final PutFromLoadValidator putValidator;
+   protected final AdvancedCache<Object, Object> writeCache;
 
    /**
     * Create a new transactional access delegate instance.
     *
-    * @param region to control access to
+    * @param region    to control access to
     * @param validator put from load validator
     */
-	@SuppressWarnings("unchecked")
-	protected InvalidationCacheAccessDelegate(InfinispanDataRegion region, PutFromLoadValidator validator) {
-		this.region = region;
-		this.cache = region.getCache();
-		this.putValidator = validator;
-		this.writeCache = Caches.ignoreReturnValuesCache( cache );
-	}
+   @SuppressWarnings("unchecked")
+   protected InvalidationCacheAccessDelegate(InfinispanDataRegion region, PutFromLoadValidator validator) {
+      this.region = region;
+      this.cache = region.getCache();
+      this.putValidator = validator;
+      this.writeCache = Caches.ignoreReturnValuesCache(cache);
+   }
 
    /**
     * Attempt to retrieve an object from the cache.
     *
-    *
-	 * @param session
-	 * @param key The key of the item to be retrieved
+    * @param session
+    * @param key         The key of the item to be retrieved
     * @param txTimestamp a timestamp prior to the transaction start time
     * @return the cached object or <code>null</code>
     * @throws CacheException if the cache retrieval failed
     */
-	@Override
-	@SuppressWarnings("UnusedParameters")
-	public Object get(Object session, Object key, long txTimestamp) throws CacheException {
-		if ( !region.checkValid() ) {
-			return null;
-		}
-		final Object val = cache.get( key );
-		if (val == null && session != null) {
-			putValidator.registerPendingPut(session, key, txTimestamp );
-		}
-		return val;
-	}
+   @Override
+   @SuppressWarnings("UnusedParameters")
+   public Object get(Object session, Object key, long txTimestamp) throws CacheException {
+      if (!region.checkValid()) {
+         return null;
+      }
+      final Object val = cache.get(key);
+      if (val == null && session != null) {
+         putValidator.registerPendingPut(session, key, txTimestamp);
+      }
+      return val;
+   }
 
-	@Override
-	public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version) {
-		return putFromLoad(session, key, value, txTimestamp, version, false );
-	}
+   @Override
+   public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version) {
+      return putFromLoad(session, key, value, txTimestamp, version, false);
+   }
 
    /**
     * Attempt to cache an object, after loading from the database, explicitly
     * specifying the minimalPut behavior.
     *
-	 * @param session Current session
-	 * @param key The item key
-    * @param value The item
-    * @param txTimestamp a timestamp prior to the transaction start time
-    * @param version the item version number
+    * @param session            Current session
+    * @param key                The item key
+    * @param value              The item
+    * @param txTimestamp        a timestamp prior to the transaction start time
+    * @param version            the item version number
     * @param minimalPutOverride Explicit minimalPut flag
     * @return <code>true</code> if the object was successfully cached
     * @throws CacheException if storing the object failed
     */
-	@Override
-	@SuppressWarnings("UnusedParameters")
-	public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
-			throws CacheException {
-		if ( !region.checkValid() ) {
-			if (log.isTraceEnabled()) {
-				log.tracef( "Region %s not valid", region.getName() );
-			}
-			return false;
-		}
+   @Override
+   @SuppressWarnings("UnusedParameters")
+   public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride)
+         throws CacheException {
+      if (!region.checkValid()) {
+         if (log.isTraceEnabled()) {
+            log.tracef("Region %s not valid", region.getName());
+         }
+         return false;
+      }
 
-		// In theory, since putForExternalRead is already as minimal as it can
-		// get, we shouldn't be need this check. However, without the check and
-		// without https://issues.jboss.org/browse/ISPN-1986, it's impossible to
-		// know whether the put actually occurred. Knowing this is crucial so
-		// that Hibernate can expose accurate statistics.
-		if ( minimalPutOverride && cache.containsKey( key ) ) {
-			return false;
-		}
+      // In theory, since putForExternalRead is already as minimal as it can
+      // get, we shouldn't be need this check. However, without the check and
+      // without https://issues.jboss.org/browse/ISPN-1986, it's impossible to
+      // know whether the put actually occurred. Knowing this is crucial so
+      // that Hibernate can expose accurate statistics.
+      if (minimalPutOverride && cache.containsKey(key)) {
+         return false;
+      }
 
-		PutFromLoadValidator.Lock lock = putValidator.acquirePutFromLoadLock(session, key, txTimestamp);
-		if ( lock == null) {
-			if (log.isTraceEnabled()) {
-				log.tracef( "Put from load lock not acquired for key %s", key );
-			}
-			return false;
-		}
+      PutFromLoadValidator.Lock lock = putValidator.acquirePutFromLoadLock(session, key, txTimestamp);
+      if (lock == null) {
+         if (log.isTraceEnabled()) {
+            log.tracef("Put from load lock not acquired for key %s", key);
+         }
+         return false;
+      }
 
-		try {
-			writeCache.putForExternalRead( key, value );
-		}
-		finally {
-			putValidator.releasePutFromLoadLock( key, lock);
-		}
+      try {
+         writeCache.putForExternalRead(key, value);
+      } finally {
+         putValidator.releasePutFromLoadLock(key, lock);
+      }
 
-		return true;
-	}
+      return true;
+   }
 
-	@Override
-	public void remove(Object session, Object key) throws CacheException {
-		// We update whether or not the region is valid. Other nodes
-		// may have already restored the region so they need to
-		// be informed of the change.
-		writeCache.remove(key);
-	}
+   @Override
+   public void remove(Object session, Object key) throws CacheException {
+      // We update whether or not the region is valid. Other nodes
+      // may have already restored the region so they need to
+      // be informed of the change.
+      writeCache.remove(key);
+   }
 
-	@Override
-	public void lockAll() throws CacheException {
-		if (!putValidator.beginInvalidatingRegion()) {
-			log.failedInvalidateRegion(region.getName());
-		}
-	}
+   @Override
+   public void lockAll() throws CacheException {
+      if (!putValidator.beginInvalidatingRegion()) {
+         log.failedInvalidateRegion(region.getName());
+      }
+   }
 
-	@Override
-	public void unlockAll() throws CacheException {
-		putValidator.endInvalidatingRegion();
-	}
+   @Override
+   public void unlockAll() throws CacheException {
+      putValidator.endInvalidatingRegion();
+   }
 
-	@Override
-	public void removeAll() throws CacheException {
-		Caches.removeAll(cache);
-	}
+   @Override
+   public void removeAll() throws CacheException {
+      Caches.removeAll(cache);
+   }
 
-	@Override
-	public void evict(Object key) throws CacheException {
-		writeCache.remove( key );
-	}
+   @Override
+   public void evict(Object key) throws CacheException {
+      writeCache.remove(key);
+   }
 
-	@Override
-	public void evictAll() throws CacheException {
-		try {
-			if (!putValidator.beginInvalidatingRegion()) {
-				log.failedInvalidateRegion(region.getName());
-			}
+   @Override
+   public void evictAll() throws CacheException {
+      try {
+         if (!putValidator.beginInvalidatingRegion()) {
+            log.failedInvalidateRegion(region.getName());
+         }
 
-			// Invalidate the local region and then go remote
-			region.invalidateRegion();
-			Caches.broadcastEvictAll(cache);
-		}
-		finally {
-			putValidator.endInvalidatingRegion();
-		}
-	}
+         // Invalidate the local region and then go remote
+         region.invalidateRegion();
+         Caches.broadcastEvictAll(cache);
+      } finally {
+         putValidator.endInvalidatingRegion();
+      }
+   }
 
-	@Override
-	public void unlockItem(Object session, Object key) throws CacheException {
-	}
+   @Override
+   public void unlockItem(Object session, Object key) throws CacheException {
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/InvalidationSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/InvalidationSynchronization.java
@@ -10,27 +10,28 @@ import jakarta.transaction.Status;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class InvalidationSynchronization implements jakarta.transaction.Synchronization {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationSynchronization.class);
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationSynchronization.class);
 
-	private final Object lockOwner;
-	private final NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor;
-	private final Object key;
+   private final Object lockOwner;
+   private final NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor;
+   private final Object key;
 
-	public InvalidationSynchronization(NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor, Object key, Object lockOwner) {
-		assert lockOwner != null;
-		this.nonTxPutFromLoadInterceptor = nonTxPutFromLoadInterceptor;
-		this.key = key;
-		this.lockOwner = lockOwner;
-	}
+   public InvalidationSynchronization(NonTxPutFromLoadInterceptor nonTxPutFromLoadInterceptor, Object key, Object lockOwner) {
+      assert lockOwner != null;
+      this.nonTxPutFromLoadInterceptor = nonTxPutFromLoadInterceptor;
+      this.key = key;
+      this.lockOwner = lockOwner;
+   }
 
-	@Override
-	public void beforeCompletion() {}
+   @Override
+   public void beforeCompletion() {
+   }
 
-	@Override
-	public void afterCompletion(int status) {
-		if (log.isTraceEnabled()) {
-			log.tracef("After completion callback with status %d", status);
-		}
-		nonTxPutFromLoadInterceptor.endInvalidating(key, lockOwner, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
-	}
+   @Override
+   public void afterCompletion(int status) {
+      if (log.isTraceEnabled()) {
+         log.tracef("After completion callback with status %d", status);
+      }
+      nonTxPutFromLoadInterceptor.endInvalidating(key, lockOwner, status == Status.STATUS_COMMITTED || status == Status.STATUS_COMMITTING);
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LocalInvalidationSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/LocalInvalidationSynchronization.java
@@ -20,7 +20,8 @@ public class LocalInvalidationSynchronization implements Synchronization {
    }
 
    @Override
-   public void beforeCompletion() {}
+   public void beforeCompletion() {
+   }
 
    @Override
    public void afterCompletion(int status) {

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonStrictAccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonStrictAccessDelegate.java
@@ -24,174 +24,171 @@ import org.infinispan.hibernate.cache.commons.util.VersionedEntry;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class NonStrictAccessDelegate implements AccessDelegate {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( NonStrictAccessDelegate.class );
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(NonStrictAccessDelegate.class);
    private static final SessionAccess SESSION_ACCESS = SessionAccess.findSessionAccess();
 
-	protected final InfinispanDataRegion region;
-	private final AdvancedCache cache;
-	protected final FunctionalMap.ReadWriteMap<Object, Object> writeMap;
-	private final FunctionalMap.ReadWriteMap<Object, Object> putFromLoadMap;
-	private final Comparator versionComparator;
+   protected final InfinispanDataRegion region;
+   private final AdvancedCache cache;
+   protected final FunctionalMap.ReadWriteMap<Object, Object> writeMap;
+   private final FunctionalMap.ReadWriteMap<Object, Object> putFromLoadMap;
+   private final Comparator versionComparator;
 
 
-	public NonStrictAccessDelegate(InfinispanDataRegion region, Comparator versionComparator) {
-		this.region = region;
-		this.cache = region.getCache();
-		FunctionalMap fmap = FunctionalMap.create(cache).withParams(Param.PersistenceMode.SKIP_LOAD);
-		this.writeMap = fmap.toReadWriteMap();
-		// Note that correct behaviour of local and async writes depends on LockingInterceptor (see there for details)
-		this.putFromLoadMap = fmap.toReadWriteMap().withParams(Param.LockingMode.TRY_LOCK, Param.ReplicationMode.ASYNC);
-		Configuration configuration = cache.getCacheConfiguration();
-		if (configuration.clustering().cacheMode().isInvalidation()) {
-			throw new IllegalArgumentException("Nonstrict-read-write mode cannot use invalidation.");
-		}
-		if (configuration.transaction().transactionMode().isTransactional()) {
-			throw new IllegalArgumentException("Currently transactional caches are not supported.");
-		}
-		this.versionComparator = versionComparator;
-		if (versionComparator == null) {
-			throw new IllegalArgumentException("This strategy requires versioned entities/collections but region " + region.getName() + " contains non-versioned data!");
-		}
-	}
+   public NonStrictAccessDelegate(InfinispanDataRegion region, Comparator versionComparator) {
+      this.region = region;
+      this.cache = region.getCache();
+      FunctionalMap fmap = FunctionalMap.create(cache).withParams(Param.PersistenceMode.SKIP_LOAD);
+      this.writeMap = fmap.toReadWriteMap();
+      // Note that correct behaviour of local and async writes depends on LockingInterceptor (see there for details)
+      this.putFromLoadMap = fmap.toReadWriteMap().withParams(Param.LockingMode.TRY_LOCK, Param.ReplicationMode.ASYNC);
+      Configuration configuration = cache.getCacheConfiguration();
+      if (configuration.clustering().cacheMode().isInvalidation()) {
+         throw new IllegalArgumentException("Nonstrict-read-write mode cannot use invalidation.");
+      }
+      if (configuration.transaction().transactionMode().isTransactional()) {
+         throw new IllegalArgumentException("Currently transactional caches are not supported.");
+      }
+      this.versionComparator = versionComparator;
+      if (versionComparator == null) {
+         throw new IllegalArgumentException("This strategy requires versioned entities/collections but region " + region.getName() + " contains non-versioned data!");
+      }
+   }
 
-	@Override
-	public Object get(Object session, Object key, long txTimestamp) throws CacheException {
-		if (txTimestamp < region.getLastRegionInvalidation() ) {
-			return null;
-		}
-		Object value = cache.get(key);
-		if (value instanceof VersionedEntry) {
-			return ((VersionedEntry) value).getValue();
-		}
-		return value;
-	}
+   @Override
+   public Object get(Object session, Object key, long txTimestamp) throws CacheException {
+      if (txTimestamp < region.getLastRegionInvalidation()) {
+         return null;
+      }
+      Object value = cache.get(key);
+      if (value instanceof VersionedEntry) {
+         return ((VersionedEntry) value).getValue();
+      }
+      return value;
+   }
 
-	@Override
-	public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version) {
-		return putFromLoad(session, key, value, txTimestamp, version, false);
-	}
+   @Override
+   public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version) {
+      return putFromLoad(session, key, value, txTimestamp, version, false);
+   }
 
-	@Override
-	public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride) throws CacheException {
-		long lastRegionInvalidation = region.getLastRegionInvalidation();
-		if (txTimestamp < lastRegionInvalidation) {
-			log.tracef("putFromLoad not executed since tx started at %d, before last region invalidation finished = %d", txTimestamp, lastRegionInvalidation);
-			return false;
-		}
-		assert version != null;
+   @Override
+   public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride) throws CacheException {
+      long lastRegionInvalidation = region.getLastRegionInvalidation();
+      if (txTimestamp < lastRegionInvalidation) {
+         log.tracef("putFromLoad not executed since tx started at %d, before last region invalidation finished = %d", txTimestamp, lastRegionInvalidation);
+         return false;
+      }
+      assert version != null;
 
-		if (minimalPutOverride) {
-			Object prev = cache.get(key);
-			if (prev != null) {
-				Object oldVersion = getVersion(prev);
-				if (oldVersion != null) {
-					if (versionComparator.compare(version, oldVersion) <= 0) {
-						if (log.isTraceEnabled()) {
-							log.tracef("putFromLoad not executed since version(%s) <= oldVersion(%s)", version, oldVersion);
-						}
-						return false;
-					}
-				}
-				else if (prev instanceof VersionedEntry && txTimestamp <= ((VersionedEntry) prev).getTimestamp()) {
-					if (log.isTraceEnabled()) {
-						log.tracef("putFromLoad not executed since tx started at %d and entry was invalidated at %d",
-								txTimestamp, ((VersionedEntry) prev).getTimestamp());
-					}
-					return false;
-				}
-			}
-		}
-		// we can't use putForExternalRead since the PFER flag means that entry is not wrapped into context
-		// when it is present in the container. TombstoneCallInterceptor will deal with this.
-		// Even if value is instanceof CacheEntry, we have to wrap it in VersionedEntry and add transaction timestamp.
-		// Otherwise, old eviction record wouldn't be overwritten.
-		CompletableFuture<Void> future = putFromLoadMap.eval(key, new VersionedEntry(value, version, txTimestamp));
-		// Rethrow exceptions
-		future.join();
-		return true;
-	}
+      if (minimalPutOverride) {
+         Object prev = cache.get(key);
+         if (prev != null) {
+            Object oldVersion = getVersion(prev);
+            if (oldVersion != null) {
+               if (versionComparator.compare(version, oldVersion) <= 0) {
+                  if (log.isTraceEnabled()) {
+                     log.tracef("putFromLoad not executed since version(%s) <= oldVersion(%s)", version, oldVersion);
+                  }
+                  return false;
+               }
+            } else if (prev instanceof VersionedEntry && txTimestamp <= ((VersionedEntry) prev).getTimestamp()) {
+               if (log.isTraceEnabled()) {
+                  log.tracef("putFromLoad not executed since tx started at %d and entry was invalidated at %d",
+                        txTimestamp, ((VersionedEntry) prev).getTimestamp());
+               }
+               return false;
+            }
+         }
+      }
+      // we can't use putForExternalRead since the PFER flag means that entry is not wrapped into context
+      // when it is present in the container. TombstoneCallInterceptor will deal with this.
+      // Even if value is instanceof CacheEntry, we have to wrap it in VersionedEntry and add transaction timestamp.
+      // Otherwise, old eviction record wouldn't be overwritten.
+      CompletableFuture<Void> future = putFromLoadMap.eval(key, new VersionedEntry(value, version, txTimestamp));
+      // Rethrow exceptions
+      future.join();
+      return true;
+   }
 
-	@Override
-	public boolean insert(Object session, Object key, Object value, Object version) throws CacheException {
-		return false;
-	}
+   @Override
+   public boolean insert(Object session, Object key, Object value, Object version) throws CacheException {
+      return false;
+   }
 
-	@Override
-	public boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException {
-		return false;
-	}
+   @Override
+   public boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException {
+      return false;
+   }
 
-	@Override
-	public void remove(Object session, Object key) throws CacheException {
-		// there's no 'afterRemove', so we have to use our own synchronization
-		// the API does not provide version of removed item but we can't load it from the cache
-		// as that would be prone to race conditions - if the entry was updated in the meantime
-		// the remove could be discarded and we would end up with stale record
-		// See VersionedTest#testCollectionUpdate for such situation
+   @Override
+   public void remove(Object session, Object key) throws CacheException {
+      // there's no 'afterRemove', so we have to use our own synchronization
+      // the API does not provide version of removed item but we can't load it from the cache
+      // as that would be prone to race conditions - if the entry was updated in the meantime
+      // the remove could be discarded and we would end up with stale record
+      // See VersionedTest#testCollectionUpdate for such situation
       TransactionCoordinatorAccess transactionCoordinator = SESSION_ACCESS.getTransactionCoordinator(session);
-		RemovalSynchronization sync = new RemovalSynchronization(transactionCoordinator, writeMap, region, key);
-		transactionCoordinator.registerLocalSynchronization(sync);
-	}
+      RemovalSynchronization sync = new RemovalSynchronization(transactionCoordinator, writeMap, region, key);
+      transactionCoordinator.registerLocalSynchronization(sync);
+   }
 
-	@Override
-	public void lockAll() throws CacheException {
-		region.beginInvalidation();
-	}
+   @Override
+   public void lockAll() throws CacheException {
+      region.beginInvalidation();
+   }
 
-	@Override
-	public void unlockAll() throws CacheException {
-		region.endInvalidation();
-	}
+   @Override
+   public void unlockAll() throws CacheException {
+      region.endInvalidation();
+   }
 
-	@Override
-	public void removeAll() throws CacheException {
-		Caches.broadcastEvictAll(cache);
-	}
+   @Override
+   public void removeAll() throws CacheException {
+      Caches.broadcastEvictAll(cache);
+   }
 
-	@Override
-	public void evict(Object key) throws CacheException {
-		writeMap.eval(key, new VersionedEntry(region.nextTimestamp())).join();
-	}
+   @Override
+   public void evict(Object key) throws CacheException {
+      writeMap.eval(key, new VersionedEntry(region.nextTimestamp())).join();
+   }
 
-	@Override
-	public void evictAll() throws CacheException {
-		region.beginInvalidation();
-		try {
-			Caches.broadcastEvictAll(cache);
-		}
-		finally {
-			region.endInvalidation();
-		}
-	}
+   @Override
+   public void evictAll() throws CacheException {
+      region.beginInvalidation();
+      try {
+         Caches.broadcastEvictAll(cache);
+      } finally {
+         region.endInvalidation();
+      }
+   }
 
-	@Override
-	public void unlockItem(Object session, Object key) throws CacheException {
-	}
+   @Override
+   public void unlockItem(Object session, Object key) throws CacheException {
+   }
 
-	@Override
-	public boolean afterInsert(Object session, Object key, Object value, Object version) {
-		assert value != null;
-		assert version != null;
-		writeMap.eval(key, new VersionedEntry(value, version, SESSION_ACCESS.getTimestamp(session))).join();
-		return true;
-	}
+   @Override
+   public boolean afterInsert(Object session, Object key, Object value, Object version) {
+      assert value != null;
+      assert version != null;
+      writeMap.eval(key, new VersionedEntry(value, version, SESSION_ACCESS.getTimestamp(session))).join();
+      return true;
+   }
 
-	@Override
-	public boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
-		assert value != null;
-		assert currentVersion != null;
-		writeMap.eval(key, new VersionedEntry(value, currentVersion, SESSION_ACCESS.getTimestamp(session))).join();
-		return true;
-	}
+   @Override
+   public boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+      assert value != null;
+      assert currentVersion != null;
+      writeMap.eval(key, new VersionedEntry(value, currentVersion, SESSION_ACCESS.getTimestamp(session))).join();
+      return true;
+   }
 
-	protected Object getVersion(Object value) {
-		if (value instanceof CacheEntry) {
-			return ((CacheEntry) value).getVersion();
-		}
-		else if (value instanceof VersionedEntry) {
-			return ((VersionedEntry) value).getVersion();
-		}
-		return null;
-	}
+   protected Object getVersion(Object value) {
+      if (value instanceof CacheEntry) {
+         return ((CacheEntry) value).getVersion();
+      } else if (value instanceof VersionedEntry) {
+         return ((VersionedEntry) value).getVersion();
+      }
+      return null;
+   }
 
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonTxInvalidationInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/NonTxInvalidationInterceptor.java
@@ -39,78 +39,78 @@ import org.infinispan.util.logging.LogFactory;
  */
 @MBean(objectName = "Invalidation", description = "Component responsible for invalidating entries on remote caches when entries are written to locally.")
 public class NonTxInvalidationInterceptor extends BaseInvalidationInterceptor {
-	@Inject Transport transport;
+   @Inject
+   Transport transport;
 
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationInterceptor.class);
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvalidationInterceptor.class);
    private static final Log ispnLog = LogFactory.getLog(NonTxInvalidationInterceptor.class);
 
    private final InvocationSuccessFunction<RemoveCommand> handleWriteReturn = this::handleWriteReturn;
-	private final InvocationSuccessFunction<RemoveCommand> handleEvictReturn = this::handleEvictReturn;
+   private final InvocationSuccessFunction<RemoveCommand> handleEvictReturn = this::handleEvictReturn;
 
-	@Override
-	public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
-		assert command.hasAnyFlag(FlagBitSets.PUT_FOR_EXTERNAL_READ);
-		return invokeNext(ctx, command);
-	}
+   @Override
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
+      assert command.hasAnyFlag(FlagBitSets.PUT_FOR_EXTERNAL_READ);
+      return invokeNext(ctx, command);
+   }
 
-	@Override
-	public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) {
-		throw new UnsupportedOperationException("Unexpected replace");
-	}
+   @Override
+   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) {
+      throw new UnsupportedOperationException("Unexpected replace");
+   }
 
-	@Override
-	public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
-		// This is how we differentiate write/remove and evict; remove sends BeginInvalidateComand while evict just InvalidateCommand
-		boolean isEvict = !command.hasAnyFlag(FlagBitSets.FORCE_WRITE_LOCK);
+   @Override
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
+      // This is how we differentiate write/remove and evict; remove sends BeginInvalidateComand while evict just InvalidateCommand
+      boolean isEvict = !command.hasAnyFlag(FlagBitSets.FORCE_WRITE_LOCK);
       return invokeNextThenApply(ctx, command, isEvict ? handleEvictReturn : handleWriteReturn);
-	}
+   }
 
-	@Override
-	public Object visitClearCommand(InvocationContext ctx, ClearCommand command) {
-		Object retval = invokeNext(ctx, command);
-		if (!isLocalModeForced(command)) {
-			// just broadcast the clear command - this is simplest!
-			if (ctx.isOriginLocal()) {
-				command.setTopologyId(rpcManager.getTopologyId());
-				if (isSynchronous(command)) {
-					return asyncValue(rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions));
-				} else {
-					rpcManager.sendToAll(command, DeliverOrder.NONE);
-				}
-			}
-		}
-		return retval;
-	}
+   @Override
+   public Object visitClearCommand(InvocationContext ctx, ClearCommand command) {
+      Object retval = invokeNext(ctx, command);
+      if (!isLocalModeForced(command)) {
+         // just broadcast the clear command - this is simplest!
+         if (ctx.isOriginLocal()) {
+            command.setTopologyId(rpcManager.getTopologyId());
+            if (isSynchronous(command)) {
+               return asyncValue(rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions));
+            } else {
+               rpcManager.sendToAll(command, DeliverOrder.NONE);
+            }
+         }
+      }
+      return retval;
+   }
 
-	@Override
-	public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
-		throw new UnsupportedOperationException("Unexpected putAll");
-	}
+   @Override
+   public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
+      throw new UnsupportedOperationException("Unexpected putAll");
+   }
 
-	private <T extends WriteCommand & RemoteLockCommand> CompletableFuture<?> invalidateAcrossCluster(
-			T command, boolean isTransactional, Object key, Object keyLockOwner) {
-		// increment invalidations counter if statistics maintained
-		incrementInvalidations();
-		InvalidateCommand invalidateCommand;
-		if (!isLocalModeForced(command)) {
-			if (isTransactional) {
-				Address address = transport != null ? transport.getAddress() : Address.LOCAL;
-				invalidateCommand = new BeginInvalidationCommand(cacheName, EnumUtil.EMPTY_BIT_SET, CommandInvocationId.generateId(address), new Object[] {key}, keyLockOwner);
-			}
-			else {
-            invalidateCommand = commandsFactory.buildInvalidateCommand(EnumUtil.EMPTY_BIT_SET, new Object[] {key });
-			}
-			invalidateCommand.setTopologyId(rpcManager.getTopologyId());
+   private <T extends WriteCommand & RemoteLockCommand> CompletableFuture<?> invalidateAcrossCluster(
+         T command, boolean isTransactional, Object key, Object keyLockOwner) {
+      // increment invalidations counter if statistics maintained
+      incrementInvalidations();
+      InvalidateCommand invalidateCommand;
+      if (!isLocalModeForced(command)) {
+         if (isTransactional) {
+            Address address = transport != null ? transport.getAddress() : Address.LOCAL;
+            invalidateCommand = new BeginInvalidationCommand(cacheName, EnumUtil.EMPTY_BIT_SET, CommandInvocationId.generateId(address), new Object[]{key}, keyLockOwner);
+         } else {
+            invalidateCommand = commandsFactory.buildInvalidateCommand(EnumUtil.EMPTY_BIT_SET, new Object[]{key});
+         }
+         invalidateCommand.setTopologyId(rpcManager.getTopologyId());
 
-			if (isSynchronous(command)) {
-				return rpcManager.invokeCommandOnAll(invalidateCommand, VoidResponseCollector.ignoreLeavers(), syncRpcOptions)
+         if (isSynchronous(command)) {
+            return rpcManager.invokeCommandOnAll(invalidateCommand, VoidResponseCollector.ignoreLeavers(), syncRpcOptions)
                   .toCompletableFuture();
-			} else {
-				rpcManager.sendToAll(invalidateCommand, DeliverOrder.NONE);
-			}
-		}
-		return null;
-	}
+         } else {
+            rpcManager.sendToAll(invalidateCommand, DeliverOrder.NONE);
+         }
+      }
+      return null;
+   }
 
    @Override
    protected Log getLog() {
@@ -118,19 +118,19 @@ public class NonTxInvalidationInterceptor extends BaseInvalidationInterceptor {
    }
 
    private Object handleWriteReturn(InvocationContext ctx, RemoveCommand removeCmd, Object rv) {
-		// Invalidation always has to send even if the command says not to replicate
-		if ( removeCmd.isSuccessful()) {
-			return invalidateAcrossCluster(removeCmd, true, removeCmd.getKey(), removeCmd.getKeyLockOwner());
-		}
-		return null;
-	}
+      // Invalidation always has to send even if the command says not to replicate
+      if (removeCmd.isSuccessful()) {
+         return invalidateAcrossCluster(removeCmd, true, removeCmd.getKey(), removeCmd.getKeyLockOwner());
+      }
+      return null;
+   }
 
-	private Object handleEvictReturn(InvocationContext ctx, RemoveCommand removeCmd, Object rv) {
-		// Invalidation always has to send even if the command says not to replicate
-		if ( removeCmd.isSuccessful()) {
-			return invalidateAcrossCluster(removeCmd, false, removeCmd.getKey(), removeCmd.getKeyLockOwner());
-		}
-		return null;
-	}
+   private Object handleEvictReturn(InvocationContext ctx, RemoveCommand removeCmd, Object rv) {
+      // Invalidation always has to send even if the command says not to replicate
+      if (removeCmd.isSuccessful()) {
+         return invalidateAcrossCluster(removeCmd, false, removeCmd.getKey(), removeCmd.getKeyLockOwner());
+      }
+      return null;
+   }
 
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/RemovalSynchronization.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/RemovalSynchronization.java
@@ -1,8 +1,8 @@
 package org.infinispan.hibernate.cache.commons.access;
 
 import org.infinispan.functional.FunctionalMap;
-import org.infinispan.hibernate.cache.commons.access.SessionAccess.TransactionCoordinatorAccess;
 import org.infinispan.hibernate.cache.commons.InfinispanDataRegion;
+import org.infinispan.hibernate.cache.commons.access.SessionAccess.TransactionCoordinatorAccess;
 import org.infinispan.hibernate.cache.commons.util.InvocationAfterCompletion;
 import org.infinispan.hibernate.cache.commons.util.VersionedEntry;
 
@@ -10,21 +10,21 @@ import org.infinispan.hibernate.cache.commons.util.VersionedEntry;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class RemovalSynchronization extends InvocationAfterCompletion {
-	private final InfinispanDataRegion region;
-	private final Object key;
-	private final FunctionalMap.ReadWriteMap<Object, Object> rwMap;
+   private final InfinispanDataRegion region;
+   private final Object key;
+   private final FunctionalMap.ReadWriteMap<Object, Object> rwMap;
 
-	public RemovalSynchronization(TransactionCoordinatorAccess tc, FunctionalMap.ReadWriteMap<Object, Object> rwMap, InfinispanDataRegion region, Object key) {
-		super(tc, false);
-		this.rwMap = rwMap;
-		this.region = region;
-		this.key = key;
-	}
+   public RemovalSynchronization(TransactionCoordinatorAccess tc, FunctionalMap.ReadWriteMap<Object, Object> rwMap, InfinispanDataRegion region, Object key) {
+      super(tc, false);
+      this.rwMap = rwMap;
+      this.region = region;
+      this.key = key;
+   }
 
-	@Override
-	protected void invoke(boolean success) {
-		if (success) {
-			rwMap.eval(key, new VersionedEntry(region.nextTimestamp())).join();
-		}
-	}
+   @Override
+   protected void invoke(boolean success) {
+      if (success) {
+         rwMap.eval(key, new VersionedEntry(region.nextTimestamp())).join();
+      }
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TombstoneAccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TombstoneAccessDelegate.java
@@ -19,153 +19,151 @@ import org.infinispan.hibernate.cache.commons.util.TombstoneUpdate;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class TombstoneAccessDelegate implements AccessDelegate {
-	protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( TombstoneAccessDelegate.class );
+   protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(TombstoneAccessDelegate.class);
    private static final SessionAccess SESSION_ACCESS = SessionAccess.findSessionAccess();
 
-	protected final InfinispanDataRegion region;
-	protected final AdvancedCache cache;
-	protected final FunctionalMap.ReadWriteMap<Object, Object> writeMap;
-	protected final FunctionalMap.ReadWriteMap<Object, Object> asyncWriteMap;
-	private final boolean requiresTransaction;
-	private final FunctionalMap.ReadWriteMap<Object, Object> putFromLoadMap;
+   protected final InfinispanDataRegion region;
+   protected final AdvancedCache cache;
+   protected final FunctionalMap.ReadWriteMap<Object, Object> writeMap;
+   protected final FunctionalMap.ReadWriteMap<Object, Object> asyncWriteMap;
+   private final boolean requiresTransaction;
+   private final FunctionalMap.ReadWriteMap<Object, Object> putFromLoadMap;
 
-	public TombstoneAccessDelegate(InfinispanDataRegion region) {
-		this.region = region;
-		this.cache = region.getCache();
-		FunctionalMap<Object, Object> fmap = FunctionalMap.create(cache).withParams(Param.PersistenceMode.SKIP_LOAD);
-		writeMap = fmap.toReadWriteMap();
-		// Note that correct behaviour of local and async writes depends on LockingInterceptor (see there for details)
-		asyncWriteMap = fmap.toReadWriteMap().withParams(Param.ReplicationMode.ASYNC);
-		putFromLoadMap = fmap.toReadWriteMap().withParams(Param.LockingMode.TRY_LOCK, Param.ReplicationMode.ASYNC);
-		Configuration configuration = this.cache.getCacheConfiguration();
-		if (configuration.clustering().cacheMode().isInvalidation()) {
-			throw new IllegalArgumentException("For tombstone-based caching, invalidation cache is not allowed.");
-		}
-		if (configuration.transaction().transactionMode().isTransactional()) {
-			throw new IllegalArgumentException("Currently transactional caches are not supported.");
-		}
-		requiresTransaction = configuration.transaction().transactionMode().isTransactional()
-				&& !configuration.transaction().autoCommit();
-	}
+   public TombstoneAccessDelegate(InfinispanDataRegion region) {
+      this.region = region;
+      this.cache = region.getCache();
+      FunctionalMap<Object, Object> fmap = FunctionalMap.create(cache).withParams(Param.PersistenceMode.SKIP_LOAD);
+      writeMap = fmap.toReadWriteMap();
+      // Note that correct behaviour of local and async writes depends on LockingInterceptor (see there for details)
+      asyncWriteMap = fmap.toReadWriteMap().withParams(Param.ReplicationMode.ASYNC);
+      putFromLoadMap = fmap.toReadWriteMap().withParams(Param.LockingMode.TRY_LOCK, Param.ReplicationMode.ASYNC);
+      Configuration configuration = this.cache.getCacheConfiguration();
+      if (configuration.clustering().cacheMode().isInvalidation()) {
+         throw new IllegalArgumentException("For tombstone-based caching, invalidation cache is not allowed.");
+      }
+      if (configuration.transaction().transactionMode().isTransactional()) {
+         throw new IllegalArgumentException("Currently transactional caches are not supported.");
+      }
+      requiresTransaction = configuration.transaction().transactionMode().isTransactional()
+            && !configuration.transaction().autoCommit();
+   }
 
-	@Override
-	public Object get(Object session, Object key, long txTimestamp) throws CacheException {
-		if (txTimestamp < region.getLastRegionInvalidation() ) {
-			return null;
-		}
-		Object value = cache.get(key);
-		if (value instanceof Tombstone) {
-			return null;
-		} else {
-			return value;
-		}
-	}
+   @Override
+   public Object get(Object session, Object key, long txTimestamp) throws CacheException {
+      if (txTimestamp < region.getLastRegionInvalidation()) {
+         return null;
+      }
+      Object value = cache.get(key);
+      if (value instanceof Tombstone) {
+         return null;
+      } else {
+         return value;
+      }
+   }
 
-	@Override
-	public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version) {
-		return putFromLoad(session, key, value, txTimestamp, version, false);
-	}
+   @Override
+   public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version) {
+      return putFromLoad(session, key, value, txTimestamp, version, false);
+   }
 
-	@Override
-	public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride) throws CacheException {
-		long lastRegionInvalidation = region.getLastRegionInvalidation();
-		if (txTimestamp < lastRegionInvalidation) {
-			log.tracef("putFromLoad not executed since tx started at %d, before last region invalidation finished = %d", txTimestamp, lastRegionInvalidation);
-			return false;
-		}
-		if (minimalPutOverride) {
-			Object prev = cache.get(key);
-			if (prev instanceof Tombstone) {
-				Tombstone tombstone = (Tombstone) prev;
-				long lastTimestamp = tombstone.getLastTimestamp();
-				if (txTimestamp <= lastTimestamp) {
-					log.tracef("putFromLoad not executed since tx started at %d, before last invalidation finished = %d", txTimestamp, lastTimestamp);
-					return false;
-				}
-			}
-			else if (prev != null) {
-				log.tracef("putFromLoad not executed since cache contains %s", prev);
-				return false;
-			}
-		}
-		// we can't use putForExternalRead since the PFER flag means that entry is not wrapped into context
-		// when it is present in the container. TombstoneCallInterceptor will deal with this.
-		CompletableFuture<Void> future = putFromLoadMap.eval(key, new TombstoneUpdate<>(SESSION_ACCESS.getTimestamp(session), value));
-		assert future.isDone(); // async try-locking should be done immediately
-		return true;
-	}
+   @Override
+   public boolean putFromLoad(Object session, Object key, Object value, long txTimestamp, Object version, boolean minimalPutOverride) throws CacheException {
+      long lastRegionInvalidation = region.getLastRegionInvalidation();
+      if (txTimestamp < lastRegionInvalidation) {
+         log.tracef("putFromLoad not executed since tx started at %d, before last region invalidation finished = %d", txTimestamp, lastRegionInvalidation);
+         return false;
+      }
+      if (minimalPutOverride) {
+         Object prev = cache.get(key);
+         if (prev instanceof Tombstone) {
+            Tombstone tombstone = (Tombstone) prev;
+            long lastTimestamp = tombstone.getLastTimestamp();
+            if (txTimestamp <= lastTimestamp) {
+               log.tracef("putFromLoad not executed since tx started at %d, before last invalidation finished = %d", txTimestamp, lastTimestamp);
+               return false;
+            }
+         } else if (prev != null) {
+            log.tracef("putFromLoad not executed since cache contains %s", prev);
+            return false;
+         }
+      }
+      // we can't use putForExternalRead since the PFER flag means that entry is not wrapped into context
+      // when it is present in the container. TombstoneCallInterceptor will deal with this.
+      CompletableFuture<Void> future = putFromLoadMap.eval(key, new TombstoneUpdate<>(SESSION_ACCESS.getTimestamp(session), value));
+      assert future.isDone(); // async try-locking should be done immediately
+      return true;
+   }
 
-	@Override
-	public boolean insert(Object session, Object key, Object value, Object version) throws CacheException {
-		write(session, key, value);
-		return true;
-	}
+   @Override
+   public boolean insert(Object session, Object key, Object value, Object version) throws CacheException {
+      write(session, key, value);
+      return true;
+   }
 
-	@Override
-	public boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException {
-		write(session, key, value);
-		return true;
-	}
+   @Override
+   public boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException {
+      write(session, key, value);
+      return true;
+   }
 
-	@Override
-	public void remove(Object session, Object key) throws CacheException {
-		write(session, key, null);
-	}
+   @Override
+   public void remove(Object session, Object key) throws CacheException {
+      write(session, key, null);
+   }
 
-	protected void write(Object session, Object key, Object value) {
+   protected void write(Object session, Object key, Object value) {
       TransactionCoordinatorAccess tc = SESSION_ACCESS.getTransactionCoordinator(session);
       long timestamp = SESSION_ACCESS.getTimestamp(session);
       FutureUpdateSynchronization sync = new FutureUpdateSynchronization(tc, asyncWriteMap, requiresTransaction, key, value, region, timestamp);
-		// The update will be invalidating all putFromLoads for the duration of expiration or until removed by the synchronization
-		Tombstone tombstone = new Tombstone(sync.getUuid(), region.nextTimestamp() + region.getTombstoneExpiration());
-		// The outcome of this operation is actually defined in TombstoneCallInterceptor
-		// Metadata in PKVC are cleared and set in the interceptor, too
-		writeMap.eval(key, tombstone).join();
+      // The update will be invalidating all putFromLoads for the duration of expiration or until removed by the synchronization
+      Tombstone tombstone = new Tombstone(sync.getUuid(), region.nextTimestamp() + region.getTombstoneExpiration());
+      // The outcome of this operation is actually defined in TombstoneCallInterceptor
+      // Metadata in PKVC are cleared and set in the interceptor, too
+      writeMap.eval(key, tombstone).join();
       tc.registerLocalSynchronization(sync);
-	}
+   }
 
-	@Override
-	public void lockAll() throws CacheException {
-		region.beginInvalidation();
-	}
+   @Override
+   public void lockAll() throws CacheException {
+      region.beginInvalidation();
+   }
 
-	@Override
-	public void unlockAll() throws CacheException {
-		region.endInvalidation();
-	}
+   @Override
+   public void unlockAll() throws CacheException {
+      region.endInvalidation();
+   }
 
-	@Override
-	public void removeAll() throws CacheException {
-		Caches.broadcastEvictAll(cache);
-	}
+   @Override
+   public void removeAll() throws CacheException {
+      Caches.broadcastEvictAll(cache);
+   }
 
-	@Override
-	public void evict(Object key) throws CacheException {
-		writeMap.eval(key, new TombstoneUpdate<>(region.nextTimestamp(), null)).join();
-	}
+   @Override
+   public void evict(Object key) throws CacheException {
+      writeMap.eval(key, new TombstoneUpdate<>(region.nextTimestamp(), null)).join();
+   }
 
-	@Override
-	public void evictAll() throws CacheException {
-		region.beginInvalidation();
-		try {
-			Caches.broadcastEvictAll(cache);
-		}
-		finally {
-			region.endInvalidation();
-		}
-	}
+   @Override
+   public void evictAll() throws CacheException {
+      region.beginInvalidation();
+      try {
+         Caches.broadcastEvictAll(cache);
+      } finally {
+         region.endInvalidation();
+      }
+   }
 
-	@Override
-	public void unlockItem(Object session, Object key) throws CacheException {
-	}
+   @Override
+   public void unlockItem(Object session, Object key) throws CacheException {
+   }
 
-	@Override
-	public boolean afterInsert(Object session, Object key, Object value, Object version) {
-		return false;
-	}
+   @Override
+   public boolean afterInsert(Object session, Object key, Object value, Object version) {
+      return false;
+   }
 
-	@Override
-	public boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
-		return false;
-	}
+   @Override
+   public boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+      return false;
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationCacheAccessDelegate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationCacheAccessDelegate.java
@@ -10,52 +10,52 @@ import org.infinispan.hibernate.cache.commons.InfinispanDataRegion;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class TxInvalidationCacheAccessDelegate extends InvalidationCacheAccessDelegate {
-	public TxInvalidationCacheAccessDelegate(InfinispanDataRegion region, PutFromLoadValidator validator) {
-		super(region, validator);
-	}
+   public TxInvalidationCacheAccessDelegate(InfinispanDataRegion region, PutFromLoadValidator validator) {
+      super(region, validator);
+   }
 
-	@Override
-	@SuppressWarnings("UnusedParameters")
-	public boolean insert(Object session, Object key, Object value, Object version) throws CacheException {
-		if ( !region.checkValid() ) {
-			return false;
-		}
+   @Override
+   @SuppressWarnings("UnusedParameters")
+   public boolean insert(Object session, Object key, Object value, Object version) throws CacheException {
+      if (!region.checkValid()) {
+         return false;
+      }
 
-		// We need to be invalidating even for regular writes; if we were not and the write was followed by eviction
-		// (or any other invalidation), naked put that was started after the eviction ended but before this insert
-		// ended could insert the stale entry into the cache (since the entry was removed by eviction).
+      // We need to be invalidating even for regular writes; if we were not and the write was followed by eviction
+      // (or any other invalidation), naked put that was started after the eviction ended but before this insert
+      // ended could insert the stale entry into the cache (since the entry was removed by eviction).
 
-		// The beginInvalidateKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
-		writeCache.put(key, value);
-		return true;
-	}
+      // The beginInvalidateKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
+      writeCache.put(key, value);
+      return true;
+   }
 
-	@Override
-	@SuppressWarnings("UnusedParameters")
-	public boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion)
-			throws CacheException {
-		// We update whether or not the region is valid. Other nodes
-		// may have already restored the region so they need to
-		// be informed of the change.
+   @Override
+   @SuppressWarnings("UnusedParameters")
+   public boolean update(Object session, Object key, Object value, Object currentVersion, Object previousVersion)
+         throws CacheException {
+      // We update whether or not the region is valid. Other nodes
+      // may have already restored the region so they need to
+      // be informed of the change.
 
-		// We need to be invalidating even for regular writes; if we were not and the write was followed by eviction
-		// (or any other invalidation), naked put that was started after the eviction ended but before this update
-		// ended could insert the stale entry into the cache (since the entry was removed by eviction).
+      // We need to be invalidating even for regular writes; if we were not and the write was followed by eviction
+      // (or any other invalidation), naked put that was started after the eviction ended but before this update
+      // ended could insert the stale entry into the cache (since the entry was removed by eviction).
 
-		// The beginInvalidateKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
-		writeCache.put(key, value);
-		return true;
-	}
+      // The beginInvalidateKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
+      writeCache.put(key, value);
+      return true;
+   }
 
-	@Override
-	public boolean afterInsert(Object session, Object key, Object value, Object version) {
-		// The endInvalidatingKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
-		return false;
-	}
+   @Override
+   public boolean afterInsert(Object session, Object key, Object value, Object version) {
+      // The endInvalidatingKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
+      return false;
+   }
 
-	@Override
-	public boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
-		// The endInvalidatingKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
-		return false;
-	}
+   @Override
+   public boolean afterUpdate(Object session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) {
+      // The endInvalidatingKey(...) is called from TxPutFromLoadInterceptor because we need the global transaction id.
+      return false;
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxInvalidationInterceptor.java
@@ -21,6 +21,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.util.EnumUtil;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.LocalTxInvocationContext;
@@ -31,14 +32,13 @@ import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.impl.VoidResponseCollector;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**
  * This interceptor acts as a replacement to the replication interceptor when the CacheImpl is configured with
  * ClusteredSyncMode as INVALIDATE.
-  * The idea is that rather than replicating changes to all caches in a cluster when write methods are called, simply
+ * The idea is that rather than replicating changes to all caches in a cluster when write methods are called, simply
  * broadcast an {@link InvalidateCommand} on the remote caches containing all keys modified.  This allows the remote
  * cache to look up the value in a shared cache loader which would have been updated with the changes.
  *
@@ -49,7 +49,7 @@ import org.infinispan.util.logging.LogFactory;
  */
 @MBean(objectName = "Invalidation", description = "Component responsible for invalidating entries on remote caches when entries are written to locally.")
 public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( TxInvalidationInterceptor.class );
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(TxInvalidationInterceptor.class);
    private static final Log ispnLog = LogFactory.getLog(TxInvalidationInterceptor.class);
 
    private final InvocationSuccessFunction<ClearCommand> broadcastClearIfNotLocal = this::broadcastClearIfNotLocal;
@@ -57,53 +57,53 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
    private final InvocationSuccessFunction<CommitCommand> handleCommit = this::handleCommit;
 
    @Override
-	public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
-		if ( !isPutForExternalRead( command ) ) {
-			return handleInvalidate( ctx, command, command.getKey() );
-		}
-		return invokeNext( ctx, command );
-	}
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
+      if (!isPutForExternalRead(command)) {
+         return handleInvalidate(ctx, command, command.getKey());
+      }
+      return invokeNext(ctx, command);
+   }
 
-	@Override
-	public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) {
-		return handleInvalidate( ctx, command, command.getKey() );
-	}
+   @Override
+   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) {
+      return handleInvalidate(ctx, command, command.getKey());
+   }
 
-	@Override
-	public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
-		return handleInvalidate( ctx, command, command.getKey() );
-	}
+   @Override
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
+      return handleInvalidate(ctx, command, command.getKey());
+   }
 
-	@Override
-	public Object visitClearCommand(InvocationContext ctx, ClearCommand command) {
+   @Override
+   public Object visitClearCommand(InvocationContext ctx, ClearCommand command) {
       return invokeNextThenApply(ctx, command, broadcastClearIfNotLocal);
-	}
+   }
 
    private Object broadcastClearIfNotLocal(InvocationContext rCtx, ClearCommand rCommand, Object rv) {
-      if ( !isLocalModeForced( rCommand ) ) {
+      if (!isLocalModeForced(rCommand)) {
          // just broadcast the clear command - this is simplest!
-         if ( rCtx.isOriginLocal() ) {
-				rCommand.setTopologyId(rpcManager.getTopologyId());
-         	if (isSynchronous(rCommand)) {
-					// the result value will be ignored, we don't need to propagate rv
-            	return asyncValue(rpcManager.invokeCommandOnAll(rCommand, VoidResponseCollector.ignoreLeavers(), syncRpcOptions));
-				} else {
-            	rpcManager.sendToAll(rCommand, DeliverOrder.NONE);
-				}
+         if (rCtx.isOriginLocal()) {
+            rCommand.setTopologyId(rpcManager.getTopologyId());
+            if (isSynchronous(rCommand)) {
+               // the result value will be ignored, we don't need to propagate rv
+               return asyncValue(rpcManager.invokeCommandOnAll(rCommand, VoidResponseCollector.ignoreLeavers(), syncRpcOptions));
+            } else {
+               rpcManager.sendToAll(rCommand, DeliverOrder.NONE);
+            }
          }
       }
       return rv;
    }
 
    @Override
-	public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
-		return handleInvalidate( ctx, command, command.getMap().keySet().toArray() );
-	}
+   public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
+      return handleInvalidate(ctx, command, command.getMap().keySet().toArray());
+   }
 
-	@Override
-	public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) {
+   @Override
+   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) {
       return invokeNextThenApply(ctx, command, broadcastInvalidateForPrepare);
-	}
+   }
 
    @Override
    public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
@@ -117,8 +117,8 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
    private Object handleCommit(InvocationContext ctx, CommitCommand command, Object ignored) {
       try {
          CompletionStage<Void> remoteInvocation =
-            rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(),
-                                          rpcManager.getSyncRpcOptions());
+               rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(),
+                     rpcManager.getSyncRpcOptions());
          return asyncValue(remoteInvocation);
       } catch (Throwable t) {
          throw t;
@@ -130,96 +130,93 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
       log.tracef("Entering InvalidationInterceptor's prepare phase");
       // fetch the modifications before the transaction is committed (and thus removed from the txTable)
       TxInvocationContext txCtx = (TxInvocationContext) rCtx;
-      if ( shouldInvokeRemoteTxCommand( txCtx ) ) {
-         if ( txCtx.getTransaction() == null ) {
-            throw new IllegalStateException( "We must have an associated transaction" );
+      if (shouldInvokeRemoteTxCommand(txCtx)) {
+         if (txCtx.getTransaction() == null) {
+            throw new IllegalStateException("We must have an associated transaction");
          }
 
          CompletionStage<Void> completion = broadcastInvalidateForPrepare(prepareCmd, txCtx);
-			if (completion != null) {
-				return asyncValue(completion);
-			} else {
-				return rv;
-			}
-		}
-      else {
-         log.tracef( "Nothing to invalidate - no modifications in the transaction." );
+         if (completion != null) {
+            return asyncValue(completion);
+         } else {
+            return rv;
+         }
+      } else {
+         log.tracef("Nothing to invalidate - no modifications in the transaction.");
       }
       return rv;
    }
 
    @Override
-	public Object visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command) {
-		Object retVal = invokeNext( ctx, command );
-		if ( ctx.isOriginLocal() ) {
-			//unlock will happen async as it is a best effort
-			boolean sync = !command.isUnlock();
-			List<Address> members = getMembers();
-			( (LocalTxInvocationContext) ctx ).remoteLocksAcquired(members);
-			command.setTopologyId(rpcManager.getTopologyId());
-			if (sync) {
-				return asyncValue(rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions));
-			} else {
-				rpcManager.sendToAll(command, DeliverOrder.NONE);
-			}
-		}
-		return retVal;
-	}
+   public Object visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command) {
+      Object retVal = invokeNext(ctx, command);
+      if (ctx.isOriginLocal()) {
+         //unlock will happen async as it is a best effort
+         boolean sync = !command.isUnlock();
+         List<Address> members = getMembers();
+         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(members);
+         command.setTopologyId(rpcManager.getTopologyId());
+         if (sync) {
+            return asyncValue(rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions));
+         } else {
+            rpcManager.sendToAll(command, DeliverOrder.NONE);
+         }
+      }
+      return retVal;
+   }
 
-	private Object handleInvalidate(InvocationContext ctx, WriteCommand command, Object... keys) {
+   private Object handleInvalidate(InvocationContext ctx, WriteCommand command, Object... keys) {
       return invokeNextThenApply(ctx, command, (rCtx, writeCmd, rv) -> {
-			if (!writeCmd.isSuccessful() || rCtx.isInTxScope()) {
-				return rv;
-			}
-			if (keys == null || keys.length == 0) {
-				return rv;
-			}
-			if (isLocalModeForced( writeCmd )) {
-				return rv;
-			}
+         if (!writeCmd.isSuccessful() || rCtx.isInTxScope()) {
+            return rv;
+         }
+         if (keys == null || keys.length == 0) {
+            return rv;
+         }
+         if (isLocalModeForced(writeCmd)) {
+            return rv;
+         }
          CompletionStage<Void> completion =
-            invalidateAcrossCluster(isSynchronous(writeCmd), keys, rCtx, true, rpcManager.getTopologyId());
-			return completion != null ? asyncValue(completion) : rv;
-		} );
-	}
+               invalidateAcrossCluster(isSynchronous(writeCmd), keys, rCtx, true, rpcManager.getTopologyId());
+         return completion != null ? asyncValue(completion) : rv;
+      });
+   }
 
    private CompletionStage<Void> broadcastInvalidateForPrepare(PrepareCommand prepareCmd, InvocationContext ctx)
-      throws Throwable {
-		// A prepare does not carry flags, so skip checking whether is local or not
-		if ( ctx.isInTxScope() ) {
+         throws Throwable {
+      // A prepare does not carry flags, so skip checking whether is local or not
+      if (ctx.isInTxScope()) {
          List<WriteCommand> modifications = prepareCmd.getModifications();
-			if ( modifications.isEmpty() ) {
-				return null;
-			}
+         if (modifications.isEmpty()) {
+            return null;
+         }
 
-			InvalidationFilterVisitor filterVisitor = new InvalidationFilterVisitor( modifications.size() );
-			filterVisitor.visitCollection( null, modifications );
+         InvalidationFilterVisitor filterVisitor = new InvalidationFilterVisitor(modifications.size());
+         filterVisitor.visitCollection(null, modifications);
 
-			if ( filterVisitor.containsPutForExternalRead ) {
+         if (filterVisitor.containsPutForExternalRead) {
             log.trace("Modification list contains a putForExternalRead operation.  Not invalidating.");
-			}
-			else if ( filterVisitor.containsLocalModeFlag ) {
+         } else if (filterVisitor.containsLocalModeFlag) {
             log.trace("Modification list contains a local mode flagged operation.  Not invalidating.");
-			}
-			else {
-				try {
+         } else {
+            try {
                CompletionStage<Void> completion =
-                  invalidateAcrossCluster(defaultSynchronous, filterVisitor.result.toArray(), ctx,
-                                          prepareCmd.isOnePhaseCommit(), prepareCmd.getTopologyId());
-					if (completion != null) {
-						return completion.exceptionally(t -> {
-							log.unableToRollbackInvalidationsDuringPrepare( t );
-							throw CompletableFutures.asCompletionException(t);
-						});
-					}
-				} catch (Throwable t) {
-					log.unableToRollbackInvalidationsDuringPrepare( t );
-					throw t;
-				}
-			}
-		}
-		return null;
-	}
+                     invalidateAcrossCluster(defaultSynchronous, filterVisitor.result.toArray(), ctx,
+                           prepareCmd.isOnePhaseCommit(), prepareCmd.getTopologyId());
+               if (completion != null) {
+                  return completion.exceptionally(t -> {
+                     log.unableToRollbackInvalidationsDuringPrepare(t);
+                     throw CompletableFutures.asCompletionException(t);
+                  });
+               }
+            } catch (Throwable t) {
+               log.unableToRollbackInvalidationsDuringPrepare(t);
+               throw t;
+            }
+         }
+      }
+      return null;
+   }
 
    @Override
    protected Log getLog() {
@@ -228,60 +225,60 @@ public class TxInvalidationInterceptor extends BaseInvalidationInterceptor {
 
    public static class InvalidationFilterVisitor extends AbstractVisitor {
 
-		Set<Object> result;
-		public boolean containsPutForExternalRead = false;
-		public boolean containsLocalModeFlag = false;
+      Set<Object> result;
+      public boolean containsPutForExternalRead = false;
+      public boolean containsLocalModeFlag = false;
 
-		public InvalidationFilterVisitor(int maxSetSize) {
-			result = new HashSet<>( maxSetSize );
-		}
+      public InvalidationFilterVisitor(int maxSetSize) {
+         result = new HashSet<>(maxSetSize);
+      }
 
-		private void processCommand(FlagAffectedCommand command) {
-			containsLocalModeFlag = containsLocalModeFlag || ( command.getFlags() != null && command.getFlags().contains( Flag.CACHE_MODE_LOCAL ) );
-		}
+      private void processCommand(FlagAffectedCommand command) {
+         containsLocalModeFlag = containsLocalModeFlag || (command.getFlags() != null && command.getFlags().contains(Flag.CACHE_MODE_LOCAL));
+      }
 
-		@Override
-		public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
-			processCommand( command );
-			containsPutForExternalRead =
-					containsPutForExternalRead || ( command.getFlags() != null && command.getFlags().contains( Flag.PUT_FOR_EXTERNAL_READ ) );
-			result.add( command.getKey() );
-			return null;
-		}
+      @Override
+      public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
+         processCommand(command);
+         containsPutForExternalRead =
+               containsPutForExternalRead || (command.getFlags() != null && command.getFlags().contains(Flag.PUT_FOR_EXTERNAL_READ));
+         result.add(command.getKey());
+         return null;
+      }
 
-		@Override
-		public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
-			processCommand( command );
-			result.add( command.getKey() );
-			return null;
-		}
+      @Override
+      public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
+         processCommand(command);
+         result.add(command.getKey());
+         return null;
+      }
 
-		@Override
-		public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
-			processCommand( command );
-			result.addAll( command.getAffectedKeys() );
-			return null;
-		}
-	}
+      @Override
+      public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) {
+         processCommand(command);
+         result.addAll(command.getAffectedKeys());
+         return null;
+      }
+   }
 
    private CompletionStage<Void> invalidateAcrossCluster(boolean synchronous, Object[] keys, InvocationContext ctx,
                                                          boolean onePhaseCommit, int topologyId) {
-		// increment invalidations counter if statistics maintained
-		incrementInvalidations();
+      // increment invalidations counter if statistics maintained
+      incrementInvalidations();
 
       InvalidateCommand invalidateCommand = commandsFactory.buildInvalidateCommand(EnumUtil.EMPTY_BIT_SET, keys);
-		CacheRpcCommand command = invalidateCommand;
-		if ( ctx.isInTxScope() ) {
-			TxInvocationContext txCtx = (TxInvocationContext) ctx;
+      CacheRpcCommand command = invalidateCommand;
+      if (ctx.isInTxScope()) {
+         TxInvocationContext txCtx = (TxInvocationContext) ctx;
          command = commandsFactory.buildPrepareCommand(txCtx.getGlobalTransaction(),
-                                                       Collections.singletonList(invalidateCommand), onePhaseCommit);
+               Collections.singletonList(invalidateCommand), onePhaseCommit);
       }
-		((TopologyAffectedCommand) command).setTopologyId(topologyId);
-		if (synchronous) {
-			return rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions);
-		} else {
-			rpcManager.sendToAll(command, DeliverOrder.NONE);
-		}
-		return null;
-	}
+      ((TopologyAffectedCommand) command).setTopologyId(topologyId);
+      if (synchronous) {
+         return rpcManager.invokeCommandOnAll(command, VoidResponseCollector.ignoreLeavers(), syncRpcOptions);
+      } else {
+         rpcManager.sendToAll(command, DeliverOrder.NONE);
+      }
+      return null;
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxPutFromLoadInterceptor.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/TxPutFromLoadInterceptor.java
@@ -38,129 +38,131 @@ import org.infinispan.util.logging.LogFactory;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 class TxPutFromLoadInterceptor extends BaseRpcInterceptor {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(TxPutFromLoadInterceptor.class);
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(TxPutFromLoadInterceptor.class);
    private static final Log ispnLog = LogFactory.getLog(TxPutFromLoadInterceptor.class);
-	private final PutFromLoadValidator putFromLoadValidator;
-	private final ByteString cacheName;
+   private final PutFromLoadValidator putFromLoadValidator;
+   private final ByteString cacheName;
 
-	@Inject RpcManager rpcManager;
-	@Inject InternalDataContainer dataContainer;
-	@Inject DistributionManager distributionManager;
+   @Inject
+   RpcManager rpcManager;
+   @Inject
+   InternalDataContainer dataContainer;
+   @Inject
+   DistributionManager distributionManager;
 
-	public TxPutFromLoadInterceptor(PutFromLoadValidator putFromLoadValidator, ByteString cacheName) {
-		this.putFromLoadValidator = putFromLoadValidator;
-		this.cacheName = cacheName;
-	}
+   public TxPutFromLoadInterceptor(PutFromLoadValidator putFromLoadValidator, ByteString cacheName) {
+      this.putFromLoadValidator = putFromLoadValidator;
+      this.cacheName = cacheName;
+   }
 
-	private void beginInvalidating(InvocationContext ctx, Object key) {
-		TxInvocationContext txCtx = (TxInvocationContext) ctx;
-		// make sure that the command is registered in the transaction
-		txCtx.addAffectedKey(key);
+   private void beginInvalidating(InvocationContext ctx, Object key) {
+      TxInvocationContext txCtx = (TxInvocationContext) ctx;
+      // make sure that the command is registered in the transaction
+      txCtx.addAffectedKey(key);
 
-		GlobalTransaction globalTransaction = txCtx.getGlobalTransaction();
-		if (!putFromLoadValidator.beginInvalidatingKey(globalTransaction, key)) {
-			throw log.failedInvalidatePendingPut(key, cacheName.toString());
-		}
-	}
+      GlobalTransaction globalTransaction = txCtx.getGlobalTransaction();
+      if (!putFromLoadValidator.beginInvalidatingKey(globalTransaction, key)) {
+         throw log.failedInvalidatePendingPut(key, cacheName.toString());
+      }
+   }
 
-	@Override
-	public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
-		if (!command.hasAnyFlag(FlagBitSets.PUT_FOR_EXTERNAL_READ)) {
-			beginInvalidating(ctx, command.getKey());
-		}
-		return invokeNext(ctx, command);
-	}
+   @Override
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) {
+      if (!command.hasAnyFlag(FlagBitSets.PUT_FOR_EXTERNAL_READ)) {
+         beginInvalidating(ctx, command.getKey());
+      }
+      return invokeNext(ctx, command);
+   }
 
-	@Override
-	public Object visitRemoveExpiredCommand(InvocationContext ctx, RemoveExpiredCommand command) throws Throwable {
-		return invokeNext(ctx, command);
-	}
+   @Override
+   public Object visitRemoveExpiredCommand(InvocationContext ctx, RemoveExpiredCommand command) throws Throwable {
+      return invokeNext(ctx, command);
+   }
 
-	@Override
-	public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
-		beginInvalidating(ctx, command.getKey());
-		return invokeNext(ctx, command);
-	}
+   @Override
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) {
+      beginInvalidating(ctx, command.getKey());
+      return invokeNext(ctx, command);
+   }
 
-	// We need to intercept PrepareCommand, not InvalidateCommand since the interception takes
-	// place before EntryWrappingInterceptor and the PrepareCommand is multiplexed into InvalidateCommands
-	// as part of EntryWrappingInterceptor
-	@Override
-	public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) {
-		if (ctx.isOriginLocal()) {
-			// We can't wait to commit phase to remove the entry locally (invalidations are processed in 1pc
-			// on remote nodes, so only local case matters here). The problem is that while the entry is locked
-			// reads still can take place and we can read outdated collection after reading updated entity
-			// owning this collection from DB; when this happens, the version lock on entity cannot protect
-			// us against concurrent modification of the collection. Therefore, we need to remove the entry
-			// here (even without lock!) and let possible update happen in commit phase.
-			for (WriteCommand wc : command.getModifications()) {
-				for (Object key : wc.getAffectedKeys()) {
-					dataContainer.remove(key);
-				}
-			}
-		}
-		else {
-			for (WriteCommand wc : command.getModifications()) {
+   // We need to intercept PrepareCommand, not InvalidateCommand since the interception takes
+   // place before EntryWrappingInterceptor and the PrepareCommand is multiplexed into InvalidateCommands
+   // as part of EntryWrappingInterceptor
+   @Override
+   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) {
+      if (ctx.isOriginLocal()) {
+         // We can't wait to commit phase to remove the entry locally (invalidations are processed in 1pc
+         // on remote nodes, so only local case matters here). The problem is that while the entry is locked
+         // reads still can take place and we can read outdated collection after reading updated entity
+         // owning this collection from DB; when this happens, the version lock on entity cannot protect
+         // us against concurrent modification of the collection. Therefore, we need to remove the entry
+         // here (even without lock!) and let possible update happen in commit phase.
+         for (WriteCommand wc : command.getModifications()) {
+            for (Object key : wc.getAffectedKeys()) {
+               dataContainer.remove(key);
+            }
+         }
+      } else {
+         for (WriteCommand wc : command.getModifications()) {
             Collection<?> keys = wc.getAffectedKeys();
-				if (log.isTraceEnabled()) {
-					log.tracef("Invalidating keys %s with lock owner %s", keys, ctx.getLockOwner());
-				}
-				for (Object key : keys ) {
-					putFromLoadValidator.beginInvalidatingKey(ctx.getLockOwner(), key);
-				}
-			}
-		}
-		return invokeNext(ctx, command);
-	}
+            if (log.isTraceEnabled()) {
+               log.tracef("Invalidating keys %s with lock owner %s", keys, ctx.getLockOwner());
+            }
+            for (Object key : keys) {
+               putFromLoadValidator.beginInvalidatingKey(ctx.getLockOwner(), key);
+            }
+         }
+      }
+      return invokeNext(ctx, command);
+   }
 
-	@Override
-	public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) {
-		if (log.isTraceEnabled()) {
-			log.tracef( "Commit command received, end invalidation" );
-		}
+   @Override
+   public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) {
+      if (log.isTraceEnabled()) {
+         log.tracef("Commit command received, end invalidation");
+      }
 
-		return endInvalidationAndInvokeNextInterceptor(ctx, command);
-	}
+      return endInvalidationAndInvokeNextInterceptor(ctx, command);
+   }
 
-	@Override
-	public Object visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) {
-		if (log.isTraceEnabled()) {
-			log.tracef( "Rollback command received, end invalidation" );
-		}
+   @Override
+   public Object visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) {
+      if (log.isTraceEnabled()) {
+         log.tracef("Rollback command received, end invalidation");
+      }
 
-		return endInvalidationAndInvokeNextInterceptor(ctx, command);
-	}
+      return endInvalidationAndInvokeNextInterceptor(ctx, command);
+   }
 
-	protected Object endInvalidationAndInvokeNextInterceptor(TxInvocationContext<?> ctx, VisitableCommand command) {
-		if (ctx.isOriginLocal()) {
-			// We cannot use directly ctx.getAffectedKeys() and that includes keys from local-only operations.
-			// During evictAll inside transaction this would cause unnecessary invalidate command
-			if (!ctx.getModifications().isEmpty()) {
-				Object[] keys = ctx.getModifications().stream()
-					.flatMap(mod -> mod.getAffectedKeys().stream()).distinct().toArray();
+   protected Object endInvalidationAndInvokeNextInterceptor(TxInvocationContext<?> ctx, VisitableCommand command) {
+      if (ctx.isOriginLocal()) {
+         // We cannot use directly ctx.getAffectedKeys() and that includes keys from local-only operations.
+         // During evictAll inside transaction this would cause unnecessary invalidate command
+         if (!ctx.getModifications().isEmpty()) {
+            Object[] keys = ctx.getModifications().stream()
+                  .flatMap(mod -> mod.getAffectedKeys().stream()).distinct().toArray();
 
-				if (log.isTraceEnabled()) {
-					log.tracef( "Sending end invalidation for keys %s asynchronously, modifications are %s",
-						Arrays.toString(keys), ctx.getCacheTransaction().getModifications());
-				}
+            if (log.isTraceEnabled()) {
+               log.tracef("Sending end invalidation for keys %s asynchronously, modifications are %s",
+                     Arrays.toString(keys), ctx.getCacheTransaction().getModifications());
+            }
 
-				GlobalTransaction globalTransaction = ctx.getGlobalTransaction();
-				EndInvalidationCommand commitCommand = new EndInvalidationCommand(cacheName, keys, globalTransaction);
-				List<Address> members = distributionManager.getCacheTopology().getMembers();
-				rpcManager.sendToMany(members, commitCommand, DeliverOrder.NONE);
+            GlobalTransaction globalTransaction = ctx.getGlobalTransaction();
+            EndInvalidationCommand commitCommand = new EndInvalidationCommand(cacheName, keys, globalTransaction);
+            List<Address> members = distributionManager.getCacheTopology().getMembers();
+            rpcManager.sendToMany(members, commitCommand, DeliverOrder.NONE);
 
-				// If the transaction is not successful, *RegionAccessStrategy would not be called, therefore
-				// we have to end invalidation from here manually (in successful case as well)
-				for (Object key : keys) {
-					putFromLoadValidator.endInvalidatingKey(globalTransaction, key);
-				}
-			}
-		}
-		return invokeNext(ctx, command);
-	}
+            // If the transaction is not successful, *RegionAccessStrategy would not be called, therefore
+            // we have to end invalidation from here manually (in successful case as well)
+            for (Object key : keys) {
+               putFromLoadValidator.endInvalidatingKey(globalTransaction, key);
+            }
+         }
+      }
+      return invokeNext(ctx, command);
+   }
 
-	@Override
+   @Override
    protected Log getLog() {
       return ispnLog;
    }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/UnorderedReplicationLogic.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/UnorderedReplicationLogic.java
@@ -9,7 +9,7 @@ public class UnorderedReplicationLogic extends ClusteringDependentLogic.Replicat
    @Override
    public Commit commitType(
          FlagAffectedCommand command, InvocationContext ctx, int segment, boolean removed) {
-      Commit commit = super.commitType( command, ctx, segment, removed );
+      Commit commit = super.commitType(command, ctx, segment, removed);
       return commit == Commit.NO_COMMIT ? Commit.COMMIT_LOCAL : commit;
    }
 

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/package-info.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/package-info.java
@@ -1,4 +1,3 @@
-
 /**
  * Internal Infinispan-based implementation of the cache region access strategies
  */

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/package-info.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/package-info.java
@@ -1,4 +1,3 @@
-
 /**
  * Defines the integration with Infinispan as a second-level cache service.
  */

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/BeginInvalidationCommand.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/BeginInvalidationCommand.java
@@ -19,55 +19,55 @@ import org.infinispan.util.ByteString;
  */
 @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_INVALIDATE_COMMAND_BEGIN)
 public class BeginInvalidationCommand extends InvalidateCommand {
-	private Object lockOwner;
+   private Object lockOwner;
 
-	public BeginInvalidationCommand(ByteString cacheName, long flagsBitSet, CommandInvocationId commandInvocationId, Object[] keys, Object lockOwner) {
-		super(cacheName, flagsBitSet, commandInvocationId, keys);
-		this.lockOwner = lockOwner;
-	}
-	@ProtoFactory
-	BeginInvalidationCommand(ByteString cacheName, long flagsWithoutRemote, int topologyId, CommandInvocationId commandInvocationId,
-									 MarshallableArray<Object> wrappedKeys, MarshallableObject<Object> wrappedLockOwner) {
-		super(cacheName, flagsWithoutRemote, topologyId, commandInvocationId, wrappedKeys);
-		this.lockOwner = MarshallableObject.unwrap(wrappedLockOwner);
-	}
+   public BeginInvalidationCommand(ByteString cacheName, long flagsBitSet, CommandInvocationId commandInvocationId, Object[] keys, Object lockOwner) {
+      super(cacheName, flagsBitSet, commandInvocationId, keys);
+      this.lockOwner = lockOwner;
+   }
 
-	@ProtoField(number = 6, name = "lock_owner")
-	MarshallableObject<Object> getWrappedLockOwner() {
-		return MarshallableObject.create(lockOwner);
-	}
+   @ProtoFactory
+   BeginInvalidationCommand(ByteString cacheName, long flagsWithoutRemote, int topologyId, CommandInvocationId commandInvocationId,
+                            MarshallableArray<Object> wrappedKeys, MarshallableObject<Object> wrappedLockOwner) {
+      super(cacheName, flagsWithoutRemote, topologyId, commandInvocationId, wrappedKeys);
+      this.lockOwner = MarshallableObject.unwrap(wrappedLockOwner);
+   }
 
-	public Object getLockOwner() {
-		return lockOwner;
-	}
+   @ProtoField(number = 6, name = "lock_owner")
+   MarshallableObject<Object> getWrappedLockOwner() {
+      return MarshallableObject.create(lockOwner);
+   }
+
+   public Object getLockOwner() {
+      return lockOwner;
+   }
 
    @Override
-	public boolean equals(Object o) {
-		if (!super.equals(o)) {
-			return false;
-		}
-		if (o instanceof BeginInvalidationCommand) {
-			BeginInvalidationCommand bic = (BeginInvalidationCommand) o;
-			return Objects.equals(lockOwner, bic.lockOwner);
-		}
-		else {
-			return false;
-		}
-	}
+   public boolean equals(Object o) {
+      if (!super.equals(o)) {
+         return false;
+      }
+      if (o instanceof BeginInvalidationCommand) {
+         BeginInvalidationCommand bic = (BeginInvalidationCommand) o;
+         return Objects.equals(lockOwner, bic.lockOwner);
+      } else {
+         return false;
+      }
+   }
 
-	@Override
-	public int hashCode() {
-		return super.hashCode() + (lockOwner == null ? 0 : lockOwner.hashCode());
-	}
+   @Override
+   public int hashCode() {
+      return super.hashCode() + (lockOwner == null ? 0 : lockOwner.hashCode());
+   }
 
-	@Override
-	public NodeVersion supportedSince() {
-		return NodeVersion.SIXTEEN;
-	}
+   @Override
+   public NodeVersion supportedSince() {
+      return NodeVersion.SIXTEEN;
+   }
 
-	@Override
-	public String toString() {
-		return "BeginInvalidationCommand{keys=" + Arrays.toString(keys) +
-				", sessionTransactionId=" + lockOwner + '}';
-	}
+   @Override
+   public String toString() {
+      return "BeginInvalidationCommand{keys=" + Arrays.toString(keys) +
+            ", sessionTransactionId=" + lockOwner + '}';
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/Caches.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/Caches.java
@@ -32,453 +32,444 @@ import jakarta.transaction.TransactionManager;
  */
 public class Caches {
 
-	private Caches() {
-		// Suppresses default constructor, ensuring non-instantiability.
-	}
+   private Caches() {
+      // Suppresses default constructor, ensuring non-instantiability.
+   }
 
-	/**
-	 * Call an operation within a transaction. This method guarantees that the
-	 * right pattern is used to make sure that the transaction is always either
-	 * committed or rollback.
-	 *
-	 * @param cache instance whose transaction manager to use
-	 * @param c callable instance to run within a transaction
-	 * @param <T> type of callable return
-	 * @return returns whatever the callable returns
-	 * @throws Exception if any operation within the transaction fails
-	 */
-	public static <T> T withinTx(
-			AdvancedCache cache,
-			Callable<T> c) throws Exception {
-		// Retrieve transaction manager
-		return withinTx( cache.getTransactionManager(), c );
-	}
+   /**
+    * Call an operation within a transaction. This method guarantees that the
+    * right pattern is used to make sure that the transaction is always either
+    * committed or rollback.
+    *
+    * @param cache instance whose transaction manager to use
+    * @param c     callable instance to run within a transaction
+    * @param <T>   type of callable return
+    * @return returns whatever the callable returns
+    * @throws Exception if any operation within the transaction fails
+    */
+   public static <T> T withinTx(
+         AdvancedCache cache,
+         Callable<T> c) throws Exception {
+      // Retrieve transaction manager
+      return withinTx(cache.getTransactionManager(), c);
+   }
 
-	/**
-	 * Call an operation within a transaction. This method guarantees that the
-	 * right pattern is used to make sure that the transaction is always either
-	 * committed or rollbacked.
-	 *
-	 * @param tm transaction manager
-	 * @param c callable instance to run within a transaction
-	 * @param <T> type of callable return
-	 * @return returns whatever the callable returns
-	 * @throws Exception if any operation within the transaction fails
-	 */
-	public static <T> T withinTx(
-			TransactionManager tm,
-			Callable<T> c) throws Exception {
-		if ( tm == null ) {
-			try {
-				return c.call();
-			}
-			catch (Exception e) {
-				throw e;
-			}
-		}
-		else {
-			tm.begin();
-			try {
-				return c.call();
-			}
-			catch (Exception e) {
-				tm.setRollbackOnly();
-				throw e;
-			}
-			finally {
-				if ( tm.getStatus() == Status.STATUS_ACTIVE ) {
-					tm.commit();
-				}
-				else {
-					tm.rollback();
-				}
-			}
-		}
-	}
+   /**
+    * Call an operation within a transaction. This method guarantees that the
+    * right pattern is used to make sure that the transaction is always either
+    * committed or rollbacked.
+    *
+    * @param tm  transaction manager
+    * @param c   callable instance to run within a transaction
+    * @param <T> type of callable return
+    * @return returns whatever the callable returns
+    * @throws Exception if any operation within the transaction fails
+    */
+   public static <T> T withinTx(
+         TransactionManager tm,
+         Callable<T> c) throws Exception {
+      if (tm == null) {
+         try {
+            return c.call();
+         } catch (Exception e) {
+            throw e;
+         }
+      } else {
+         tm.begin();
+         try {
+            return c.call();
+         } catch (Exception e) {
+            tm.setRollbackOnly();
+            throw e;
+         } finally {
+            if (tm.getStatus() == Status.STATUS_ACTIVE) {
+               tm.commit();
+            } else {
+               tm.rollback();
+            }
+         }
+      }
+   }
 
-	public static void withinTx(TransactionManager tm, final Runnable runnable) throws Exception {
-		withinTx(tm, new Callable<Void>() {
-			@Override
-			public Void call() throws Exception {
-				runnable.run();
-				return null;
-			}
-		});
-	}
+   public static void withinTx(TransactionManager tm, final Runnable runnable) throws Exception {
+      withinTx(tm, new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            runnable.run();
+            return null;
+         }
+      });
+   }
 
-	/**
-	 * Transform a given cache into a local cache
-	 *
-	 * @param cache to be transformed
-	 * @return a cache that operates only in local-mode
-	 */
-	public static AdvancedCache localCache(AdvancedCache cache) {
-		return cache.withFlags( Flag.CACHE_MODE_LOCAL );
-	}
+   /**
+    * Transform a given cache into a local cache
+    *
+    * @param cache to be transformed
+    * @return a cache that operates only in local-mode
+    */
+   public static AdvancedCache localCache(AdvancedCache cache) {
+      return cache.withFlags(Flag.CACHE_MODE_LOCAL);
+   }
 
-	/**
-	 * Transform a given cache into a cache that ignores return values for
-	 * operations returning previous values, i.e. {@link AdvancedCache#put(Object, Object)}
-	 *
-	 * @param cache to be transformed
-	 * @return a cache that ignores return values
-	 */
-	public static AdvancedCache ignoreReturnValuesCache(AdvancedCache cache) {
-		return cache.withFlags( Flag.SKIP_CACHE_LOAD, Flag.SKIP_REMOTE_LOOKUP, Flag.IGNORE_RETURN_VALUES );
-	}
+   /**
+    * Transform a given cache into a cache that ignores return values for
+    * operations returning previous values, i.e. {@link AdvancedCache#put(Object, Object)}
+    *
+    * @param cache to be transformed
+    * @return a cache that ignores return values
+    */
+   public static AdvancedCache ignoreReturnValuesCache(AdvancedCache cache) {
+      return cache.withFlags(Flag.SKIP_CACHE_LOAD, Flag.SKIP_REMOTE_LOOKUP, Flag.IGNORE_RETURN_VALUES);
+   }
 
-	/**
-	 * Transform a given cache into a cache that ignores return values for
-	 * operations returning previous values, i.e. {@link AdvancedCache#put(Object, Object)},
-	 * adding an extra flag.
-	 *
-	 * @param cache to be transformed
-	 * @param extraFlag to add to the returned cache
-	 * @return a cache that ignores return values
-	 */
-	public static AdvancedCache ignoreReturnValuesCache(
-			AdvancedCache cache, Flag extraFlag) {
-		return cache.withFlags(
-				Flag.SKIP_CACHE_LOAD, Flag.SKIP_REMOTE_LOOKUP, Flag.IGNORE_RETURN_VALUES, extraFlag
-		);
-	}
+   /**
+    * Transform a given cache into a cache that ignores return values for
+    * operations returning previous values, i.e. {@link AdvancedCache#put(Object, Object)},
+    * adding an extra flag.
+    *
+    * @param cache     to be transformed
+    * @param extraFlag to add to the returned cache
+    * @return a cache that ignores return values
+    */
+   public static AdvancedCache ignoreReturnValuesCache(
+         AdvancedCache cache, Flag extraFlag) {
+      return cache.withFlags(
+            Flag.SKIP_CACHE_LOAD, Flag.SKIP_REMOTE_LOOKUP, Flag.IGNORE_RETURN_VALUES, extraFlag
+      );
+   }
 
-	/**
-	 * Transform a given cache into a cache that writes cache entries without
-	 * waiting for them to complete, adding an extra flag.
-	 *
-	 * @param cache to be transformed
-	 * @param extraFlag to add to the returned cache
-	 * @return a cache that writes asynchronously
-	 */
-	public static AdvancedCache asyncWriteCache(
-			AdvancedCache cache,
-			Flag extraFlag) {
-		return cache.withFlags(
-				Flag.SKIP_CACHE_LOAD,
-				Flag.SKIP_REMOTE_LOOKUP,
-				Flag.FORCE_ASYNCHRONOUS,
-				extraFlag
-		);
-	}
+   /**
+    * Transform a given cache into a cache that writes cache entries without
+    * waiting for them to complete, adding an extra flag.
+    *
+    * @param cache     to be transformed
+    * @param extraFlag to add to the returned cache
+    * @return a cache that writes asynchronously
+    */
+   public static AdvancedCache asyncWriteCache(
+         AdvancedCache cache,
+         Flag extraFlag) {
+      return cache.withFlags(
+            Flag.SKIP_CACHE_LOAD,
+            Flag.SKIP_REMOTE_LOOKUP,
+            Flag.FORCE_ASYNCHRONOUS,
+            extraFlag
+      );
+   }
 
-	/**
-	 * Transform a given cache into a cache that fails silently if cache writes fail.
-	 *
-	 * @param cache to be transformed
-	 * @return a cache that fails silently if cache writes fail
-	 */
-	public static AdvancedCache failSilentWriteCache(AdvancedCache cache) {
-		return cache.withFlags(
-				Flag.FAIL_SILENTLY,
-				Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
-				Flag.SKIP_CACHE_LOAD,
-				Flag.SKIP_REMOTE_LOOKUP
-		);
-	}
+   /**
+    * Transform a given cache into a cache that fails silently if cache writes fail.
+    *
+    * @param cache to be transformed
+    * @return a cache that fails silently if cache writes fail
+    */
+   public static AdvancedCache failSilentWriteCache(AdvancedCache cache) {
+      return cache.withFlags(
+            Flag.FAIL_SILENTLY,
+            Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
+            Flag.SKIP_CACHE_LOAD,
+            Flag.SKIP_REMOTE_LOOKUP
+      );
+   }
 
-	/**
-	 * Transform a given cache into a cache that fails silently if
-	 * cache writes fail, adding an extra flag.
-	 *
-	 * @param cache to be transformed
-	 * @param extraFlag to be added to returned cache
-	 * @return a cache that fails silently if cache writes fail
-	 */
-	public static AdvancedCache failSilentWriteCache(
-			AdvancedCache cache,
-			Flag extraFlag) {
-		return cache.withFlags(
-				Flag.FAIL_SILENTLY,
-				Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
-				Flag.SKIP_CACHE_LOAD,
-				Flag.SKIP_REMOTE_LOOKUP,
-				extraFlag
-		);
-	}
+   /**
+    * Transform a given cache into a cache that fails silently if
+    * cache writes fail, adding an extra flag.
+    *
+    * @param cache     to be transformed
+    * @param extraFlag to be added to returned cache
+    * @return a cache that fails silently if cache writes fail
+    */
+   public static AdvancedCache failSilentWriteCache(
+         AdvancedCache cache,
+         Flag extraFlag) {
+      return cache.withFlags(
+            Flag.FAIL_SILENTLY,
+            Flag.ZERO_LOCK_ACQUISITION_TIMEOUT,
+            Flag.SKIP_CACHE_LOAD,
+            Flag.SKIP_REMOTE_LOOKUP,
+            extraFlag
+      );
+   }
 
-	/**
-	 * Transform a given cache into a cache that fails silently if
-	 * cache reads fail.
-	 *
-	 * @param cache to be transformed
-	 * @return a cache that fails silently if cache reads fail
-	 */
-	public static AdvancedCache failSilentReadCache(AdvancedCache cache) {
-		return cache.withFlags(
-				Flag.FAIL_SILENTLY,
-				Flag.ZERO_LOCK_ACQUISITION_TIMEOUT
-		);
-	}
+   /**
+    * Transform a given cache into a cache that fails silently if
+    * cache reads fail.
+    *
+    * @param cache to be transformed
+    * @return a cache that fails silently if cache reads fail
+    */
+   public static AdvancedCache failSilentReadCache(AdvancedCache cache) {
+      return cache.withFlags(
+            Flag.FAIL_SILENTLY,
+            Flag.ZERO_LOCK_ACQUISITION_TIMEOUT
+      );
+   }
 
-	/**
-	 * Broadcast an evict-all command with the given cache instance.
-	 * @param cache instance used to broadcast command
-	 *
-	 */
-	public static void broadcastEvictAll(AdvancedCache cache) {
-		final RpcManager rpcManager = cache.getRpcManager();
-		if (rpcManager != null) {
-			final EvictAllCommand cmd = new EvictAllCommand(ByteString.fromString(cache.getName()));
-			if (isSynchronousCache(cache)) {
-				rpcManager.blocking(rpcManager.invokeCommandOnAll(cmd, VoidResponseCollector.validOnly(), rpcManager.getSyncRpcOptions()));
-			} else {
-				rpcManager.sendToAll(cmd, DeliverOrder.PER_SENDER);
-			}
-		}
-	}
+   /**
+    * Broadcast an evict-all command with the given cache instance.
+    *
+    * @param cache instance used to broadcast command
+    *
+    */
+   public static void broadcastEvictAll(AdvancedCache cache) {
+      final RpcManager rpcManager = cache.getRpcManager();
+      if (rpcManager != null) {
+         final EvictAllCommand cmd = new EvictAllCommand(ByteString.fromString(cache.getName()));
+         if (isSynchronousCache(cache)) {
+            rpcManager.blocking(rpcManager.invokeCommandOnAll(cmd, VoidResponseCollector.validOnly(), rpcManager.getSyncRpcOptions()));
+         } else {
+            rpcManager.sendToAll(cmd, DeliverOrder.PER_SENDER);
+         }
+      }
+   }
 
-	/**
-	 * Indicates whether the given cache is configured with
-	 * {@link org.infinispan.configuration.cache.CacheMode#INVALIDATION_ASYNC} or
-	 * {@link org.infinispan.configuration.cache.CacheMode#INVALIDATION_SYNC}.
-	 *
-	 * @param cache to check for invalidation configuration
-	 * @return true if the cache is configured with invalidation, false otherwise
-	 */
-	public static boolean isInvalidationCache(AdvancedCache cache) {
-		return cache.getCacheConfiguration()
-				.clustering().cacheMode().isInvalidation();
-	}
+   /**
+    * Indicates whether the given cache is configured with
+    * {@link org.infinispan.configuration.cache.CacheMode#INVALIDATION_ASYNC} or
+    * {@link org.infinispan.configuration.cache.CacheMode#INVALIDATION_SYNC}.
+    *
+    * @param cache to check for invalidation configuration
+    * @return true if the cache is configured with invalidation, false otherwise
+    */
+   public static boolean isInvalidationCache(AdvancedCache cache) {
+      return cache.getCacheConfiguration()
+            .clustering().cacheMode().isInvalidation();
+   }
 
-	/**
-	 * Indicates whether the given cache is configured with
-	 * {@link org.infinispan.configuration.cache.CacheMode#REPL_SYNC},
-	 * {@link org.infinispan.configuration.cache.CacheMode#INVALIDATION_SYNC}, or
-	 * {@link org.infinispan.configuration.cache.CacheMode#DIST_SYNC}.
-	 *
-	 * @param cache to check for synchronous configuration
-	 * @return true if the cache is configured with synchronous mode, false otherwise
-	 */
-	public static boolean isSynchronousCache(AdvancedCache cache) {
-		return cache.getCacheConfiguration()
-				.clustering().cacheMode().isSynchronous();
-	}
+   /**
+    * Indicates whether the given cache is configured with
+    * {@link org.infinispan.configuration.cache.CacheMode#REPL_SYNC},
+    * {@link org.infinispan.configuration.cache.CacheMode#INVALIDATION_SYNC}, or
+    * {@link org.infinispan.configuration.cache.CacheMode#DIST_SYNC}.
+    *
+    * @param cache to check for synchronous configuration
+    * @return true if the cache is configured with synchronous mode, false otherwise
+    */
+   public static boolean isSynchronousCache(AdvancedCache cache) {
+      return cache.getCacheConfiguration()
+            .clustering().cacheMode().isSynchronous();
+   }
 
-	/**
-	 * Indicates whether the given cache is configured to cluster its contents.
-	 * A cache is considered to clustered if it's configured with any cache mode
-	 * except {@link org.infinispan.configuration.cache.CacheMode#LOCAL}
-	 *
-	 * @param cache to check whether it clusters its contents
-	 * @return true if the cache is configured with clustering, false otherwise
-	 */
-	public static boolean isClustered(AdvancedCache cache) {
-		return cache.getCacheConfiguration()
-				.clustering().cacheMode().isClustered();
-	}
+   /**
+    * Indicates whether the given cache is configured to cluster its contents.
+    * A cache is considered to clustered if it's configured with any cache mode
+    * except {@link org.infinispan.configuration.cache.CacheMode#LOCAL}
+    *
+    * @param cache to check whether it clusters its contents
+    * @return true if the cache is configured with clustering, false otherwise
+    */
+   public static boolean isClustered(AdvancedCache cache) {
+      return cache.getCacheConfiguration()
+            .clustering().cacheMode().isClustered();
+   }
 
-	public static boolean isTransactionalCache(AdvancedCache cache) {
-		return cache.getCacheConfiguration().transaction().transactionMode().isTransactional();
-	}
+   public static boolean isTransactionalCache(AdvancedCache cache) {
+      return cache.getCacheConfiguration().transaction().transactionMode().isTransactional();
+   }
 
 
-	public static void removeAll(AdvancedCache cache) {
-		CloseableIterator it = cache.keySet().iterator();
-		try {
-			while (it.hasNext()) {
-				// Cannot use it.next(); it.remove() due to ISPN-5653
-				cache.remove(it.next());
-			}
-		}
-		finally {
-			it.close();
-		}
-	}
+   public static void removeAll(AdvancedCache cache) {
+      CloseableIterator it = cache.keySet().iterator();
+      try {
+         while (it.hasNext()) {
+            // Cannot use it.next(); it.remove() due to ISPN-5653
+            cache.remove(it.next());
+         }
+      } finally {
+         it.close();
+      }
+   }
 
-	/**
-	 * This interface is provided for convenient fluent use of CloseableIterable
-	 */
-	public interface CollectableCloseableIterable<T> extends CloseableIterable<T> {
-		Set<T> toSet();
-	}
+   /**
+    * This interface is provided for convenient fluent use of CloseableIterable
+    */
+   public interface CollectableCloseableIterable<T> extends CloseableIterable<T> {
+      Set<T> toSet();
+   }
 
-	public interface MapCollectableCloseableIterable<K, V> extends CloseableIterable<CacheEntry<K, V>> {
-		Map<K, V> toMap();
-	}
+   public interface MapCollectableCloseableIterable<K, V> extends CloseableIterable<CacheEntry<K, V>> {
+      Map<K, V> toMap();
+   }
 
-	public static <K, V> MapCollectableCloseableIterable<K, V> entrySet(AdvancedCache<K, V> cache) {
-		return entrySet(cache, (KeyValueFilter<K, V>) AcceptAllKeyValueFilter.getInstance());
-	}
+   public static <K, V> MapCollectableCloseableIterable<K, V> entrySet(AdvancedCache<K, V> cache) {
+      return entrySet(cache, (KeyValueFilter<K, V>) AcceptAllKeyValueFilter.getInstance());
+   }
 
-	public static <K, V> MapCollectableCloseableIterable<K, V> entrySet(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
-		// HHH-10023: we can't use values()
+   public static <K, V> MapCollectableCloseableIterable<K, V> entrySet(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter) {
+      if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
+         // Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
+         cache.containsKey(false);
+      }
+      // HHH-10023: we can't use values()
       CloseableIterator<CacheEntry<K, V>> iterator = Closeables.iterator(
-         cache.cacheEntrySet().stream().filter(CacheFilters.predicate(filter)));
+            cache.cacheEntrySet().stream().filter(CacheFilters.predicate(filter)));
       return new MapCollectableCloseableIterableImpl<K, V>(iterator);
-	}
+   }
 
-	public static <K, V, T> MapCollectableCloseableIterable<K, T> entrySet(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter, Converter<K, V, T> converter) {
-		if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
-			// Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
-			cache.containsKey(false);
-		}
-		// HHH-10023: we can't use values()
+   public static <K, V, T> MapCollectableCloseableIterable<K, T> entrySet(AdvancedCache<K, V> cache, KeyValueFilter<K, V> filter, Converter<K, V, T> converter) {
+      if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
+         // Dummy read to enlist the LocalTransaction as workaround for ISPN-5676
+         cache.containsKey(false);
+      }
+      // HHH-10023: we can't use values()
       CloseableIterator<CacheEntry<K, T>> it = Closeables.iterator(cache.cacheEntrySet().stream()
-         .filter(CacheFilters.predicate(filter))
-         .map(CacheFilters.function(converter)));
+            .filter(CacheFilters.predicate(filter))
+            .map(CacheFilters.function(converter)));
       return new MapCollectableCloseableIterableImpl<K, T>(it);
-	}
+   }
 
-	/* Function<CacheEntry<K, V>, T> */
-	private interface Selector<K, V, T> {
-		Selector KEY = new Selector<Object, Void, Object>() {
-			@Override
-			public Object apply(CacheEntry<Object, Void> entry) {
-				return entry.getKey();
-			}
-		};
+   /* Function<CacheEntry<K, V>, T> */
+   private interface Selector<K, V, T> {
+      Selector KEY = new Selector<Object, Void, Object>() {
+         @Override
+         public Object apply(CacheEntry<Object, Void> entry) {
+            return entry.getKey();
+         }
+      };
 
-		Selector VALUE = new Selector<Object, Object, Object>() {
-			@Override
-			public Object apply(CacheEntry<Object, Object> entry) {
-				return entry.getValue();
-			}
-		};
+      Selector VALUE = new Selector<Object, Object, Object>() {
+         @Override
+         public Object apply(CacheEntry<Object, Object> entry) {
+            return entry.getValue();
+         }
+      };
 
-		T apply(CacheEntry<K, V> entry);
-	}
+      T apply(CacheEntry<K, V> entry);
+   }
 
-	private static class CollectableCloseableIterableImpl<K, V, T> implements CollectableCloseableIterable<T> {
-		private final CloseableIterable<CacheEntry<K, V>> entryIterable;
-		private final Selector<K, V, T> selector;
+   private static class CollectableCloseableIterableImpl<K, V, T> implements CollectableCloseableIterable<T> {
+      private final CloseableIterable<CacheEntry<K, V>> entryIterable;
+      private final Selector<K, V, T> selector;
 
-		public CollectableCloseableIterableImpl(CloseableIterable<CacheEntry<K, V>> entryIterable, Selector<K, V, T> selector) {
-			this.entryIterable = entryIterable;
-			this.selector = selector;
-		}
+      public CollectableCloseableIterableImpl(CloseableIterable<CacheEntry<K, V>> entryIterable, Selector<K, V, T> selector) {
+         this.entryIterable = entryIterable;
+         this.selector = selector;
+      }
 
-		@Override
-		public void close() {
-			entryIterable.close();
-		}
+      @Override
+      public void close() {
+         entryIterable.close();
+      }
 
-		@Override
-		public CloseableIterator<T> iterator() {
-			final CloseableIterator<CacheEntry<K, V>> entryIterator = entryIterable.iterator();
-			return new CloseableIterator<T>() {
-				@Override
-				public void close() {
-					entryIterator.close();
-				}
+      @Override
+      public CloseableIterator<T> iterator() {
+         final CloseableIterator<CacheEntry<K, V>> entryIterator = entryIterable.iterator();
+         return new CloseableIterator<T>() {
+            @Override
+            public void close() {
+               entryIterator.close();
+            }
 
-				@Override
-				public boolean hasNext() {
-					return entryIterator.hasNext();
-				}
+            @Override
+            public boolean hasNext() {
+               return entryIterator.hasNext();
+            }
 
-				@Override
-				public T next() {
-					return selector.apply(entryIterator.next());
-				}
+            @Override
+            public T next() {
+               return selector.apply(entryIterator.next());
+            }
 
-				@Override
-				public void remove() {
-					throw new UnsupportedOperationException( "remove() not supported" );
-				}
-			};
-		}
+            @Override
+            public void remove() {
+               throw new UnsupportedOperationException("remove() not supported");
+            }
+         };
+      }
 
-		@Override
-		public String toString() {
-			CloseableIterator<CacheEntry<K, V>> it = entryIterable.iterator();
-			try {
-				if (!it.hasNext()) {
-					return "[]";
-				}
+      @Override
+      public String toString() {
+         CloseableIterator<CacheEntry<K, V>> it = entryIterable.iterator();
+         try {
+            if (!it.hasNext()) {
+               return "[]";
+            }
 
-				StringBuilder sb = new StringBuilder();
-				sb.append('[');
-				for (; ; ) {
-					CacheEntry<K, V> entry = it.next();
-					sb.append(selector.apply(entry));
-					if (!it.hasNext()) {
-						return sb.append(']').toString();
-					}
-					sb.append(',').append(' ');
-				}
-			}
-			finally {
-				it.close();
-			}
-		}
+            StringBuilder sb = new StringBuilder();
+            sb.append('[');
+            for (; ; ) {
+               CacheEntry<K, V> entry = it.next();
+               sb.append(selector.apply(entry));
+               if (!it.hasNext()) {
+                  return sb.append(']').toString();
+               }
+               sb.append(',').append(' ');
+            }
+         } finally {
+            it.close();
+         }
+      }
 
-		@Override
-		public Set toSet() {
-			HashSet set = new HashSet();
-			CloseableIterator it = iterator();
-			try {
-				while (it.hasNext()) {
-					set.add(it.next());
-				}
-			}
-			finally {
-				it.close();
-			}
-			return set;
-		}
-	}
+      @Override
+      public Set toSet() {
+         HashSet set = new HashSet();
+         CloseableIterator it = iterator();
+         try {
+            while (it.hasNext()) {
+               set.add(it.next());
+            }
+         } finally {
+            it.close();
+         }
+         return set;
+      }
+   }
 
-	private static class MapCollectableCloseableIterableImpl<K, V> implements MapCollectableCloseableIterable<K, V> {
+   private static class MapCollectableCloseableIterableImpl<K, V> implements MapCollectableCloseableIterable<K, V> {
       private final CloseableIterator<CacheEntry<K, V>> it;
 
-		public MapCollectableCloseableIterableImpl(CloseableIterator<CacheEntry<K, V>> it) {
-			this.it = it;
-		}
+      public MapCollectableCloseableIterableImpl(CloseableIterator<CacheEntry<K, V>> it) {
+         this.it = it;
+      }
 
-		@Override
-		public Map<K, V> toMap() {
-			Map<K, V> map = new HashMap<K, V>();
-			try {
-				while (it.hasNext()) {
-					CacheEntry<K, V> entry = it.next();
-					V value = entry.getValue();
-					if (value != null) {
-						map.put(entry.getKey(), value);
-					}
-				}
-				return map;
-			}
-			finally {
-				it.close();
-			}
-		}
+      @Override
+      public Map<K, V> toMap() {
+         Map<K, V> map = new HashMap<K, V>();
+         try {
+            while (it.hasNext()) {
+               CacheEntry<K, V> entry = it.next();
+               V value = entry.getValue();
+               if (value != null) {
+                  map.put(entry.getKey(), value);
+               }
+            }
+            return map;
+         } finally {
+            it.close();
+         }
+      }
 
-		@Override
-		public String toString() {
-			try {
-				if (!it.hasNext()) {
-					return "{}";
-				}
+      @Override
+      public String toString() {
+         try {
+            if (!it.hasNext()) {
+               return "{}";
+            }
 
-				StringBuilder sb = new StringBuilder();
-				sb.append('{');
-				for (; ; ) {
-					CacheEntry<K, V> entry = it.next();
-					sb.append(entry.getKey()).append('=').append(entry.getValue());
-					if (!it.hasNext()) {
-						return sb.append('}').toString();
-					}
-					sb.append(',').append(' ');
-				}
-			}
-			finally {
-				it.close();
-			}
-		}
+            StringBuilder sb = new StringBuilder();
+            sb.append('{');
+            for (; ; ) {
+               CacheEntry<K, V> entry = it.next();
+               sb.append(entry.getKey()).append('=').append(entry.getValue());
+               if (!it.hasNext()) {
+                  return sb.append('}').toString();
+               }
+               sb.append(',').append(' ');
+            }
+         } finally {
+            it.close();
+         }
+      }
 
-		@Override
-		public void close() {
+      @Override
+      public void close() {
          it.close();
-		}
+      }
 
-		@Override
-		public CloseableIterator<CacheEntry<K, V>> iterator() {
-			return it;
-		}
-	}
+      @Override
+      public CloseableIterator<CacheEntry<K, V>> iterator() {
+         return it;
+      }
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/CompletableFunction.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/CompletableFunction.java
@@ -7,5 +7,6 @@ package org.infinispan.hibernate.cache.commons.util;
  */
 public interface CompletableFunction {
    boolean isComplete();
+
    void markComplete();
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/EndInvalidationCommand.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/EndInvalidationCommand.java
@@ -25,71 +25,71 @@ import org.infinispan.util.concurrent.BlockingManager;
  */
 @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_INVALIDATE_COMMAND_END)
 public class EndInvalidationCommand extends BaseRpcCommand {
-	private final Object[] keys;
-	private final Object lockOwner;
+   private final Object[] keys;
+   private final Object lockOwner;
 
-	/**
-	 * @param cacheName name of the cache to evict
-	 */
-	public EndInvalidationCommand(ByteString cacheName, Object[] keys, Object lockOwner) {
-		super(cacheName);
-		this.keys = keys;
-		this.lockOwner = lockOwner;
-	}
+   /**
+    * @param cacheName name of the cache to evict
+    */
+   public EndInvalidationCommand(ByteString cacheName, Object[] keys, Object lockOwner) {
+      super(cacheName);
+      this.keys = keys;
+      this.lockOwner = lockOwner;
+   }
 
-	@ProtoFactory
-	EndInvalidationCommand(ByteString cacheName, MarshallableArray<Object> keys, MarshallableObject<Object> lockOwner) {
-		this(cacheName, MarshallableArray.unwrap(keys), MarshallableObject.unwrap(lockOwner));
-	}
+   @ProtoFactory
+   EndInvalidationCommand(ByteString cacheName, MarshallableArray<Object> keys, MarshallableObject<Object> lockOwner) {
+      this(cacheName, MarshallableArray.unwrap(keys), MarshallableObject.unwrap(lockOwner));
+   }
 
-	@ProtoField(2)
-	MarshallableArray<Object> getKeys() {
-		return MarshallableArray.create(keys);
-	}
+   @ProtoField(2)
+   MarshallableArray<Object> getKeys() {
+      return MarshallableArray.create(keys);
+   }
 
-	@ProtoField(3)
-	MarshallableObject<Object> getLockOwner() {
-		return MarshallableObject.create(lockOwner);
-	}
+   @ProtoField(3)
+   MarshallableObject<Object> getLockOwner() {
+      return MarshallableObject.create(lockOwner);
+   }
 
-	@Override
-	public CompletionStage<?> invokeAsync(ComponentRegistry componentRegistry) {
-		BlockingManager bm = componentRegistry.getGlobalComponentRegistry().getComponent(BlockingManager.class);
-		PutFromLoadValidator putFromLoadValidator = componentRegistry.getComponent(PutFromLoadValidator.class);
-		return bm.runBlocking(() -> {
-			for (Object key : keys) {
-				putFromLoadValidator.endInvalidatingKey(lockOwner, key);
-			}
-		}, "end-invalidation");
-	}
+   @Override
+   public CompletionStage<?> invokeAsync(ComponentRegistry componentRegistry) {
+      BlockingManager bm = componentRegistry.getGlobalComponentRegistry().getComponent(BlockingManager.class);
+      PutFromLoadValidator putFromLoadValidator = componentRegistry.getComponent(PutFromLoadValidator.class);
+      return bm.runBlocking(() -> {
+         for (Object key : keys) {
+            putFromLoadValidator.endInvalidatingKey(lockOwner, key);
+         }
+      }, "end-invalidation");
+   }
 
-	@Override
-	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass()) return false;
-		EndInvalidationCommand that = (EndInvalidationCommand) o;
-		return Objects.deepEquals(keys, that.keys) && Objects.equals(lockOwner, that.lockOwner) && Objects.equals(cacheName, that.cacheName);
-	}
+   @Override
+   public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      EndInvalidationCommand that = (EndInvalidationCommand) o;
+      return Objects.deepEquals(keys, that.keys) && Objects.equals(lockOwner, that.lockOwner) && Objects.equals(cacheName, that.cacheName);
+   }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(Arrays.hashCode(keys), lockOwner, cacheName);
-	}
+   @Override
+   public int hashCode() {
+      return Objects.hash(Arrays.hashCode(keys), lockOwner, cacheName);
+   }
 
-	@Override
-	public boolean isReturnValueExpected() {
-		return false;
-	}
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
 
-	@Override
-	public NodeVersion supportedSince() {
-		return NodeVersion.SIXTEEN;
-	}
+   @Override
+   public NodeVersion supportedSince() {
+      return NodeVersion.SIXTEEN;
+   }
 
-	@Override
-	public String toString() {
+   @Override
+   public String toString() {
       return "EndInvalidationCommand{" + "cacheName=" + cacheName +
             ", keys=" + Arrays.toString(keys) +
             ", sessionTransactionId=" + lockOwner +
             '}';
-	}
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/EvictAllCommand.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/EvictAllCommand.java
@@ -28,27 +28,27 @@ public class EvictAllCommand extends BaseRpcCommand {
     */
    @ProtoFactory
    public EvictAllCommand(ByteString cacheName) {
-		super(cacheName);
-	}
-
-	@Override
-	public CompletionStage<?> invokeAsync(ComponentRegistry registry) throws Throwable {
-		// When a node is joining the cluster, it may receive an EvictAllCommand before the regions
-		// are started up. It's safe to ignore such invalidation at this point since no data got in.
-		var region = registry.getComponent(InfinispanBaseRegion.class);
-		if (region != null) {
-			region.invalidateRegion();
-		}
-		return CompletableFutures.completedNull();
-	}
+      super(cacheName);
+   }
 
    @Override
-	public boolean isReturnValueExpected() {
-		return false;
-	}
+   public CompletionStage<?> invokeAsync(ComponentRegistry registry) throws Throwable {
+      // When a node is joining the cluster, it may receive an EvictAllCommand before the regions
+      // are started up. It's safe to ignore such invalidation at this point since no data got in.
+      var region = registry.getComponent(InfinispanBaseRegion.class);
+      if (region != null) {
+         region.invalidateRegion();
+      }
+      return CompletableFutures.completedNull();
+   }
 
-	@Override
-	public NodeVersion supportedSince() {
-		return NodeVersion.SIXTEEN;
-	}
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
+   public NodeVersion supportedSince() {
+      return NodeVersion.SIXTEEN;
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/FutureUpdate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/FutureUpdate.java
@@ -15,77 +15,77 @@ import org.infinispan.protostream.annotations.ProtoTypeId;
 
 /**
  * Request to update the tombstone, coming from insert/update/remove operation.
- *
+ * <p>
  * This object should *not* be stored in cache.
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_FUTURE_UPDATE)
 public class FutureUpdate implements Function<EntryView.ReadWriteEntryView<Object, Object>, Void>, InjectableComponent {
-	private final UUID uuid;
-	private final long timestamp;
-	private final Object value;
-	private transient InfinispanDataRegion region;
+   private final UUID uuid;
+   private final long timestamp;
+   private final Object value;
+   private transient InfinispanDataRegion region;
 
-	public FutureUpdate(UUID uuid, long timestamp, Object value) {
-		this.uuid = uuid;
-		this.timestamp = timestamp;
-		this.value = value;
-	}
+   public FutureUpdate(UUID uuid, long timestamp, Object value) {
+      this.uuid = uuid;
+      this.timestamp = timestamp;
+      this.value = value;
+   }
 
-	@ProtoFactory
-	FutureUpdate(UUID uuid, long timestamp, MarshallableObject<?> value) {
-		this(uuid, timestamp, MarshallableObject.unwrap(value));
-	}
+   @ProtoFactory
+   FutureUpdate(UUID uuid, long timestamp, MarshallableObject<?> value) {
+      this(uuid, timestamp, MarshallableObject.unwrap(value));
+   }
 
-	@Override
-	public String toString() {
-		final StringBuilder sb = new StringBuilder("FutureUpdate{");
-		sb.append("uuid=").append(uuid);
-		sb.append(", timestamp=").append(timestamp);
-		sb.append(", value=").append(value);
-		sb.append('}');
-		return sb.toString();
-	}
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder("FutureUpdate{");
+      sb.append("uuid=").append(uuid);
+      sb.append(", timestamp=").append(timestamp);
+      sb.append(", value=").append(value);
+      sb.append('}');
+      return sb.toString();
+   }
 
-	@ProtoField(1)
-	public UUID getUuid() {
-		return uuid;
-	}
+   @ProtoField(1)
+   public UUID getUuid() {
+      return uuid;
+   }
 
-	@ProtoField(2)
-	public long getTimestamp() {
-		return timestamp;
-	}
+   @ProtoField(2)
+   public long getTimestamp() {
+      return timestamp;
+   }
 
-	@ProtoField(3)
-	public MarshallableObject<?> getValue() {
-		return MarshallableObject.create(value);
-	}
+   @ProtoField(3)
+   public MarshallableObject<?> getValue() {
+      return MarshallableObject.create(value);
+   }
 
-	@Override
-	public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
-		Object storedValue = view.find().orElse(null);
-		if (storedValue instanceof Tombstone) {
-			// Note that the update has to keep tombstone even if the transaction was unsuccessful;
-			// before write we have removed the value and we have to protect the entry against stale putFromLoads
-			Tombstone tombstone = (Tombstone) storedValue;
-			Object result = tombstone.applyUpdate(uuid, timestamp, this.value);
-			if (result instanceof Tombstone) {
-				view.set(result, region.getExpiringMetaParam());
-			} else {
-				view.set(result);
-			}
-		}
-		// Else: this is an async future update, and it's timestamp may be vastly outdated
-		// We need to first execute the async update and then local one, because if we're on the primary
-		// owner the local future update would fail the async one.
-		// TODO: There is some discrepancy with TombstoneUpdate handling which does not fail the update
-		return null;
-	}
+   @Override
+   public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
+      Object storedValue = view.find().orElse(null);
+      if (storedValue instanceof Tombstone) {
+         // Note that the update has to keep tombstone even if the transaction was unsuccessful;
+         // before write we have removed the value and we have to protect the entry against stale putFromLoads
+         Tombstone tombstone = (Tombstone) storedValue;
+         Object result = tombstone.applyUpdate(uuid, timestamp, this.value);
+         if (result instanceof Tombstone) {
+            view.set(result, region.getExpiringMetaParam());
+         } else {
+            view.set(result);
+         }
+      }
+      // Else: this is an async future update, and it's timestamp may be vastly outdated
+      // We need to first execute the async update and then local one, because if we're on the primary
+      // owner the local future update would fail the async one.
+      // TODO: There is some discrepancy with TombstoneUpdate handling which does not fail the update
+      return null;
+   }
 
-	@Override
-	public void inject(ComponentRegistry registry) {
-		region = registry.getComponent(InfinispanDataRegion.class);
-	}
+   @Override
+   public void inject(ComponentRegistry registry) {
+      region = registry.getComponent(InfinispanDataRegion.class);
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/InfinispanMessageLogger.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/InfinispanMessageLogger.java
@@ -27,140 +27,140 @@ import jakarta.transaction.SystemException;
  */
 @MessageLogger(projectCode = "HHH")
 public interface InfinispanMessageLogger extends BasicLogger {
-	// Workaround for JBLOGGING-120: cannot add static interface method
-	class Provider {
-		public static InfinispanMessageLogger getLog(Class clazz) {
-			return Logger.getMessageLogger(MethodHandles.lookup(), InfinispanMessageLogger.class, clazz.getName());
-		}
-	}
+   // Workaround for JBLOGGING-120: cannot add static interface method
+   class Provider {
+      public static InfinispanMessageLogger getLog(Class clazz) {
+         return Logger.getMessageLogger(MethodHandles.lookup(), InfinispanMessageLogger.class, clazz.getName());
+      }
+   }
 
-	@Message(value = "Pending-puts cache must not be clustered!", id = 25001)
-	CacheException pendingPutsMustNotBeClustered();
+   @Message(value = "Pending-puts cache must not be clustered!", id = 25001)
+   CacheException pendingPutsMustNotBeClustered();
 
-	@Message(value = "Pending-puts cache must not be transactional!", id = 25002)
-	CacheException pendingPutsMustNotBeTransactional();
+   @Message(value = "Pending-puts cache must not be transactional!", id = 25002)
+   CacheException pendingPutsMustNotBeTransactional();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Pending-puts cache configuration should be a template.", id = 25003)
-	void pendingPutsShouldBeTemplate();
+   @LogMessage(level = WARN)
+   @Message(value = "Pending-puts cache configuration should be a template.", id = 25003)
+   void pendingPutsShouldBeTemplate();
 
-	@Message(value = "Pending-puts cache must have expiration.max-idle set", id = 25004)
-	CacheException pendingPutsMustHaveMaxIdle();
+   @Message(value = "Pending-puts cache must have expiration.max-idle set", id = 25004)
+   CacheException pendingPutsMustHaveMaxIdle();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Property '" + InfinispanProperties.INFINISPAN_USE_SYNCHRONIZATION_PROP + "' is deprecated; 2LC with transactional cache must always use synchronizations.", id = 25005)
-	void propertyUseSynchronizationDeprecated();
+   @LogMessage(level = WARN)
+   @Message(value = "Property '" + InfinispanProperties.INFINISPAN_USE_SYNCHRONIZATION_PROP + "' is deprecated; 2LC with transactional cache must always use synchronizations.", id = 25005)
+   void propertyUseSynchronizationDeprecated();
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Custom cache configuration '%s' was requested for type %s but it was not found!", id = 25006)
-	void customConfigForTypeNotFound(String cacheName, String type);
+   @LogMessage(level = ERROR)
+   @Message(value = "Custom cache configuration '%s' was requested for type %s but it was not found!", id = 25006)
+   void customConfigForTypeNotFound(String cacheName, String type);
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Custom cache configuration '%s' was requested for region %s but it was not found - using configuration by type (%s).", id = 25007)
-	void customConfigForRegionNotFound(String templateCacheName, String regionName, String type);
+   @LogMessage(level = ERROR)
+   @Message(value = "Custom cache configuration '%s' was requested for region %s but it was not found - using configuration by type (%s).", id = 25007)
+   void customConfigForRegionNotFound(String templateCacheName, String regionName, String type);
 
-	@Message(value = "Timestamps cache must not use eviction!", id = 25008)
-	CacheException timestampsMustNotUseEviction();
+   @Message(value = "Timestamps cache must not use eviction!", id = 25008)
+   CacheException timestampsMustNotUseEviction();
 
-	@Message(value = "Unable to start region factory", id = 25009)
-	CacheException unableToStart(@Cause Throwable t);
+   @Message(value = "Unable to start region factory", id = 25009)
+   CacheException unableToStart(@Cause Throwable t);
 
-	@Message(value = "Unable to create default cache manager", id = 25010)
-	CacheException unableToCreateCacheManager(@Cause Throwable t);
+   @Message(value = "Unable to create default cache manager", id = 25010)
+   CacheException unableToCreateCacheManager(@Cause Throwable t);
 
-	@Message(value = "Infinispan custom cache command factory not installed (possibly because the classloader where Infinispan lives couldn't find the Hibernate Infinispan cache provider)", id = 25011)
-	CacheException cannotInstallCommandFactory();
+   @Message(value = "Infinispan custom cache command factory not installed (possibly because the classloader where Infinispan lives couldn't find the Hibernate Infinispan cache provider)", id = 25011)
+   CacheException cannotInstallCommandFactory();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Requesting TRANSACTIONAL cache concurrency strategy but the cache is not configured as transactional.", id = 25012)
-	void transactionalStrategyNonTransactionalCache();
+   @LogMessage(level = WARN)
+   @Message(value = "Requesting TRANSACTIONAL cache concurrency strategy but the cache is not configured as transactional.", id = 25012)
+   void transactionalStrategyNonTransactionalCache();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Requesting READ_WRITE cache concurrency strategy but the cache was configured as transactional.", id = 25013)
-	void readWriteStrategyTransactionalCache();
+   @LogMessage(level = WARN)
+   @Message(value = "Requesting READ_WRITE cache concurrency strategy but the cache was configured as transactional.", id = 25013)
+   void readWriteStrategyTransactionalCache();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Setting eviction on cache using tombstones can introduce inconsistencies!", id = 25014)
-	void evictionWithTombstones();
+   @LogMessage(level = WARN)
+   @Message(value = "Setting eviction on cache using tombstones can introduce inconsistencies!", id = 25014)
+   void evictionWithTombstones();
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Failure updating cache in afterCompletion, will retry", id = 25015)
-	void failureInAfterCompletion(@Cause Throwable e);
+   @LogMessage(level = ERROR)
+   @Message(value = "Failure updating cache in afterCompletion, will retry", id = 25015)
+   void failureInAfterCompletion(@Cause Throwable e);
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Failed to end invalidating pending putFromLoad calls for key %s from region %s; the key won't be cached until invalidation expires.", id = 25016)
-	void failedEndInvalidating(Object key, ByteString name);
+   @LogMessage(level = ERROR)
+   @Message(value = "Failed to end invalidating pending putFromLoad calls for key %s from region %s; the key won't be cached until invalidation expires.", id = 25016)
+   void failedEndInvalidating(Object key, ByteString name);
 
-	@Message(value = "Unable to retrieve CacheManager from JNDI [%s]", id = 25017)
-	CacheException unableToRetrieveCmFromJndi(String jndiNamespace);
+   @Message(value = "Unable to retrieve CacheManager from JNDI [%s]", id = 25017)
+   CacheException unableToRetrieveCmFromJndi(String jndiNamespace);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Unable to release initial context", id = 25018)
-	void unableToReleaseContext(@Cause NamingException ne);
+   @LogMessage(level = WARN)
+   @Message(value = "Unable to release initial context", id = 25018)
+   void unableToReleaseContext(@Cause NamingException ne);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Use non-transactional query caches for best performance!", id = 25019)
-	void useNonTransactionalQueryCache();
+   @LogMessage(level = WARN)
+   @Message(value = "Use non-transactional query caches for best performance!", id = 25019)
+   void useNonTransactionalQueryCache();
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Unable to broadcast invalidations as a part of the prepare phase. Rolling back.", id = 25020)
-	void unableToRollbackInvalidationsDuringPrepare(@Cause Throwable t);
+   @LogMessage(level = ERROR)
+   @Message(value = "Unable to broadcast invalidations as a part of the prepare phase. Rolling back.", id = 25020)
+   void unableToRollbackInvalidationsDuringPrepare(@Cause Throwable t);
 
-	@Message(value = "Could not suspend transaction", id = 25021)
-	CacheException cannotSuspendTx(@Cause SystemException se);
+   @Message(value = "Could not suspend transaction", id = 25021)
+   CacheException cannotSuspendTx(@Cause SystemException se);
 
-	@Message(value = "Could not resume transaction", id = 25022)
-	CacheException cannotResumeTx(@Cause Exception e);
+   @Message(value = "Could not resume transaction", id = 25022)
+   CacheException cannotResumeTx(@Cause Exception e);
 
-	@Message(value = "Unable to get current transaction", id = 25023)
-	CacheException cannotGetCurrentTx(@Cause SystemException e);
+   @Message(value = "Unable to get current transaction", id = 25023)
+   CacheException cannotGetCurrentTx(@Cause SystemException e);
 
-	@Message(value = "Failed to invalidate pending putFromLoad calls for key %s from region %s", id = 25024)
-	CacheException failedInvalidatePendingPut(Object key, String regionName);
+   @Message(value = "Failed to invalidate pending putFromLoad calls for key %s from region %s", id = 25024)
+   CacheException failedInvalidatePendingPut(Object key, String regionName);
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Failed to invalidate pending putFromLoad calls for region %s", id = 25025)
-	void failedInvalidateRegion(String regionName);
+   @LogMessage(level = ERROR)
+   @Message(value = "Failed to invalidate pending putFromLoad calls for region %s", id = 25025)
+   void failedInvalidateRegion(String regionName);
 
-	@Message(value = "Property '" + InfinispanProperties.CACHE_MANAGER_RESOURCE_PROP + "' not set", id = 25026)
-	CacheException propertyCacheManagerResourceNotSet();
+   @Message(value = "Property '" + InfinispanProperties.CACHE_MANAGER_RESOURCE_PROP + "' not set", id = 25026)
+   CacheException propertyCacheManagerResourceNotSet();
 
-	@Message(value = "Timestamp cache cannot be configured with invalidation", id = 25027)
-	CacheException timestampsMustNotUseInvalidation();
+   @Message(value = "Timestamp cache cannot be configured with invalidation", id = 25027)
+   CacheException timestampsMustNotUseInvalidation();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Ignoring deprecated property '%s'", id = 25028)
-	void ignoringDeprecatedProperty(String deprecated);
+   @LogMessage(level = WARN)
+   @Message(value = "Ignoring deprecated property '%s'", id = 25028)
+   void ignoringDeprecatedProperty(String deprecated);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Property '%s' is deprecated, please use '%s' instead", id = 25029)
-	void deprecatedProperty(String deprecated, String alternative);
+   @LogMessage(level = WARN)
+   @Message(value = "Property '%s' is deprecated, please use '%s' instead", id = 25029)
+   void deprecatedProperty(String deprecated, String alternative);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Transactional caches are not supported. The configuration option will be ignored; please unset.", id = 25030)
-	void transactionalConfigurationIgnored();
+   @LogMessage(level = WARN)
+   @Message(value = "Transactional caches are not supported. The configuration option will be ignored; please unset.", id = 25030)
+   void transactionalConfigurationIgnored();
 
-	@LogMessage(level = WARN)
-	@Message(value = "Configuration for pending-puts cache '%s' is already defined - another instance of SessionFactory was not closed properly.", id = 25031)
-	void pendingPutsCacheAlreadyDefined(String pendingPutsName);
+   @LogMessage(level = WARN)
+   @Message(value = "Configuration for pending-puts cache '%s' is already defined - another instance of SessionFactory was not closed properly.", id = 25031)
+   void pendingPutsCacheAlreadyDefined(String pendingPutsName);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Cache configuration '%s' is present but the use has not been defined through " + InfinispanProperties.PREFIX + "%s" + InfinispanProperties.CONFIG_SUFFIX + "=%s", id = 25032)
-	void regionNameMatchesCacheName(String regionName, String regionName2, String regionName3);
+   @LogMessage(level = WARN)
+   @Message(value = "Cache configuration '%s' is present but the use has not been defined through " + InfinispanProperties.PREFIX + "%s" + InfinispanProperties.CONFIG_SUFFIX + "=%s", id = 25032)
+   void regionNameMatchesCacheName(String regionName, String regionName2, String regionName3);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Configuration properties contain record for unqualified region name '%s' but it should contain qualified region name '%s'", id = 25033)
-	void usingUnqualifiedNameInConfiguration(String unqualifiedRegionName, String cacheName);
+   @LogMessage(level = WARN)
+   @Message(value = "Configuration properties contain record for unqualified region name '%s' but it should contain qualified region name '%s'", id = 25033)
+   void usingUnqualifiedNameInConfiguration(String unqualifiedRegionName, String cacheName);
 
-	@LogMessage(level = WARN)
-	@Message(value = "Configuration for unqualified region name '%s' is defined but the cache will use qualified name '%s'", id = 25034)
-	void configurationWithUnqualifiedName(String unqualifiedRegionName, String cacheName);
+   @LogMessage(level = WARN)
+   @Message(value = "Configuration for unqualified region name '%s' is defined but the cache will use qualified name '%s'", id = 25034)
+   void configurationWithUnqualifiedName(String unqualifiedRegionName, String cacheName);
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Operation #%d scheduled to complete before transaction completion failed", id = 25035)
-	void failureBeforeTransactionCompletion(int index, @Cause Exception e);
+   @LogMessage(level = ERROR)
+   @Message(value = "Operation #%d scheduled to complete before transaction completion failed", id = 25035)
+   void failureBeforeTransactionCompletion(int index, @Cause Exception e);
 
-	@LogMessage(level = ERROR)
-	@Message(value = "Operation #%d scheduled after transaction completion failed (transaction successful? %s)", id = 25036)
-	void failureAfterTransactionCompletion(int index, boolean successful, @Cause Exception e);
+   @LogMessage(level = ERROR)
+   @Message(value = "Operation #%d scheduled after transaction completion failed (transaction successful? %s)", id = 25036)
+   void failureAfterTransactionCompletion(int index, boolean successful, @Cause Exception e);
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/InvocationAfterCompletion.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/InvocationAfterCompletion.java
@@ -10,49 +10,48 @@ import jakarta.transaction.Synchronization;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class InvocationAfterCompletion implements Synchronization {
-	protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( InvocationAfterCompletion.class );
+   protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(InvocationAfterCompletion.class);
 
-	protected final TransactionCoordinatorAccess tc;
-	protected final boolean requiresTransaction;
+   protected final TransactionCoordinatorAccess tc;
+   protected final boolean requiresTransaction;
 
    public InvocationAfterCompletion(TransactionCoordinatorAccess tc, boolean requiresTransaction) {
-		this.tc = tc;
-		this.requiresTransaction = requiresTransaction;
-	}
+      this.tc = tc;
+      this.requiresTransaction = requiresTransaction;
+   }
 
-	@Override
-	public void beforeCompletion() {
-	}
+   @Override
+   public void beforeCompletion() {
+   }
 
-	@Override
-	public void afterCompletion(int status) {
-		switch (status) {
-			case Status.STATUS_COMMITTING:
-			case Status.STATUS_COMMITTED:
-				invokeIsolated(true);
-				break;
-			default:
-				// it would be nicer to react only on ROLLING_BACK and ROLLED_BACK statuses
-				// but TransactionCoordinator gives us UNKNOWN on rollback
-				invokeIsolated(false);
-				break;
-		}
-	}
+   @Override
+   public void afterCompletion(int status) {
+      switch (status) {
+         case Status.STATUS_COMMITTING:
+         case Status.STATUS_COMMITTED:
+            invokeIsolated(true);
+            break;
+         default:
+            // it would be nicer to react only on ROLLING_BACK and ROLLED_BACK statuses
+            // but TransactionCoordinator gives us UNKNOWN on rollback
+            invokeIsolated(false);
+            break;
+      }
+   }
 
-	protected void invokeIsolated(final boolean success) {
-		try {
-			tc.delegateWork((executor, connection) -> {
-				invoke(success);
-				return null;
-			}, requiresTransaction);
-		}
-		catch (HibernateException e) {
-			// silently fail any exceptions
-			if (log.isTraceEnabled()) {
-				log.trace("Exception during query cache update", e);
-			}
-		}
-	}
+   protected void invokeIsolated(final boolean success) {
+      try {
+         tc.delegateWork((executor, connection) -> {
+            invoke(success);
+            return null;
+         }, requiresTransaction);
+      } catch (HibernateException e) {
+         // silently fail any exceptions
+         if (log.isTraceEnabled()) {
+            log.trace("Exception during query cache update", e);
+         }
+      }
+   }
 
-	protected abstract void invoke(boolean success);
+   protected abstract void invoke(boolean success);
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/LifecycleCallbacks.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/LifecycleCallbacks.java
@@ -9,9 +9,9 @@ import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 @InfinispanModule(name = "hibernate-cache-commons", requiredModules = "core")
 public class LifecycleCallbacks implements ModuleLifecycle {
 
-	@Override
-	public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {
-		SerializationContextRegistry ctxRegistry = gcr.getComponent(SerializationContextRegistry.class);
-		ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.GLOBAL, new org.infinispan.hibernate.cache.commons.GlobalContextInitializerImpl());
-	}
+   @Override
+   public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {
+      SerializationContextRegistry ctxRegistry = gcr.getComponent(SerializationContextRegistry.class);
+      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.GLOBAL, new org.infinispan.hibernate.cache.commons.GlobalContextInitializerImpl());
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/Tombstone.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/Tombstone.java
@@ -22,179 +22,171 @@ import org.infinispan.protostream.annotations.ProtoTypeId;
  */
 @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_TOMBSTONE)
 public class Tombstone implements Function<EntryView.ReadWriteEntryView<Object, Object>, Void>, InjectableComponent, CompletableFunction {
-	public static final ExcludeTombstonesFilter EXCLUDE_TOMBSTONES = new ExcludeTombstonesFilter();
+   public static final ExcludeTombstonesFilter EXCLUDE_TOMBSTONES = new ExcludeTombstonesFilter();
 
-	// the format of data is repeated (timestamp, UUID.LSB, UUID.MSB)
-	@ProtoField(1)
-	final long[] data;
-	private transient InfinispanDataRegion region;
-	private transient boolean complete;
+   // the format of data is repeated (timestamp, UUID.LSB, UUID.MSB)
+   @ProtoField(1)
+   final long[] data;
+   private transient InfinispanDataRegion region;
+   private transient boolean complete;
 
-	public Tombstone(UUID uuid, long timestamp) {
-		this.data = new long[] { timestamp, uuid.getLeastSignificantBits(), uuid.getMostSignificantBits() };
-	}
+   public Tombstone(UUID uuid, long timestamp) {
+      this.data = new long[]{timestamp, uuid.getLeastSignificantBits(), uuid.getMostSignificantBits()};
+   }
 
-	@ProtoFactory
-	Tombstone(long[] data) {
-		this.data = data;
-	}
+   @ProtoFactory
+   Tombstone(long[] data) {
+      this.data = data;
+   }
 
-	public long getLastTimestamp() {
-		long max = data[0];
-		for (int i = 3; i < data.length; i += 3) {
-			max = Math.max(max, data[i]);
-		}
-		return max;
-	}
+   public long getLastTimestamp() {
+      long max = data[0];
+      for (int i = 3; i < data.length; i += 3) {
+         max = Math.max(max, data[i]);
+      }
+      return max;
+   }
 
-	@Override
-	public String toString() {
-		final StringBuilder sb = new StringBuilder("Tombstone{");
-		for (int i = 0; i < data.length; i += 3) {
-			if (i != 0) {
-				sb.append(", ");
-			}
-			sb.append(new UUID(data[i + 2], data[i + 1])).append('=').append(data[i]);
-		}
-		sb.append('}');
-		return sb.toString();
-	}
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder("Tombstone{");
+      for (int i = 0; i < data.length; i += 3) {
+         if (i != 0) {
+            sb.append(", ");
+         }
+         sb.append(new UUID(data[i + 2], data[i + 1])).append('=').append(data[i]);
+      }
+      sb.append('}');
+      return sb.toString();
+   }
 
-	public Tombstone merge(Tombstone update) {
-		assert update != null;
-		assert update.data.length == 3;
-		int toRemove = 0;
-		for (int i = 0; i < data.length; i += 3) {
-			if (data[i] < update.data[0]) {
-				toRemove += 3;
-			}
-			else if (update.data[1] == data[i + 1] && update.data[2] == data[i + 2]) {
-				// UUID matches - second update during retry?
-				toRemove += 3;
-			}
-		}
-		if (data.length == toRemove) {
-			// applying the update second time?
-			return update;
-		}
-		else {
-			long[] newData = new long[data.length - toRemove + 3]; // 3 for the update
-			int j = 0;
-			boolean uuidMatch = false;
-			for (int i = 0; i < data.length; i += 3) {
-				if (data[i] < update.data[0]) {
-					// This is an old eviction
-					continue;
-				}
-				else if (update.data[1] == data[i + 1] && update.data[2] == data[i + 2]) {
-					// UUID matches
-					System.arraycopy(update.data, 0, newData, j, 3);
-					uuidMatch = true;
-					j += 3;
-				}
-				else {
-					System.arraycopy(data, i, newData, j, 3);
-					j += 3;
-				}
-			}
-			assert (uuidMatch && j == newData.length) || (!uuidMatch && j == newData.length - 3);
-			if (!uuidMatch) {
-				System.arraycopy(update.data, 0, newData, j, 3);
-			}
-			return new Tombstone(newData);
-		}
-	}
+   public Tombstone merge(Tombstone update) {
+      assert update != null;
+      assert update.data.length == 3;
+      int toRemove = 0;
+      for (int i = 0; i < data.length; i += 3) {
+         if (data[i] < update.data[0]) {
+            toRemove += 3;
+         } else if (update.data[1] == data[i + 1] && update.data[2] == data[i + 2]) {
+            // UUID matches - second update during retry?
+            toRemove += 3;
+         }
+      }
+      if (data.length == toRemove) {
+         // applying the update second time?
+         return update;
+      } else {
+         long[] newData = new long[data.length - toRemove + 3]; // 3 for the update
+         int j = 0;
+         boolean uuidMatch = false;
+         for (int i = 0; i < data.length; i += 3) {
+            if (data[i] < update.data[0]) {
+               // This is an old eviction
+               continue;
+            } else if (update.data[1] == data[i + 1] && update.data[2] == data[i + 2]) {
+               // UUID matches
+               System.arraycopy(update.data, 0, newData, j, 3);
+               uuidMatch = true;
+               j += 3;
+            } else {
+               System.arraycopy(data, i, newData, j, 3);
+               j += 3;
+            }
+         }
+         assert (uuidMatch && j == newData.length) || (!uuidMatch && j == newData.length - 3);
+         if (!uuidMatch) {
+            System.arraycopy(update.data, 0, newData, j, 3);
+         }
+         return new Tombstone(newData);
+      }
+   }
 
-	public Object applyUpdate(UUID uuid, long timestamp, Object value) {
-		int toRemove = 0;
-		for (int i = 0; i < data.length; i += 3) {
-			if (data[i] < timestamp) {
-				toRemove += 3;
-			}
-			else if (uuid.getLeastSignificantBits() == data[i + 1] && uuid.getMostSignificantBits() == data[i + 2]) {
-				toRemove += 3;
-			}
-		}
-		if (data.length == toRemove) {
-			if (value == null) {
-				return new Tombstone(uuid, timestamp);
-			}
-			else {
-				return value;
-			}
-		}
-		else {
-			long[] newData = new long[data.length - toRemove + 3]; // 3 for the update
-			int j = 0;
-			boolean uuidMatch = false;
-			for (int i = 0; i < data.length; i += 3) {
-				if (data[i] < timestamp) {
-					// This is an old eviction
-					continue;
-				}
-				else if (uuid.getLeastSignificantBits() == data[i + 1] && uuid.getMostSignificantBits() == data[i + 2]) {
-					newData[j] = timestamp;
-					newData[j + 1] = uuid.getLeastSignificantBits();
-					newData[j + 2] = uuid.getMostSignificantBits();
-					uuidMatch = true;
-					j += 3;
-				}
-				else {
-					System.arraycopy(data, i, newData, j, 3);
-					j += 3;
-				}
-			}
-			assert (uuidMatch && j == newData.length) || (!uuidMatch && j == newData.length - 3);
-			if (!uuidMatch) {
-				newData[j] = timestamp;
-				newData[j + 1] = uuid.getLeastSignificantBits();
-				newData[j + 2] = uuid.getMostSignificantBits();
-			}
-			return new Tombstone(newData);
-		}
-	}
+   public Object applyUpdate(UUID uuid, long timestamp, Object value) {
+      int toRemove = 0;
+      for (int i = 0; i < data.length; i += 3) {
+         if (data[i] < timestamp) {
+            toRemove += 3;
+         } else if (uuid.getLeastSignificantBits() == data[i + 1] && uuid.getMostSignificantBits() == data[i + 2]) {
+            toRemove += 3;
+         }
+      }
+      if (data.length == toRemove) {
+         if (value == null) {
+            return new Tombstone(uuid, timestamp);
+         } else {
+            return value;
+         }
+      } else {
+         long[] newData = new long[data.length - toRemove + 3]; // 3 for the update
+         int j = 0;
+         boolean uuidMatch = false;
+         for (int i = 0; i < data.length; i += 3) {
+            if (data[i] < timestamp) {
+               // This is an old eviction
+               continue;
+            } else if (uuid.getLeastSignificantBits() == data[i + 1] && uuid.getMostSignificantBits() == data[i + 2]) {
+               newData[j] = timestamp;
+               newData[j + 1] = uuid.getLeastSignificantBits();
+               newData[j + 2] = uuid.getMostSignificantBits();
+               uuidMatch = true;
+               j += 3;
+            } else {
+               System.arraycopy(data, i, newData, j, 3);
+               j += 3;
+            }
+         }
+         assert (uuidMatch && j == newData.length) || (!uuidMatch && j == newData.length - 3);
+         if (!uuidMatch) {
+            newData[j] = timestamp;
+            newData[j + 1] = uuid.getLeastSignificantBits();
+            newData[j + 2] = uuid.getMostSignificantBits();
+         }
+         return new Tombstone(newData);
+      }
+   }
 
-	// Used only for testing purposes
-	public int size() {
-		return data.length / 3;
-	}
+   // Used only for testing purposes
+   public int size() {
+      return data.length / 3;
+   }
 
-	@Override
-	public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
-		Object storedValue = view.find().orElse(null);
-		MetaParam.MetaLifespan expiringMetaParam = region.getExpiringMetaParam();
-		if (storedValue instanceof Tombstone) {
-			view.set(((Tombstone) storedValue).merge(this), expiringMetaParam);
-		} else {
-			view.set(this, expiringMetaParam);
-		}
-		return null;
-	}
+   @Override
+   public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
+      Object storedValue = view.find().orElse(null);
+      MetaParam.MetaLifespan expiringMetaParam = region.getExpiringMetaParam();
+      if (storedValue instanceof Tombstone) {
+         view.set(((Tombstone) storedValue).merge(this), expiringMetaParam);
+      } else {
+         view.set(this, expiringMetaParam);
+      }
+      return null;
+   }
 
-	@Override
-	public void inject(ComponentRegistry registry) {
-		region = registry.getComponent(InfinispanDataRegion.class);
-	}
+   @Override
+   public void inject(ComponentRegistry registry) {
+      region = registry.getComponent(InfinispanDataRegion.class);
+   }
 
-	@Override
-	public boolean isComplete() {
-		return complete;
-	}
+   @Override
+   public boolean isComplete() {
+      return complete;
+   }
 
-	@Override
-	public void markComplete() {
-		complete = true;
-	}
+   @Override
+   public void markComplete() {
+      complete = true;
+   }
 
-	@ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_TOMBSTONE_EXCLUDE_EMPTY_VERSIONED_ENTRY)
-	public static class ExcludeTombstonesFilter implements Predicate<Map.Entry<Object, Object>> {
+   @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_TOMBSTONE_EXCLUDE_EMPTY_VERSIONED_ENTRY)
+   public static class ExcludeTombstonesFilter implements Predicate<Map.Entry<Object, Object>> {
 
-		@ProtoFactory
-		ExcludeTombstonesFilter() {}
+      @ProtoFactory
+      ExcludeTombstonesFilter() {
+      }
 
-		@Override
-		public boolean test(Map.Entry<Object, Object> entry) {
-			return !(entry.getValue() instanceof Tombstone);
-		}
-	}
+      @Override
+      public boolean test(Map.Entry<Object, Object> entry) {
+         return !(entry.getValue() instanceof Tombstone);
+      }
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/TombstoneUpdate.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/TombstoneUpdate.java
@@ -17,83 +17,83 @@ import org.infinispan.protostream.annotations.ProtoTypeId;
 /**
  * Request to update cache either as a result of putFromLoad (if {@link #getValue()} is non-null
  * or evict (if it is null).
- *
+ * <p>
  * This object should *not* be stored in cache.
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_TOMBSTONE_UPDATE)
 public class TombstoneUpdate<T> implements Function<EntryView.ReadWriteEntryView<Object, Object>, Void>, InjectableComponent {
-	private static final UUID ZERO = new UUID(0, 0);
+   private static final UUID ZERO = new UUID(0, 0);
 
-	private final long timestamp;
-	private final T value;
-	private transient InfinispanDataRegion region;
+   private final long timestamp;
+   private final T value;
+   private transient InfinispanDataRegion region;
 
-	public TombstoneUpdate(long timestamp, T value) {
-		this.timestamp = timestamp;
-		this.value = value;
-	}
+   public TombstoneUpdate(long timestamp, T value) {
+      this.timestamp = timestamp;
+      this.value = value;
+   }
 
-	@ProtoFactory
-	TombstoneUpdate(long timestamp, MarshallableObject<T> wrappedValue) {
-		this(timestamp, MarshallableObject.unwrap(wrappedValue));
-	}
+   @ProtoFactory
+   TombstoneUpdate(long timestamp, MarshallableObject<T> wrappedValue) {
+      this(timestamp, MarshallableObject.unwrap(wrappedValue));
+   }
 
-	@ProtoField(1)
-	public long getTimestamp() {
-		return timestamp;
-	}
+   @ProtoField(1)
+   public long getTimestamp() {
+      return timestamp;
+   }
 
-	public T getValue() {
-		return value;
-	}
+   public T getValue() {
+      return value;
+   }
 
-	@ProtoField(number = 2, name = "value")
-	MarshallableObject<T> getWrappedValue() {
-		return MarshallableObject.create(value);
-	}
+   @ProtoField(number = 2, name = "value")
+   MarshallableObject<T> getWrappedValue() {
+      return MarshallableObject.create(value);
+   }
 
-	@Override
-	public String toString() {
-		final StringBuilder sb = new StringBuilder("TombstoneUpdate{");
-		sb.append("timestamp=").append(timestamp);
-		sb.append(", value=").append(value);
-		sb.append('}');
-		return sb.toString();
-	}
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder("TombstoneUpdate{");
+      sb.append("timestamp=").append(timestamp);
+      sb.append(", value=").append(value);
+      sb.append('}');
+      return sb.toString();
+   }
 
-	@Override
-	public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
-		Object storedValue = view.find().orElse(null);
+   @Override
+   public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
+      Object storedValue = view.find().orElse(null);
 
-		if (value == null) {
-			if (storedValue != null && !(storedValue instanceof Tombstone)) {
-				// We have to keep Tombstone, because otherwise putFromLoad could insert a stale entry
-				// (after it has been already updated and *then* evicted)
-				view.set(new Tombstone(ZERO, timestamp), region.getExpiringMetaParam());
-			}
-			// otherwise it's eviction
-		} else if (storedValue instanceof Tombstone) {
-			Tombstone tombstone = (Tombstone) storedValue;
-			if (tombstone.getLastTimestamp() < timestamp) {
-				view.set(value);
-			}
-		} else if (storedValue == null) {
-			// async putFromLoads shouldn't cross the invalidation timestamp
-			if (region.getLastRegionInvalidation() < timestamp) {
-				view.set(value);
-			}
-		} else {
-			// Don't do anything locally. This could be the async remote write, though, when local
-			// value has been already updated: let it propagate to remote nodes, too
-			view.set(storedValue, view.findMetaParam(MetaParam.MetaLifespan.class).get());
-		}
-		return null;
-	}
+      if (value == null) {
+         if (storedValue != null && !(storedValue instanceof Tombstone)) {
+            // We have to keep Tombstone, because otherwise putFromLoad could insert a stale entry
+            // (after it has been already updated and *then* evicted)
+            view.set(new Tombstone(ZERO, timestamp), region.getExpiringMetaParam());
+         }
+         // otherwise it's eviction
+      } else if (storedValue instanceof Tombstone) {
+         Tombstone tombstone = (Tombstone) storedValue;
+         if (tombstone.getLastTimestamp() < timestamp) {
+            view.set(value);
+         }
+      } else if (storedValue == null) {
+         // async putFromLoads shouldn't cross the invalidation timestamp
+         if (region.getLastRegionInvalidation() < timestamp) {
+            view.set(value);
+         }
+      } else {
+         // Don't do anything locally. This could be the async remote write, though, when local
+         // value has been already updated: let it propagate to remote nodes, too
+         view.set(storedValue, view.findMetaParam(MetaParam.MetaLifespan.class).get());
+      }
+      return null;
+   }
 
-	@Override
-	public void inject(ComponentRegistry registry) {
-		region = registry.getComponent(InfinispanDataRegion.class);
-	}
+   @Override
+   public void inject(ComponentRegistry registry) {
+      region = registry.getComponent(InfinispanDataRegion.class);
+   }
 }

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/VersionedEntry.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/util/VersionedEntry.java
@@ -24,153 +24,153 @@ import org.infinispan.protostream.annotations.ProtoTypeId;
  */
 @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_VERSIONED_ENTRY)
 public class VersionedEntry implements Function<EntryView.ReadWriteEntryView<Object, Object>, Void>, InjectableComponent {
-	private static final Log log = LogFactory.getLog(VersionedEntry.class);
+   private static final Log log = LogFactory.getLog(VersionedEntry.class);
 
-	public static final ExcludeEmptyFilter EXCLUDE_EMPTY_VERSIONED_ENTRY = new ExcludeEmptyFilter();
-	private final Object value;
-	private final Object version;
-	private final long timestamp;
-	private transient InfinispanDataRegion region;
+   public static final ExcludeEmptyFilter EXCLUDE_EMPTY_VERSIONED_ENTRY = new ExcludeEmptyFilter();
+   private final Object value;
+   private final Object version;
+   private final long timestamp;
+   private transient InfinispanDataRegion region;
 
-	public VersionedEntry(long timestamp) {
-		this(null, null, timestamp);
-	}
+   public VersionedEntry(long timestamp) {
+      this(null, null, timestamp);
+   }
 
-	public VersionedEntry(Object value, Object version, long timestamp) {
-		this.value = value;
-		this.version = version;
-		this.timestamp = timestamp;
-	}
+   public VersionedEntry(Object value, Object version, long timestamp) {
+      this.value = value;
+      this.version = version;
+      this.timestamp = timestamp;
+   }
 
-	@ProtoFactory
-	VersionedEntry(MarshallableObject<?> wrappedValue, MarshallableObject<?> wrappedVersion, long timestamp) {
-		this(MarshallableObject.unwrap(wrappedValue), MarshallableObject.unwrap(wrappedVersion), timestamp);
-	}
+   @ProtoFactory
+   VersionedEntry(MarshallableObject<?> wrappedValue, MarshallableObject<?> wrappedVersion, long timestamp) {
+      this(MarshallableObject.unwrap(wrappedValue), MarshallableObject.unwrap(wrappedVersion), timestamp);
+   }
 
-	public Object getValue() {
-		return value;
-	}
+   public Object getValue() {
+      return value;
+   }
 
-	@ProtoField(number = 1, name = "value")
-	MarshallableObject<?> getWrappedValue() {
-		return MarshallableObject.create(value);
-	}
+   @ProtoField(number = 1, name = "value")
+   MarshallableObject<?> getWrappedValue() {
+      return MarshallableObject.create(value);
+   }
 
-	public Object getVersion() {
-		return version;
-	}
+   public Object getVersion() {
+      return version;
+   }
 
-	@ProtoField(number = 2, name = "version")
-	MarshallableObject<?> getWrappedVersion() {
-		return MarshallableObject.create(version);
-	}
+   @ProtoField(number = 2, name = "version")
+   MarshallableObject<?> getWrappedVersion() {
+      return MarshallableObject.create(version);
+   }
 
-	@ProtoField(3)
-	public long getTimestamp() {
-		return timestamp;
-	}
+   @ProtoField(3)
+   public long getTimestamp() {
+      return timestamp;
+   }
 
-	@Override
-	public String toString() {
-		final StringBuilder sb = new StringBuilder("VersionedEntry{");
-		sb.append("value=").append(value);
-		sb.append(", version=").append(version);
-		sb.append(", timestamp=").append(timestamp);
-		sb.append('}');
-		return sb.toString();
-	}
+   @Override
+   public String toString() {
+      final StringBuilder sb = new StringBuilder("VersionedEntry{");
+      sb.append("value=").append(value);
+      sb.append(", version=").append(version);
+      sb.append(", timestamp=").append(timestamp);
+      sb.append('}');
+      return sb.toString();
+   }
 
-	@Override
-	public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
-		if (log.isTraceEnabled()) {
-			log.tracef("Applying %s to %s", this, view.find().orElse(null));
-		}
-		if (version == null) {
-			// eviction or post-commit removal: we'll store it with given timestamp
-			view.set(this, region.getExpiringMetaParam());
-			return null;
-		}
+   @Override
+   public Void apply(EntryView.ReadWriteEntryView<Object, Object> view) {
+      if (log.isTraceEnabled()) {
+         log.tracef("Applying %s to %s", this, view.find().orElse(null));
+      }
+      if (version == null) {
+         // eviction or post-commit removal: we'll store it with given timestamp
+         view.set(this, region.getExpiringMetaParam());
+         return null;
+      }
 
-		Object oldValue = view.find().orElse(null);
-		Object oldVersion = null;
-		long oldTimestamp = Long.MIN_VALUE;
-		if (oldValue instanceof VersionedEntry) {
-			VersionedEntry oldVersionedEntry = (VersionedEntry) oldValue;
-			oldVersion = oldVersionedEntry.version;
-			oldTimestamp = oldVersionedEntry.timestamp;
-			oldValue = oldVersionedEntry.value;
-		} else {
-			oldVersion = findVersion(oldValue);
-		}
+      Object oldValue = view.find().orElse(null);
+      Object oldVersion = null;
+      long oldTimestamp = Long.MIN_VALUE;
+      if (oldValue instanceof VersionedEntry) {
+         VersionedEntry oldVersionedEntry = (VersionedEntry) oldValue;
+         oldVersion = oldVersionedEntry.version;
+         oldTimestamp = oldVersionedEntry.timestamp;
+         oldValue = oldVersionedEntry.value;
+      } else {
+         oldVersion = findVersion(oldValue);
+      }
 
-		if (oldVersion == null) {
-			assert oldValue == null || oldTimestamp != Long.MIN_VALUE : oldValue;
-			if (timestamp <= oldTimestamp) {
-				// either putFromLoad or regular update/insert - in either case this update might come
-				// when it was evicted/region-invalidated. In both cases, with old timestamp we'll leave
-				// the invalid value
-				assert oldValue == null;
-			} else {
-				view.set(value instanceof CacheEntry ? value : this);
-			}
-			return null;
-		} else {
-			Comparator<Object> versionComparator = null;
-			String subclass = findSubclass(value);
-			if (subclass != null) {
-				versionComparator = region.getComparator(subclass);
-				if (versionComparator == null) {
-					log.errorf("Cannot find comparator for %s", subclass);
-				}
-			}
-			if (versionComparator == null) {
-				view.set(new VersionedEntry(null, null, timestamp), region.getExpiringMetaParam());
-			} else {
-				int compareResult = versionComparator.compare(version, oldVersion);
-				if (log.isTraceEnabled()) {
-					log.tracef("Comparing %s and %s -> %d (using %s)", version, oldVersion, compareResult, versionComparator);
-				}
-				if (value == null && compareResult >= 0) {
-					view.set(this, region.getExpiringMetaParam());
-				} else if (compareResult > 0) {
-					view.set(value instanceof CacheEntry ? value : this);
-				}
-			}
-		}
-		return null;
-	}
+      if (oldVersion == null) {
+         assert oldValue == null || oldTimestamp != Long.MIN_VALUE : oldValue;
+         if (timestamp <= oldTimestamp) {
+            // either putFromLoad or regular update/insert - in either case this update might come
+            // when it was evicted/region-invalidated. In both cases, with old timestamp we'll leave
+            // the invalid value
+            assert oldValue == null;
+         } else {
+            view.set(value instanceof CacheEntry ? value : this);
+         }
+         return null;
+      } else {
+         Comparator<Object> versionComparator = null;
+         String subclass = findSubclass(value);
+         if (subclass != null) {
+            versionComparator = region.getComparator(subclass);
+            if (versionComparator == null) {
+               log.errorf("Cannot find comparator for %s", subclass);
+            }
+         }
+         if (versionComparator == null) {
+            view.set(new VersionedEntry(null, null, timestamp), region.getExpiringMetaParam());
+         } else {
+            int compareResult = versionComparator.compare(version, oldVersion);
+            if (log.isTraceEnabled()) {
+               log.tracef("Comparing %s and %s -> %d (using %s)", version, oldVersion, compareResult, versionComparator);
+            }
+            if (value == null && compareResult >= 0) {
+               view.set(this, region.getExpiringMetaParam());
+            } else if (compareResult > 0) {
+               view.set(value instanceof CacheEntry ? value : this);
+            }
+         }
+      }
+      return null;
+   }
 
-	private Object findVersion(Object entry) {
-		if (entry instanceof CacheEntry) {
-			// with UnstructuredCacheEntry
-			return ((CacheEntry) entry).getVersion();
-		} else if (entry instanceof Map) {
-			return ((Map) entry).get(StructuredCacheEntry.VERSION_KEY);
-		} else {
-			return null;
-		}
-	}
+   private Object findVersion(Object entry) {
+      if (entry instanceof CacheEntry) {
+         // with UnstructuredCacheEntry
+         return ((CacheEntry) entry).getVersion();
+      } else if (entry instanceof Map) {
+         return ((Map) entry).get(StructuredCacheEntry.VERSION_KEY);
+      } else {
+         return null;
+      }
+   }
 
-	private String findSubclass(Object entry) {
-		// we won't find subclass for structured collections
-		if (entry instanceof CacheEntry) {
-			return ((CacheEntry) this.value).getSubclass();
-		} else if (entry instanceof Map) {
-			Object maybeSubclass = ((Map) entry).get(StructuredCacheEntry.SUBCLASS_KEY);
-			return maybeSubclass instanceof String ? (String) maybeSubclass : null;
-		} else {
-			return null;
-		}
-	}
+   private String findSubclass(Object entry) {
+      // we won't find subclass for structured collections
+      if (entry instanceof CacheEntry) {
+         return ((CacheEntry) this.value).getSubclass();
+      } else if (entry instanceof Map) {
+         Object maybeSubclass = ((Map) entry).get(StructuredCacheEntry.SUBCLASS_KEY);
+         return maybeSubclass instanceof String ? (String) maybeSubclass : null;
+      } else {
+         return null;
+      }
+   }
 
 
-	@Override
-	public void inject(ComponentRegistry registry) {
-		region = registry.getComponent(InfinispanDataRegion.class);
-	}
+   @Override
+   public void inject(ComponentRegistry registry) {
+      region = registry.getComponent(InfinispanDataRegion.class);
+   }
 
-	@ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_VERSIONED_ENTRY_EXCLUDE_EMPTY_FILTER)
-	public static class ExcludeEmptyFilter implements Predicate<Map.Entry<Object, Object>> {
+   @ProtoTypeId(ProtoStreamTypeIds.HIBERNATE_VERSIONED_ENTRY_EXCLUDE_EMPTY_FILTER)
+   public static class ExcludeEmptyFilter implements Predicate<Map.Entry<Object, Object>> {
       @Override
       public boolean test(Map.Entry<Object, Object> entry) {
          if (entry.getValue() instanceof VersionedEntry) {

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractEntityCollectionRegionTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractEntityCollectionRegionTest.java
@@ -16,26 +16,25 @@ import org.junit.Test;
  * @since 3.5
  */
 public abstract class AbstractEntityCollectionRegionTest extends AbstractRegionImplTest {
-	@Test
-	public void testSupportedAccessTypes() {
-		StandardServiceRegistryBuilder ssrb = createStandardServiceRegistryBuilder();
-		final StandardServiceRegistry registry = ssrb.build();
-		try {
-			TestRegionFactory regionFactory = CacheTestUtil.startRegionFactory(
-					registry,
-					getCacheTestSupport()
-			);
-			supportedAccessTypeTest( regionFactory, CacheTestUtil.toProperties( ssrb.getSettings() ) );
-		}
-		finally {
-			StandardServiceRegistryBuilder.destroy( registry );
-		}
-	}
+   @Test
+   public void testSupportedAccessTypes() {
+      StandardServiceRegistryBuilder ssrb = createStandardServiceRegistryBuilder();
+      final StandardServiceRegistry registry = ssrb.build();
+      try {
+         TestRegionFactory regionFactory = CacheTestUtil.startRegionFactory(
+               registry,
+               getCacheTestSupport()
+         );
+         supportedAccessTypeTest(regionFactory, CacheTestUtil.toProperties(ssrb.getSettings()));
+      } finally {
+         StandardServiceRegistryBuilder.destroy(registry);
+      }
+   }
 
-	/**
-	 * Creates a Region using the given factory, and then ensure that it handles calls to
-	 * buildAccessStrategy as expected when all the various {@link AccessType}s are passed as
-	 * arguments.
-	 */
-	protected abstract void supportedAccessTypeTest(TestRegionFactory regionFactory, Properties properties);
+   /**
+    * Creates a Region using the given factory, and then ensure that it handles calls to
+    * buildAccessStrategy as expected when all the various {@link AccessType}s are passed as
+    * arguments.
+    */
+   protected abstract void supportedAccessTypeTest(TestRegionFactory regionFactory, Properties properties);
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractExtraAPITest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractExtraAPITest.java
@@ -1,68 +1,67 @@
 package org.infinispan.test.hibernate.cache.commons;
 
-import org.hibernate.cache.spi.access.SoftLock;
+import static org.junit.Assert.assertNull;
 
+import org.hibernate.cache.spi.access.SoftLock;
+import org.hibernate.testing.AfterClassOnce;
+import org.hibernate.testing.BeforeClassOnce;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess.TestRegionAccessStrategy;
 import org.infinispan.test.hibernate.cache.commons.util.TestingKeyFactory;
-import org.hibernate.testing.AfterClassOnce;
-import org.hibernate.testing.BeforeClassOnce;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNull;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class AbstractExtraAPITest<S> extends AbstractNonFunctionalTest {
 
-	public static final String REGION_NAME = "test/com.foo.test";
-	public static final Object KEY = TestingKeyFactory.generateCollectionCacheKey( "KEY" );
+   public static final String REGION_NAME = "test/com.foo.test";
+   public static final Object KEY = TestingKeyFactory.generateCollectionCacheKey("KEY");
    protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
    protected static final Object SESSION = TEST_SESSION_ACCESS.mockSessionImplementor();
 
-	protected S accessStrategy;
+   protected S accessStrategy;
    protected TestRegionAccessStrategy testAccessStrategy;
-	protected NodeEnvironment environment;
+   protected NodeEnvironment environment;
 
-	@BeforeClassOnce
-	public final void prepareLocalAccessStrategy() throws Exception {
-		environment = new NodeEnvironment( createStandardServiceRegistryBuilder() );
-		environment.prepare();
+   @BeforeClassOnce
+   public final void prepareLocalAccessStrategy() throws Exception {
+      environment = new NodeEnvironment(createStandardServiceRegistryBuilder());
+      environment.prepare();
 
-		accessStrategy = getAccessStrategy();
+      accessStrategy = getAccessStrategy();
       testAccessStrategy = TEST_SESSION_ACCESS.fromAccess(accessStrategy);
-	}
+   }
 
-	protected abstract S getAccessStrategy();
+   protected abstract S getAccessStrategy();
 
-	@AfterClassOnce
-	public final void releaseLocalAccessStrategy() throws Exception {
-		if ( environment != null ) {
-			environment.release();
-		}
-	}
+   @AfterClassOnce
+   public final void releaseLocalAccessStrategy() throws Exception {
+      if (environment != null) {
+         environment.release();
+      }
+   }
 
-	@Test
-	public void testLockItem() {
-		assertNull( testAccessStrategy.lockItem(SESSION, KEY, Integer.valueOf( 1 ) ) );
-	}
+   @Test
+   public void testLockItem() {
+      assertNull(testAccessStrategy.lockItem(SESSION, KEY, Integer.valueOf(1)));
+   }
 
-	@Test
-	public void testLockRegion() {
-		assertNull( testAccessStrategy.lockRegion() );
-	}
+   @Test
+   public void testLockRegion() {
+      assertNull(testAccessStrategy.lockRegion());
+   }
 
-	@Test
-	public void testUnlockItem() {
-      testAccessStrategy.unlockItem(SESSION, KEY, new MockSoftLock() );
-	}
+   @Test
+   public void testUnlockItem() {
+      testAccessStrategy.unlockItem(SESSION, KEY, new MockSoftLock());
+   }
 
-	@Test
-	public void testUnlockRegion() {
-      testAccessStrategy.unlockItem(SESSION, KEY, new MockSoftLock() );
-	}
+   @Test
+   public void testUnlockRegion() {
+      testAccessStrategy.unlockItem(SESSION, KEY, new MockSoftLock());
+   }
 
-	public static class MockSoftLock implements SoftLock {
-	}
+   public static class MockSoftLock implements SoftLock {
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractGeneralDataRegionTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractGeneralDataRegionTest.java
@@ -38,57 +38,57 @@ import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess.TestRe
  * @since 3.5
  */
 public abstract class AbstractGeneralDataRegionTest extends AbstractRegionImplTest {
-	protected static final String KEY = "Key";
+   protected static final String KEY = "Key";
 
-	protected static final String VALUE1 = "value1";
-	protected static final String VALUE2 = "value2";
-	protected static final String VALUE3 = "value3";
+   protected static final String VALUE1 = "value1";
+   protected static final String VALUE2 = "value2";
+   protected static final String VALUE3 = "value3";
 
    protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
 
-	@Override
-	public List<Object[]> getParameters() {
-		// the actual cache mode and access type is irrelevant for the general data regions
-		return Arrays.asList(
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.TRANSACTIONAL},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE}
-		);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      // the actual cache mode and access type is irrelevant for the general data regions
+      return Arrays.asList(
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.TRANSACTIONAL},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE}
+      );
+   }
 
-	protected interface SFRConsumer {
-		void accept(List<SessionFactory> sessionFactories, List<InfinispanBaseRegion> regions) throws Exception;
-	}
+   protected interface SFRConsumer {
+      void accept(List<SessionFactory> sessionFactories, List<InfinispanBaseRegion> regions) throws Exception;
+   }
 
-	protected void withSessionFactoriesAndRegions(int num, SFRConsumer consumer) throws Exception {
-		StandardServiceRegistryBuilder ssrb = createStandardServiceRegistryBuilder()
-				.applySetting(AvailableSettings.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName());
-		Properties properties = CacheTestUtil.toProperties( ssrb.getSettings() );
-		List<StandardServiceRegistry> registries = new ArrayList<>();
-		List<SessionFactory> sessionFactories = new ArrayList<>();
-		List<InfinispanBaseRegion> regions = new ArrayList<>();
-		for (int i = 0; i < num; ++i) {
-			StandardServiceRegistry registry = ssrb.build();
-			registries.add(registry);
+   protected void withSessionFactoriesAndRegions(int num, SFRConsumer consumer) throws Exception {
+      StandardServiceRegistryBuilder ssrb = createStandardServiceRegistryBuilder()
+            .applySetting(AvailableSettings.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName());
+      Properties properties = CacheTestUtil.toProperties(ssrb.getSettings());
+      List<StandardServiceRegistry> registries = new ArrayList<>();
+      List<SessionFactory> sessionFactories = new ArrayList<>();
+      List<InfinispanBaseRegion> regions = new ArrayList<>();
+      for (int i = 0; i < num; ++i) {
+         StandardServiceRegistry registry = ssrb.build();
+         registries.add(registry);
 
-			SessionFactory sessionFactory = new MetadataSources(registry).buildMetadata().buildSessionFactory();
-			sessionFactories.add(sessionFactory);
+         SessionFactory sessionFactory = new MetadataSources(registry).buildMetadata().buildSessionFactory();
+         sessionFactories.add(sessionFactory);
 
-			TestRegionFactory regionFactory = TestRegionFactoryProvider.load().wrap(registry.getService(RegionFactory.class));
-			InfinispanBaseRegion region = createRegion(regionFactory, REGION_PREFIX + "/who-cares");
-			regions.add(region);
-		}
+         TestRegionFactory regionFactory = TestRegionFactoryProvider.load().wrap(registry.getService(RegionFactory.class));
+         InfinispanBaseRegion region = createRegion(regionFactory, REGION_PREFIX + "/who-cares");
+         regions.add(region);
+      }
       waitForClusterToForm(regions);
-		try {
-			consumer.accept(sessionFactories, regions);
-		} finally {
-			for (SessionFactory sessionFactory : sessionFactories) {
-				sessionFactory.close();
-			}
-			for (StandardServiceRegistry registry : registries) {
-				StandardServiceRegistryBuilder.destroy( registry );
-			}
-		}
-	}
+      try {
+         consumer.accept(sessionFactories, regions);
+      } finally {
+         for (SessionFactory sessionFactory : sessionFactories) {
+            sessionFactory.close();
+         }
+         for (StandardServiceRegistry registry : registries) {
+            StandardServiceRegistryBuilder.destroy(registry);
+         }
+      }
+   }
 
    private void waitForClusterToForm(List<InfinispanBaseRegion> regions) {
       List<AdvancedCache> caches = regions.stream()
@@ -100,59 +100,59 @@ public abstract class AbstractGeneralDataRegionTest extends AbstractRegionImplTe
    }
 
 
-	/**
-	 * Test method for {@link QueryResultsRegion#evictAll()}.
-	 	 * FIXME add testing of the "immediately without regard for transaction isolation" bit in the
-	 * CollectionRegionAccessStrategy API.
-	 */
-	public void testEvictAll() throws Exception {
-		withSessionFactoriesAndRegions(2, (sessionFactories, regions) -> {
-			InfinispanBaseRegion localRegion = regions.get(0);
+   /**
+    * Test method for {@link QueryResultsRegion#evictAll()}.
+    * FIXME add testing of the "immediately without regard for transaction isolation" bit in the
+    * CollectionRegionAccessStrategy API.
+    */
+   public void testEvictAll() throws Exception {
+      withSessionFactoriesAndRegions(2, (sessionFactories, regions) -> {
+         InfinispanBaseRegion localRegion = regions.get(0);
          TestRegion testLocalRegion = TEST_SESSION_ACCESS.fromRegion(localRegion);
-			InfinispanBaseRegion remoteRegion = regions.get(1);
+         InfinispanBaseRegion remoteRegion = regions.get(1);
          TestRegion testRemoteRegion = TEST_SESSION_ACCESS.fromRegion(remoteRegion);
-			AdvancedCache localCache = localRegion.getCache();
-			AdvancedCache remoteCache = remoteRegion.getCache();
-			Object localSession = sessionFactories.get(0).openSession();
+         AdvancedCache localCache = localRegion.getCache();
+         AdvancedCache remoteCache = remoteRegion.getCache();
+         Object localSession = sessionFactories.get(0).openSession();
          Object remoteSession = sessionFactories.get(1).openSession();
 
-			try {
-				Set localKeys = localCache.keySet();
-				assertEquals( "No valid children in " + localKeys, 0, localKeys.size() );
+         try {
+            Set localKeys = localCache.keySet();
+            assertEquals("No valid children in " + localKeys, 0, localKeys.size());
 
-				Set remoteKeys = remoteCache.keySet();
-				assertEquals( "No valid children in " + remoteKeys, 0, remoteKeys.size() );
+            Set remoteKeys = remoteCache.keySet();
+            assertEquals("No valid children in " + remoteKeys, 0, remoteKeys.size());
 
-				assertNull( "local is clean", testLocalRegion.get(null, KEY ) );
-				assertNull( "remote is clean", testRemoteRegion.get(null, KEY ) );
+            assertNull("local is clean", testLocalRegion.get(null, KEY));
+            assertNull("remote is clean", testRemoteRegion.get(null, KEY));
 
-				testLocalRegion.put(localSession, KEY, VALUE1);
-				assertEquals( VALUE1, testLocalRegion.get(null, KEY ) );
+            testLocalRegion.put(localSession, KEY, VALUE1);
+            assertEquals(VALUE1, testLocalRegion.get(null, KEY));
 
-				testRemoteRegion.put(remoteSession, KEY, VALUE1);
-				assertEquals( VALUE1, testRemoteRegion.get(null, KEY ) );
+            testRemoteRegion.put(remoteSession, KEY, VALUE1);
+            assertEquals(VALUE1, testRemoteRegion.get(null, KEY));
 
-				testLocalRegion.evictAll();
+            testLocalRegion.evictAll();
 
-				// This should re-establish the region root node in the optimistic case
-				assertNull( testLocalRegion.get(null, KEY ) );
-				localKeys = localCache.keySet();
-				assertEquals( "No valid children in " + localKeys, 0, localKeys.size() );
+            // This should re-establish the region root node in the optimistic case
+            assertNull(testLocalRegion.get(null, KEY));
+            localKeys = localCache.keySet();
+            assertEquals("No valid children in " + localKeys, 0, localKeys.size());
 
-				// Re-establishing the region root on the local node doesn't
-				// propagate it to other nodes. Do a get on the remote node to re-establish
-				// This only adds a node in the case of optimistic locking
-				assertEquals( null, testRemoteRegion.get(null, KEY ) );
-				remoteKeys = remoteCache.keySet();
-				assertEquals( "No valid children in " + remoteKeys, 0, remoteKeys.size() );
+            // Re-establishing the region root on the local node doesn't
+            // propagate it to other nodes. Do a get on the remote node to re-establish
+            // This only adds a node in the case of optimistic locking
+            assertEquals(null, testRemoteRegion.get(null, KEY));
+            remoteKeys = remoteCache.keySet();
+            assertEquals("No valid children in " + remoteKeys, 0, remoteKeys.size());
 
-				assertEquals( "local is clean", null, testLocalRegion.get(null, KEY ) );
-				assertEquals( "remote is clean", null, testRemoteRegion.get(null, KEY ) );
-			} finally {
-				( (Session) localSession ).close();
-				( (Session) remoteSession ).close();
-			}
+            assertEquals("local is clean", null, testLocalRegion.get(null, KEY));
+            assertEquals("remote is clean", null, testRemoteRegion.get(null, KEY));
+         } finally {
+            ((Session) localSession).close();
+            ((Session) remoteSession).close();
+         }
 
-		});
-	}
+      });
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractNonFunctionalTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractNonFunctionalTest.java
@@ -37,137 +37,137 @@ import jakarta.transaction.TransactionManager;
  */
 @RunWith(CustomParameterized.class)
 public abstract class AbstractNonFunctionalTest extends org.hibernate.testing.junit4.BaseUnitTestCase {
-	@ClassRule
-	public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
+   @ClassRule
+   public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
 
    protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
 
-	@Parameterized.Parameter(0)
-	public String mode;
+   @Parameterized.Parameter(0)
+   public String mode;
 
-	@Parameterized.Parameter(1)
-	public Class<? extends JtaPlatform> jtaPlatform;
+   @Parameterized.Parameter(1)
+   public Class<? extends JtaPlatform> jtaPlatform;
 
-	@Parameterized.Parameter(2)
-	public CacheMode cacheMode;
+   @Parameterized.Parameter(2)
+   public CacheMode cacheMode;
 
-	@Parameterized.Parameter(3)
-	public AccessType accessType;
+   @Parameterized.Parameter(3)
+   public AccessType accessType;
 
-	public static final String REGION_PREFIX = "test";
+   public static final String REGION_PREFIX = "test";
 
-	private static final String PREFER_IPV4STACK = "java.net.preferIPv4Stack";
-	private String preferIPv4Stack;
-	private static final String JGROUPS_CFG_FILE = "hibernate.cache.infinispan.jgroups_cfg";
-	private String jgroupsCfgFile;
+   private static final String PREFER_IPV4STACK = "java.net.preferIPv4Stack";
+   private String preferIPv4Stack;
+   private static final String JGROUPS_CFG_FILE = "hibernate.cache.infinispan.jgroups_cfg";
+   private String jgroupsCfgFile;
 
-	private final CacheTestSupport testSupport = new CacheTestSupport();
+   private final CacheTestSupport testSupport = new CacheTestSupport();
 
-	@Parameterized.Parameters(name = "{0}, {2}, {3}")
-	public List<Object[]> getParameters() {
-		List<Object[]> parameters = new ArrayList<>(Arrays.asList(
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.TRANSACTIONAL},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_ONLY},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_WRITE},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_ONLY},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.NONSTRICT_READ_WRITE},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_WRITE},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_ONLY},
-				new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_ONLY},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_WRITE},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_ONLY},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.NONSTRICT_READ_WRITE},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_WRITE},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_ONLY},
-				new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE}
-		));
-		if (canUseLocalMode()) {
-			parameters.addAll(Arrays.asList(
-					new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.TRANSACTIONAL},
-					new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_WRITE},
-					new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_ONLY},
-					new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.NONSTRICT_READ_WRITE},
-					new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_WRITE},
-					new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_ONLY},
-					new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.LOCAL, AccessType.NONSTRICT_READ_WRITE}
-			));
-		}
-		return parameters;
-	}
+   @Parameterized.Parameters(name = "{0}, {2}, {3}")
+   public List<Object[]> getParameters() {
+      List<Object[]> parameters = new ArrayList<>(Arrays.asList(
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.TRANSACTIONAL},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_ONLY},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_WRITE},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_ONLY},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.NONSTRICT_READ_WRITE},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_WRITE},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_ONLY},
+            new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.INVALIDATION_SYNC, AccessType.READ_ONLY},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_WRITE},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.READ_ONLY},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.DIST_SYNC, AccessType.NONSTRICT_READ_WRITE},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_WRITE},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.READ_ONLY},
+            new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE}
+      ));
+      if (canUseLocalMode()) {
+         parameters.addAll(Arrays.asList(
+               new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.TRANSACTIONAL},
+               new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_WRITE},
+               new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_ONLY},
+               new Object[]{"JTA", BatchModeJtaPlatform.class, CacheMode.LOCAL, AccessType.NONSTRICT_READ_WRITE},
+               new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_WRITE},
+               new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.LOCAL, AccessType.READ_ONLY},
+               new Object[]{"non-JTA", NoJtaPlatform.class, CacheMode.LOCAL, AccessType.NONSTRICT_READ_WRITE}
+         ));
+      }
+      return parameters;
+   }
 
-	@Before
-	public void prepareCacheSupport() throws Exception {
-		infinispanTestIdentifier.joinContext();
-		preferIPv4Stack = System.getProperty(PREFER_IPV4STACK);
-		System.setProperty(PREFER_IPV4STACK, "true");
-		jgroupsCfgFile = System.getProperty(JGROUPS_CFG_FILE);
-		System.setProperty(JGROUPS_CFG_FILE, "2lc-test-tcp.xml");
+   @Before
+   public void prepareCacheSupport() throws Exception {
+      infinispanTestIdentifier.joinContext();
+      preferIPv4Stack = System.getProperty(PREFER_IPV4STACK);
+      System.setProperty(PREFER_IPV4STACK, "true");
+      jgroupsCfgFile = System.getProperty(JGROUPS_CFG_FILE);
+      System.setProperty(JGROUPS_CFG_FILE, "2lc-test-tcp.xml");
 
-		testSupport.setUp();
-	}
+      testSupport.setUp();
+   }
 
-	@After
-	public void releaseCachSupport() throws Exception {
-		testSupport.tearDown();
+   @After
+   public void releaseCachSupport() throws Exception {
+      testSupport.tearDown();
 
-		if (preferIPv4Stack == null) {
-			System.clearProperty(PREFER_IPV4STACK);
-		} else {
-			System.setProperty(PREFER_IPV4STACK, preferIPv4Stack);
-		}
+      if (preferIPv4Stack == null) {
+         System.clearProperty(PREFER_IPV4STACK);
+      } else {
+         System.setProperty(PREFER_IPV4STACK, preferIPv4Stack);
+      }
 
-		if (jgroupsCfgFile == null)
-			System.clearProperty(JGROUPS_CFG_FILE);
-		else
-			System.setProperty(JGROUPS_CFG_FILE, jgroupsCfgFile);
-	}
+      if (jgroupsCfgFile == null)
+         System.clearProperty(JGROUPS_CFG_FILE);
+      else
+         System.setProperty(JGROUPS_CFG_FILE, jgroupsCfgFile);
+   }
 
-	protected boolean canUseLocalMode() {
-		return true;
-	}
+   protected boolean canUseLocalMode() {
+      return true;
+   }
 
-	protected <T> T withTx(NodeEnvironment environment, Object session, Callable<T> callable) throws Exception {
-		TransactionManager tm = environment.getServiceRegistry().getService(JtaPlatform.class).retrieveTransactionManager();
-		if (tm != null) {
-			return Caches.withinTx(tm, callable);
-		} else {
-			Transaction transaction = TEST_SESSION_ACCESS.beginTransaction(session);
-			boolean rollingBack = false;
-			try {
-				T retval = callable.call();
-				if (transaction.getStatus() == TransactionStatus.ACTIVE) {
-					transaction.commit();
-				} else {
-					rollingBack = true;
-					transaction.rollback();
-				}
-				return retval;
-			} catch (Exception e) {
-				if (!rollingBack) {
-					try {
-						transaction.rollback();
-					} catch (Exception suppressed) {
-						e.addSuppressed(suppressed);
-					}
-				}
-				throw e;
-			}
-		}
-	}
+   protected <T> T withTx(NodeEnvironment environment, Object session, Callable<T> callable) throws Exception {
+      TransactionManager tm = environment.getServiceRegistry().getService(JtaPlatform.class).retrieveTransactionManager();
+      if (tm != null) {
+         return Caches.withinTx(tm, callable);
+      } else {
+         Transaction transaction = TEST_SESSION_ACCESS.beginTransaction(session);
+         boolean rollingBack = false;
+         try {
+            T retval = callable.call();
+            if (transaction.getStatus() == TransactionStatus.ACTIVE) {
+               transaction.commit();
+            } else {
+               rollingBack = true;
+               transaction.rollback();
+            }
+            return retval;
+         } catch (Exception e) {
+            if (!rollingBack) {
+               try {
+                  transaction.rollback();
+               } catch (Exception suppressed) {
+                  e.addSuppressed(suppressed);
+               }
+            }
+            throw e;
+         }
+      }
+   }
 
-	protected CacheTestSupport getCacheTestSupport() {
-		return testSupport;
-	}
+   protected CacheTestSupport getCacheTestSupport() {
+      return testSupport;
+   }
 
-	protected StandardServiceRegistryBuilder createStandardServiceRegistryBuilder() {
-		final StandardServiceRegistryBuilder ssrb = CacheTestUtil.buildBaselineStandardServiceRegistryBuilder(
-				REGION_PREFIX, true, false, jtaPlatform);
-		ssrb.applySetting(TestRegionFactory.TRANSACTIONAL, TestRegionFactoryProvider.load().supportTransactionalCaches() && accessType == AccessType.TRANSACTIONAL);
-		ssrb.applySetting(TestRegionFactory.CACHE_MODE, cacheMode);
-		return ssrb;
-	}
+   protected StandardServiceRegistryBuilder createStandardServiceRegistryBuilder() {
+      final StandardServiceRegistryBuilder ssrb = CacheTestUtil.buildBaselineStandardServiceRegistryBuilder(
+            REGION_PREFIX, true, false, jtaPlatform);
+      ssrb.applySetting(TestRegionFactory.TRANSACTIONAL, TestRegionFactoryProvider.load().supportTransactionalCaches() && accessType == AccessType.TRANSACTIONAL);
+      ssrb.applySetting(TestRegionFactory.CACHE_MODE, cacheMode);
+      return ssrb;
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractRegionAccessStrategyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/AbstractRegionAccessStrategyTest.java
@@ -30,6 +30,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.InvalidateCommand;
+import org.infinispan.commons.time.ControlledTimeService;
 import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
 import org.infinispan.hibernate.cache.commons.access.PutFromLoadValidator;
 import org.infinispan.hibernate.cache.commons.access.SessionAccess;
@@ -43,7 +44,6 @@ import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess.TestRegionAccessStrategy;
 import org.infinispan.test.hibernate.cache.commons.util.TestSynchronization;
-import org.infinispan.commons.time.ControlledTimeService;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Rule;
@@ -57,213 +57,212 @@ import jakarta.transaction.SystemException;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class AbstractRegionAccessStrategyTest<S>
-		extends AbstractNonFunctionalTest {
-	protected final Logger log = Logger.getLogger(getClass());
+      extends AbstractNonFunctionalTest {
+   protected final Logger log = Logger.getLogger(getClass());
 
-	public static final String REGION_NAME = "com.foo.test";
-	public static final String KEY_BASE = "KEY";
-	public static final TestCacheEntry VALUE1 = new TestCacheEntry("VALUE1", 1);
-	public static final TestCacheEntry VALUE2 = new TestCacheEntry("VALUE2", 2);
+   public static final String REGION_NAME = "com.foo.test";
+   public static final String KEY_BASE = "KEY";
+   public static final TestCacheEntry VALUE1 = new TestCacheEntry("VALUE1", 1);
+   public static final TestCacheEntry VALUE2 = new TestCacheEntry("VALUE2", 2);
 
-	protected static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
+   protected static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
    protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
    protected static final SessionAccess SESSION_ACCESS = SessionAccess.findSessionAccess();
 
-	protected NodeEnvironment localEnvironment;
-	protected InfinispanBaseRegion localRegion;
-	protected S localAccessStrategy;
+   protected NodeEnvironment localEnvironment;
+   protected InfinispanBaseRegion localRegion;
+   protected S localAccessStrategy;
    protected TestRegionAccessStrategy testLocalAccessStrategy;
 
-	protected NodeEnvironment remoteEnvironment;
-	protected InfinispanBaseRegion remoteRegion;
+   protected NodeEnvironment remoteEnvironment;
+   protected InfinispanBaseRegion remoteRegion;
    protected S remoteAccessStrategy;
    protected TestRegionAccessStrategy testRemoteAccessStrategy;
 
-	protected boolean transactional;
-	protected boolean invalidation;
-	protected boolean synchronous;
-	protected Exception node1Exception;
-	protected Exception node2Exception;
-	protected AssertionError node1Failure;
-	protected AssertionError node2Failure;
+   protected boolean transactional;
+   protected boolean invalidation;
+   protected boolean synchronous;
+   protected Exception node1Exception;
+   protected Exception node2Exception;
+   protected AssertionError node1Failure;
+   protected AssertionError node2Failure;
 
-	protected List<Runnable> cleanup = new ArrayList<>();
+   protected List<Runnable> cleanup = new ArrayList<>();
 
    @Rule
    public TestName name = new TestName();
 
-	@Override
-	protected boolean canUseLocalMode() {
-		return false;
-	}
+   @Override
+   protected boolean canUseLocalMode() {
+      return false;
+   }
 
-	@BeforeClassOnce
-	public void prepareResources() throws Exception {
-		// to mimic exactly the old code results, both environments here are exactly the same...
-		StandardServiceRegistryBuilder ssrb = createStandardServiceRegistryBuilder();
-		localEnvironment = new NodeEnvironment( ssrb );
-		localEnvironment.prepare();
+   @BeforeClassOnce
+   public void prepareResources() throws Exception {
+      // to mimic exactly the old code results, both environments here are exactly the same...
+      StandardServiceRegistryBuilder ssrb = createStandardServiceRegistryBuilder();
+      localEnvironment = new NodeEnvironment(ssrb);
+      localEnvironment.prepare();
 
-		localRegion = getRegion(localEnvironment);
-		localAccessStrategy = getAccessStrategy(localRegion);
+      localRegion = getRegion(localEnvironment);
+      localAccessStrategy = getAccessStrategy(localRegion);
       testLocalAccessStrategy = TEST_SESSION_ACCESS.fromAccess(localAccessStrategy);
 
-		transactional = Caches.isTransactionalCache(localRegion.getCache());
-		invalidation = Caches.isInvalidationCache(localRegion.getCache());
-		synchronous = Caches.isSynchronousCache(localRegion.getCache());
+      transactional = Caches.isTransactionalCache(localRegion.getCache());
+      invalidation = Caches.isInvalidationCache(localRegion.getCache());
+      synchronous = Caches.isSynchronousCache(localRegion.getCache());
 
-		remoteEnvironment = new NodeEnvironment( ssrb );
-		remoteEnvironment.prepare();
+      remoteEnvironment = new NodeEnvironment(ssrb);
+      remoteEnvironment.prepare();
 
-		remoteRegion = getRegion(remoteEnvironment);
-		remoteAccessStrategy = getAccessStrategy(remoteRegion);
+      remoteRegion = getRegion(remoteEnvironment);
+      remoteAccessStrategy = getAccessStrategy(remoteRegion);
       testRemoteAccessStrategy = TEST_SESSION_ACCESS.fromAccess(remoteAccessStrategy);
 
-		waitForClusterToForm(localRegion.getCache(), remoteRegion.getCache());
-	}
+      waitForClusterToForm(localRegion.getCache(), remoteRegion.getCache());
+   }
 
-	@After
-	public void cleanup() {
-		cleanup.forEach(Runnable::run);
-		cleanup.clear();
-		if (localRegion != null) localRegion.getCache().clear();
-		if (remoteRegion != null) remoteRegion.getCache().clear();
-		node1Exception = node2Exception = null;
-		node1Failure = node2Failure = null;
-		TIME_SERVICE.advance(1); // There might be invalidation from the previous test
-	}
+   @After
+   public void cleanup() {
+      cleanup.forEach(Runnable::run);
+      cleanup.clear();
+      if (localRegion != null) localRegion.getCache().clear();
+      if (remoteRegion != null) remoteRegion.getCache().clear();
+      node1Exception = node2Exception = null;
+      node1Failure = node2Failure = null;
+      TIME_SERVICE.advance(1); // There might be invalidation from the previous test
+   }
 
-	@AfterClassOnce
-	public void releaseResources() throws Exception {
-		try {
-			if (localEnvironment != null) {
-				localEnvironment.release();
-			}
-		}
-		finally {
-			if (remoteEnvironment != null) {
-				remoteEnvironment.release();
-			}
-		}
-	}
+   @AfterClassOnce
+   public void releaseResources() throws Exception {
+      try {
+         if (localEnvironment != null) {
+            localEnvironment.release();
+         }
+      } finally {
+         if (remoteEnvironment != null) {
+            remoteEnvironment.release();
+         }
+      }
+   }
 
-	@Override
-	protected StandardServiceRegistryBuilder createStandardServiceRegistryBuilder() {
-		StandardServiceRegistryBuilder ssrb = super.createStandardServiceRegistryBuilder();
-		ssrb.applySetting(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
-		return ssrb;
-	}
+   @Override
+   protected StandardServiceRegistryBuilder createStandardServiceRegistryBuilder() {
+      StandardServiceRegistryBuilder ssrb = super.createStandardServiceRegistryBuilder();
+      ssrb.applySetting(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
+      return ssrb;
+   }
 
-	/**
-	 * Simulate 2 nodes, both start, tx do a get, experience a cache miss, then
-	 * 'read from db.' First does a putFromLoad, then an update (or removal if it is a collection).
-	 * Second tries to do a putFromLoad with stale data (i.e. it took longer to read from the db).
-	 * Both commit their tx. Then both start a new tx and get. First should see
-	 * the updated data; second should either see the updated data
-	 * (isInvalidation() == false) or null (isInvalidation() == true).
-	 *
-	 * @param useMinimalAPI
-	 * @param isRemoval
-	 * @throws Exception
-	 */
-	protected void putFromLoadTest(final boolean useMinimalAPI, boolean isRemoval) throws Exception {
+   /**
+    * Simulate 2 nodes, both start, tx do a get, experience a cache miss, then
+    * 'read from db.' First does a putFromLoad, then an update (or removal if it is a collection).
+    * Second tries to do a putFromLoad with stale data (i.e. it took longer to read from the db).
+    * Both commit their tx. Then both start a new tx and get. First should see
+    * the updated data; second should either see the updated data
+    * (isInvalidation() == false) or null (isInvalidation() == true).
+    *
+    * @param useMinimalAPI
+    * @param isRemoval
+    * @throws Exception
+    */
+   protected void putFromLoadTest(final boolean useMinimalAPI, boolean isRemoval) throws Exception {
 
-		final Object KEY = generateNextKey();
+      final Object KEY = generateNextKey();
 
-		final CountDownLatch writeLatch1 = new CountDownLatch(1);
-		final CountDownLatch writeLatch2 = new CountDownLatch(1);
-		final CountDownLatch completionLatch = new CountDownLatch(2);
+      final CountDownLatch writeLatch1 = new CountDownLatch(1);
+      final CountDownLatch writeLatch2 = new CountDownLatch(1);
+      final CountDownLatch completionLatch = new CountDownLatch(2);
 
       CountDownLatch[] putFromLoadLatches = new CountDownLatch[2];
 
-		Thread node1 = new Thread(() -> {
-				try {
-               Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-               putFromLoadLatches[0] = withTx(localEnvironment, session, () -> {
-						assertNull(testLocalAccessStrategy.get(session, KEY));
+      Thread node1 = new Thread(() -> {
+         try {
+            Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+            putFromLoadLatches[0] = withTx(localEnvironment, session, () -> {
+               assertNull(testLocalAccessStrategy.get(session, KEY));
 
-						writeLatch1.await();
+               writeLatch1.await();
 
-                  CountDownLatch latch = expectPutFromLoad(remoteRegion, KEY);
-						if (useMinimalAPI) {
-							testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version, true);
-						} else {
-							testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version);
-						}
+               CountDownLatch latch = expectPutFromLoad(remoteRegion, KEY);
+               if (useMinimalAPI) {
+                  testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version, true);
+               } else {
+                  testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version);
+               }
 
-						doUpdate(testLocalAccessStrategy, session, KEY, VALUE2);
-						return latch;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
-               // Let node2 write
-					writeLatch2.countDown();
-					completionLatch.countDown();
-            }
+               doUpdate(testLocalAccessStrategy, session, KEY, VALUE2);
+               return latch;
+            });
+         } catch (Exception e) {
+            log.error("node1 caught exception", e);
+            node1Exception = e;
+         } catch (AssertionError e) {
+            node1Failure = e;
+         } finally {
+            // Let node2 write
+            writeLatch2.countDown();
+            completionLatch.countDown();
+         }
       }, putFromLoadTestThreadName("node1", useMinimalAPI, isRemoval));
 
-		Thread node2 = new Thread(() -> {
-				try {
-               Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-               putFromLoadLatches[1] = withTx(remoteEnvironment, session, () -> {
+      Thread node2 = new Thread(() -> {
+         try {
+            Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+            putFromLoadLatches[1] = withTx(remoteEnvironment, session, () -> {
 
-						assertNull(testRemoteAccessStrategy.get(session, KEY));
+               assertNull(testRemoteAccessStrategy.get(session, KEY));
 
-						// Let node1 write
-						writeLatch1.countDown();
-						// Wait for node1 to finish
-						writeLatch2.await();
+               // Let node1 write
+               writeLatch1.countDown();
+               // Wait for node1 to finish
+               writeLatch2.await();
 
-                  CountDownLatch latch = expectPutFromLoad(localRegion, KEY);
-						if (useMinimalAPI) {
-                     testRemoteAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version, true);
-						} else {
-                     testRemoteAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version);
-						}
-						return latch;
-					});
-				} catch (Exception e) {
-					log.error("node2 caught exception", e);
-					node2Exception = e;
-				} catch (AssertionError e) {
-					node2Failure = e;
-				} finally {
-					completionLatch.countDown();
-				}
+               CountDownLatch latch = expectPutFromLoad(localRegion, KEY);
+               if (useMinimalAPI) {
+                  testRemoteAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version, true);
+               } else {
+                  testRemoteAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.version);
+               }
+               return latch;
+            });
+         } catch (Exception e) {
+            log.error("node2 caught exception", e);
+            node2Exception = e;
+         } catch (AssertionError e) {
+            node2Failure = e;
+         } finally {
+            completionLatch.countDown();
+         }
       }, putFromLoadTestThreadName("node2", useMinimalAPI, isRemoval));
 
-		node1.setDaemon(true);
-		node2.setDaemon(true);
+      node1.setDaemon(true);
+      node2.setDaemon(true);
 
-		CountDownLatch remoteUpdate = expectAfterUpdate(KEY);
+      CountDownLatch remoteUpdate = expectAfterUpdate(KEY);
 
-		node1.start();
-		node2.start();
+      node1.start();
+      node2.start();
 
-		assertTrue("Threads completed", completionLatch.await(2, TimeUnit.SECONDS));
+      assertTrue("Threads completed", completionLatch.await(2, TimeUnit.SECONDS));
 
-		assertThreadsRanCleanly();
-		assertTrue("Update was replicated", remoteUpdate.await(2, TimeUnit.SECONDS));
+      assertThreadsRanCleanly();
+      assertTrue("Update was replicated", remoteUpdate.await(2, TimeUnit.SECONDS));
 
-		// At least one of the put from load latch should have completed
-		assertPutFromLoadLatches(putFromLoadLatches);
+      // At least one of the put from load latch should have completed
+      assertPutFromLoadLatches(putFromLoadLatches);
 
-		Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals(isRemoval ? null : VALUE2, testLocalAccessStrategy.get(s1, KEY));
-		Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		Object remoteValue = testRemoteAccessStrategy.get(s2, KEY);
-		if (isUsingInvalidation() || isRemoval) {
-			// invalidation command invalidates pending put
-			assertNull(remoteValue);
-		} else {
-			// The node1 update is replicated, preventing the node2 PFER
-			assertEquals(VALUE2, remoteValue);
-		}
-	}
+      Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      assertEquals(isRemoval ? null : VALUE2, testLocalAccessStrategy.get(s1, KEY));
+      Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      Object remoteValue = testRemoteAccessStrategy.get(s2, KEY);
+      if (isUsingInvalidation() || isRemoval) {
+         // invalidation command invalidates pending put
+         assertNull(remoteValue);
+      } else {
+         // The node1 update is replicated, preventing the node2 PFER
+         assertEquals(VALUE2, remoteValue);
+      }
+   }
 
    protected void assertPutFromLoadLatches(CountDownLatch[] latches) {
       // In some cases, both puts might execute, so make sure you wait for both
@@ -271,8 +270,8 @@ public abstract class AbstractRegionAccessStrategyTest<S>
       boolean await0 = await(latches[0]);
       boolean await1 = await(latches[1]);
       assertTrue(String.format(
-         "One of the latches in %s should have at least completed", Arrays.toString(latches)),
-         await0 || await1);
+                  "One of the latches in %s should have at least completed", Arrays.toString(latches)),
+            await0 || await1);
    }
 
    private boolean await(CountDownLatch latch) {
@@ -290,40 +289,40 @@ public abstract class AbstractRegionAccessStrategyTest<S>
 
    String putFromLoadTestThreadName(String node, boolean useMinimalAPI, boolean isRemoval) {
       return String.format("putFromLoad=%s,%s,%s,%s,minimal=%s,isRemove=%s",
-         node, mode, cacheMode, accessType, useMinimalAPI, isRemoval);
+            node, mode, cacheMode, accessType, useMinimalAPI, isRemoval);
    }
 
-	protected CountDownLatch expectAfterUpdate(Object key) {
-		return expectReadWriteKeyCommand(key, value -> value instanceof FutureUpdate);
-	}
+   protected CountDownLatch expectAfterUpdate(Object key) {
+      return expectReadWriteKeyCommand(key, value -> value instanceof FutureUpdate);
+   }
 
-	protected CountDownLatch expectReadWriteKeyCommand(Object key, Predicate<Object> functionPredicate) {
-		if (!isUsingInvalidation() && accessType != AccessType.NONSTRICT_READ_WRITE) {
-			CountDownLatch latch = new CountDownLatch(1);
-			ExpectingInterceptor.get(remoteRegion.getCache())
-				.when((ctx, cmd) -> isExpectedReadWriteKey(key, cmd) &&
-                  functionPredicate.test(((ReadWriteKeyCommand) cmd).getFunction()))
-				.countDown(latch);
-			cleanup.add(() -> ExpectingInterceptor.cleanup(remoteRegion.getCache()));
-			return latch;
-		} else {
-			return new CountDownLatch(0);
-		}
-	}
+   protected CountDownLatch expectReadWriteKeyCommand(Object key, Predicate<Object> functionPredicate) {
+      if (!isUsingInvalidation() && accessType != AccessType.NONSTRICT_READ_WRITE) {
+         CountDownLatch latch = new CountDownLatch(1);
+         ExpectingInterceptor.get(remoteRegion.getCache())
+               .when((ctx, cmd) -> isExpectedReadWriteKey(key, cmd) &&
+                     functionPredicate.test(((ReadWriteKeyCommand) cmd).getFunction()))
+               .countDown(latch);
+         cleanup.add(() -> ExpectingInterceptor.cleanup(remoteRegion.getCache()));
+         return latch;
+      } else {
+         return new CountDownLatch(0);
+      }
+   }
 
-	protected CountDownLatch expectPutFromLoad(Object key) {
-		return expectReadWriteKeyCommand(key, value -> value instanceof TombstoneUpdate);
-	}
+   protected CountDownLatch expectPutFromLoad(Object key) {
+      return expectReadWriteKeyCommand(key, value -> value instanceof TombstoneUpdate);
+   }
 
    protected CountDownLatch expectPutFromLoad(InfinispanBaseRegion region, Object key) {
       Predicate<Object> functionPredicate = accessType == AccessType.NONSTRICT_READ_WRITE
-         ? VersionedEntry.class::isInstance : TombstoneUpdate.class::isInstance;
+            ? VersionedEntry.class::isInstance : TombstoneUpdate.class::isInstance;
       CountDownLatch latch = new CountDownLatch(1);
       if (!isUsingInvalidation()) {
          ExpectingInterceptor.get(region.getCache())
-            .when((ctx, cmd) -> isExpectedReadWriteKey(key, cmd)
-                  && functionPredicate.test(((ReadWriteKeyCommand) cmd).getFunction()))
-            .countDown(latch);
+               .when((ctx, cmd) -> isExpectedReadWriteKey(key, cmd)
+                     && functionPredicate.test(((ReadWriteKeyCommand) cmd).getFunction()))
+               .countDown(latch);
          cleanup.add(() -> ExpectingInterceptor.cleanup(region.getCache()));
       } else {
          if (transactional) {
@@ -338,91 +337,90 @@ public abstract class AbstractRegionAccessStrategyTest<S>
 
    protected abstract void doUpdate(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry);
 
-	protected abstract S getAccessStrategy(InfinispanBaseRegion region);
+   protected abstract S getAccessStrategy(InfinispanBaseRegion region);
 
-	@Test
-	public void testRemove() throws Exception {
+   @Test
+   public void testRemove() throws Exception {
       log.infof(name.getMethodName());
-		evictOrRemoveTest( false );
-	}
+      evictOrRemoveTest(false);
+   }
 
-	@Test
-	public void testEvict() throws Exception {
+   @Test
+   public void testEvict() throws Exception {
       log.infof(name.getMethodName());
-		evictOrRemoveTest( true );
-	}
+      evictOrRemoveTest(true);
+   }
 
-	protected abstract InfinispanBaseRegion getRegion(NodeEnvironment environment);
+   protected abstract InfinispanBaseRegion getRegion(NodeEnvironment environment);
 
-	protected void waitForClusterToForm(Cache... caches) {
-		TestingUtil.blockUntilViewsReceived(10000, Arrays.asList(caches));
-	}
+   protected void waitForClusterToForm(Cache... caches) {
+      TestingUtil.blockUntilViewsReceived(10000, Arrays.asList(caches));
+   }
 
-	protected boolean isTransactional() {
-		return transactional;
-	}
+   protected boolean isTransactional() {
+      return transactional;
+   }
 
-	protected boolean isUsingInvalidation() {
-		return invalidation;
-	}
+   protected boolean isUsingInvalidation() {
+      return invalidation;
+   }
 
-	protected boolean isSynchronous() {
-		return synchronous;
-	}
+   protected boolean isSynchronous() {
+      return synchronous;
+   }
 
-	protected void evictOrRemoveTest(final boolean evict) throws Exception {
-		final Object KEY = generateNextKey();
-		assertEquals(0, localRegion.getElementCountInMemory());
-		assertEquals(0, remoteRegion.getElementCountInMemory());
+   protected void evictOrRemoveTest(final boolean evict) throws Exception {
+      final Object KEY = generateNextKey();
+      assertEquals(0, localRegion.getElementCountInMemory());
+      assertEquals(0, remoteRegion.getElementCountInMemory());
 
-		CountDownLatch localPutFromLoadLatch = expectRemotePutFromLoad(remoteRegion.getCache(), localRegion.getCache(), KEY);
-		CountDownLatch remotePutFromLoadLatch = expectRemotePutFromLoad(localRegion.getCache(), remoteRegion.getCache(), KEY);
+      CountDownLatch localPutFromLoadLatch = expectRemotePutFromLoad(remoteRegion.getCache(), localRegion.getCache(), KEY);
+      CountDownLatch remotePutFromLoadLatch = expectRemotePutFromLoad(localRegion.getCache(), remoteRegion.getCache(), KEY);
 
       Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertNull("local is clean", testLocalAccessStrategy.get(s1, KEY));
+      assertNull("local is clean", testLocalAccessStrategy.get(s1, KEY));
       Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertNull("remote is clean", testRemoteAccessStrategy.get(s2, KEY));
+      assertNull("remote is clean", testRemoteAccessStrategy.get(s2, KEY));
 
       Object s3 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		testLocalAccessStrategy.putFromLoad(s3, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s3), VALUE1.version);
+      testLocalAccessStrategy.putFromLoad(s3, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s3), VALUE1.version);
       Object s5 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		testRemoteAccessStrategy.putFromLoad(s5, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s5), VALUE1.version);
+      testRemoteAccessStrategy.putFromLoad(s5, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s5), VALUE1.version);
 
-		// putFromLoad is applied on local node synchronously, but if there's a concurrent update
-		// from the other node it can silently fail when acquiring the loc . Then we could try to read
-		// before the update is fully applied.
-		assertTrue(localPutFromLoadLatch.await(1, TimeUnit.SECONDS));
-		assertTrue(remotePutFromLoadLatch.await(1, TimeUnit.SECONDS));
+      // putFromLoad is applied on local node synchronously, but if there's a concurrent update
+      // from the other node it can silently fail when acquiring the loc . Then we could try to read
+      // before the update is fully applied.
+      assertTrue(localPutFromLoadLatch.await(1, TimeUnit.SECONDS));
+      assertTrue(remotePutFromLoadLatch.await(1, TimeUnit.SECONDS));
 
       Object s4 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals(VALUE1, testLocalAccessStrategy.get(s4, KEY));
+      assertEquals(VALUE1, testLocalAccessStrategy.get(s4, KEY));
       Object s6 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertEquals(VALUE1, testRemoteAccessStrategy.get(s6, KEY));
+      assertEquals(VALUE1, testRemoteAccessStrategy.get(s6, KEY));
 
       CountDownLatch endInvalidationLatch = createEndInvalidationLatch(evict, KEY);
       CountDownLatch endRemoveLatch = createRemoveLatch(evict, KEY);
 
       Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		withTx(localEnvironment, session, () -> {
-			if (evict) {
-				testLocalAccessStrategy.evict(KEY);
-			}
-			else {
-				doRemove(testLocalAccessStrategy, session, KEY);
-			}
-			return null;
-		});
+      withTx(localEnvironment, session, () -> {
+         if (evict) {
+            testLocalAccessStrategy.evict(KEY);
+         } else {
+            doRemove(testLocalAccessStrategy, session, KEY);
+         }
+         return null;
+      });
 
       Object s7 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertNull(testLocalAccessStrategy.get(s7, KEY));
+      assertNull(testLocalAccessStrategy.get(s7, KEY));
       Object s8 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertNull(testRemoteAccessStrategy.get(s8, KEY));
+      assertNull(testRemoteAccessStrategy.get(s8, KEY));
 
       assertTrue(endInvalidationLatch.await(1, TimeUnit.SECONDS));
       assertEquals(0, localRegion.getElementCountInMemory());
-		assertEquals(0, remoteRegion.getElementCountInMemory());
+      assertEquals(0, remoteRegion.getElementCountInMemory());
       assertTrue(endRemoveLatch.await(1, TimeUnit.SECONDS));
-	}
+   }
 
    protected CountDownLatch createRemoveLatch(boolean evict, Object key) {
       if (!evict)
@@ -432,121 +430,121 @@ public abstract class AbstractRegionAccessStrategyTest<S>
    }
 
    protected void doRemove(TestRegionAccessStrategy strategy, Object session, Object key) throws SystemException, RollbackException {
-		SoftLock softLock = strategy.lockItem(session, key, null);
-		strategy.remove(session, key);
+      SoftLock softLock = strategy.lockItem(session, key, null);
+      strategy.remove(session, key);
       SessionAccess.TransactionCoordinatorAccess transactionCoordinator = SESSION_ACCESS.getTransactionCoordinator(session);
       transactionCoordinator.registerLocalSynchronization(
-				new TestSynchronization.UnlockItem(strategy, session, key, softLock));
-	}
+            new TestSynchronization.UnlockItem(strategy, session, key, softLock));
+   }
 
-	@Test
+   @Test
    public void testRemoveAll() throws Exception {
       log.infof(name.getMethodName());
-		evictOrRemoveAllTest(false);
-	}
+      evictOrRemoveAllTest(false);
+   }
 
-	@Test
+   @Test
    public void testEvictAll() throws Exception {
       log.infof(name.getMethodName());
-		evictOrRemoveAllTest(true);
-	}
+      evictOrRemoveAllTest(true);
+   }
 
-	protected void assertThreadsRanCleanly() {
-		if (node1Failure != null) {
-			throw node1Failure;
-		}
-		if (node2Failure != null) {
-			throw node2Failure;
-		}
+   protected void assertThreadsRanCleanly() {
+      if (node1Failure != null) {
+         throw node1Failure;
+      }
+      if (node2Failure != null) {
+         throw node2Failure;
+      }
 
-		if (node1Exception != null) {
-			log.error("node1 saw an exception", node1Exception);
-			assertEquals("node1 saw no exceptions", null, node1Exception);
-		}
+      if (node1Exception != null) {
+         log.error("node1 saw an exception", node1Exception);
+         assertEquals("node1 saw no exceptions", null, node1Exception);
+      }
 
-		if (node2Exception != null) {
-			log.error("node2 saw an exception", node2Exception);
-			assertEquals("node2 saw no exceptions", null, node2Exception);
-		}
-	}
+      if (node2Exception != null) {
+         log.error("node2 saw an exception", node2Exception);
+         assertEquals("node2 saw no exceptions", null, node2Exception);
+      }
+   }
 
-	protected abstract Object generateNextKey();
+   protected abstract Object generateNextKey();
 
-	protected void evictOrRemoveAllTest(final boolean evict) throws Exception {
-		final Object KEY = generateNextKey();
-		assertEquals(0, localRegion.getElementCountInMemory());
-		assertEquals(0, remoteRegion.getElementCountInMemory());
+   protected void evictOrRemoveAllTest(final boolean evict) throws Exception {
+      final Object KEY = generateNextKey();
+      assertEquals(0, localRegion.getElementCountInMemory());
+      assertEquals(0, remoteRegion.getElementCountInMemory());
       Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertNull("local is clean", testLocalAccessStrategy.get(s1, KEY));
+      assertNull("local is clean", testLocalAccessStrategy.get(s1, KEY));
       Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertNull("remote is clean", testRemoteAccessStrategy.get(s2, KEY));
+      assertNull("remote is clean", testRemoteAccessStrategy.get(s2, KEY));
 
-		CountDownLatch localPutFromLoadLatch = expectRemotePutFromLoad(remoteRegion.getCache(), localRegion.getCache(), KEY);
-		CountDownLatch remotePutFromLoadLatch = expectRemotePutFromLoad(localRegion.getCache(), remoteRegion.getCache(), KEY);
+      CountDownLatch localPutFromLoadLatch = expectRemotePutFromLoad(remoteRegion.getCache(), localRegion.getCache(), KEY);
+      CountDownLatch remotePutFromLoadLatch = expectRemotePutFromLoad(localRegion.getCache(), remoteRegion.getCache(), KEY);
 
       Object s3 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
       log.infof("Call putFromLoad strategy get for key=%s", KEY);
-		testLocalAccessStrategy.putFromLoad(s3, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s3), VALUE1.version);
-		Object s5 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		log.infof("Call remote putFromLoad strategy get for key=%s", KEY);
-		testRemoteAccessStrategy.putFromLoad(s5, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s5), VALUE2.version);
+      testLocalAccessStrategy.putFromLoad(s3, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s3), VALUE1.version);
+      Object s5 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      log.infof("Call remote putFromLoad strategy get for key=%s", KEY);
+      testRemoteAccessStrategy.putFromLoad(s5, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s5), VALUE2.version);
 
-		// putFromLoad is applied on local node synchronously, but if there's a concurrent update
-		// from the other node it can silently fail when acquiring the loc . Then we could try to read
-		// before the update is fully applied.
-		assertTrue(localPutFromLoadLatch.await(1, TimeUnit.SECONDS));
-		assertTrue(remotePutFromLoadLatch.await(1, TimeUnit.SECONDS));
+      // putFromLoad is applied on local node synchronously, but if there's a concurrent update
+      // from the other node it can silently fail when acquiring the loc . Then we could try to read
+      // before the update is fully applied.
+      assertTrue(localPutFromLoadLatch.await(1, TimeUnit.SECONDS));
+      assertTrue(remotePutFromLoadLatch.await(1, TimeUnit.SECONDS));
 
-		Object s4 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		Object s6 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		log.infof("Call local strategy get for key=%s", KEY);
-		assertEquals(VALUE1, testLocalAccessStrategy.get(s4, KEY));
-		assertEquals(VALUE1, testRemoteAccessStrategy.get(s6, KEY));
+      Object s4 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      Object s6 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      log.infof("Call local strategy get for key=%s", KEY);
+      assertEquals(VALUE1, testLocalAccessStrategy.get(s4, KEY));
+      assertEquals(VALUE1, testRemoteAccessStrategy.get(s6, KEY));
 
-		CountDownLatch endInvalidationLatch = createEndInvalidationLatch(evict, KEY);
+      CountDownLatch endInvalidationLatch = createEndInvalidationLatch(evict, KEY);
 
-		Object removeSession = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		withTx(localEnvironment, removeSession, () -> {
-			if (evict) {
-				testLocalAccessStrategy.evictAll();
-			} else {
-				SoftLock softLock = testLocalAccessStrategy.lockRegion();
-				testLocalAccessStrategy.removeAll(removeSession);
-				testLocalAccessStrategy.unlockRegion(softLock);
-			}
-			return null;
-		});
+      Object removeSession = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      withTx(localEnvironment, removeSession, () -> {
+         if (evict) {
+            testLocalAccessStrategy.evictAll();
+         } else {
+            SoftLock softLock = testLocalAccessStrategy.lockRegion();
+            testLocalAccessStrategy.removeAll(removeSession);
+            testLocalAccessStrategy.unlockRegion(softLock);
+         }
+         return null;
+      });
       Object s7 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertNull(testLocalAccessStrategy.get(s7, KEY));
-		assertEquals(0, localRegion.getElementCountInMemory());
+      assertNull(testLocalAccessStrategy.get(s7, KEY));
+      assertEquals(0, localRegion.getElementCountInMemory());
 
       Object s8 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertNull(testRemoteAccessStrategy.get(s8, KEY));
-		assertEquals(0, remoteRegion.getElementCountInMemory());
+      assertNull(testRemoteAccessStrategy.get(s8, KEY));
+      assertEquals(0, remoteRegion.getElementCountInMemory());
 
-		// Wait for async propagation of EndInvalidationCommand before executing naked put
-		assertTrue(endInvalidationLatch.await(1, TimeUnit.SECONDS));
-		TIME_SERVICE.advance(1);
+      // Wait for async propagation of EndInvalidationCommand before executing naked put
+      assertTrue(endInvalidationLatch.await(1, TimeUnit.SECONDS));
+      TIME_SERVICE.advance(1);
 
-		CountDownLatch lastPutFromLoadLatch = expectRemotePutFromLoad(remoteRegion.getCache(), localRegion.getCache(), KEY);
+      CountDownLatch lastPutFromLoadLatch = expectRemotePutFromLoad(remoteRegion.getCache(), localRegion.getCache(), KEY);
 
-		// Test whether the get above messes up the optimistic version
-		Object s9 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		log.infof("Call remote strategy putFromLoad for key=%s and value=%s", KEY, VALUE1);
-		assertTrue(testRemoteAccessStrategy.putFromLoad(s9, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s9), 1));
-		Object s10 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		log.infof("Call remote strategy get for key=%s", KEY);
-		assertEquals(VALUE1, testRemoteAccessStrategy.get(s10, KEY));
-		// Wait for change to be applied in local, otherwise the count might not be correct
-		assertTrue(lastPutFromLoadLatch.await(1, TimeUnit.SECONDS));
-		assertEquals(1, remoteRegion.getElementCountInMemory());
+      // Test whether the get above messes up the optimistic version
+      Object s9 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      log.infof("Call remote strategy putFromLoad for key=%s and value=%s", KEY, VALUE1);
+      assertTrue(testRemoteAccessStrategy.putFromLoad(s9, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s9), 1));
+      Object s10 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      log.infof("Call remote strategy get for key=%s", KEY);
+      assertEquals(VALUE1, testRemoteAccessStrategy.get(s10, KEY));
+      // Wait for change to be applied in local, otherwise the count might not be correct
+      assertTrue(lastPutFromLoadLatch.await(1, TimeUnit.SECONDS));
+      assertEquals(1, remoteRegion.getElementCountInMemory());
 
 
-		Object s11 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals((isUsingInvalidation() ? null : VALUE1), testLocalAccessStrategy.get(s11, KEY));
-		Object s12 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertEquals(VALUE1, testRemoteAccessStrategy.get(s12, KEY));
-	}
+      Object s11 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      assertEquals((isUsingInvalidation() ? null : VALUE1), testLocalAccessStrategy.get(s11, KEY));
+      Object s12 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      assertEquals(VALUE1, testRemoteAccessStrategy.get(s12, KEY));
+   }
 
    private CountDownLatch createEndInvalidationLatch(boolean evict, Object key) {
       CountDownLatch endInvalidationLatch;
@@ -588,51 +586,51 @@ public abstract class AbstractRegionAccessStrategyTest<S>
 
    private void expectInvalidateCommand(InfinispanBaseRegion region, CountDownLatch latch) {
       ExpectingInterceptor.get(region.getCache())
-         .when((ctx, cmd) -> cmd instanceof InvalidateCommand || cmd instanceof ClearCommand)
-         .countDown(latch);
+            .when((ctx, cmd) -> cmd instanceof InvalidateCommand || cmd instanceof ClearCommand)
+            .countDown(latch);
       cleanup.add(() -> ExpectingInterceptor.cleanup(region.getCache()));
    }
 
    private CountDownLatch expectRemotePutFromLoad(AdvancedCache localCache, AdvancedCache remoteCache, Object key) {
-		CountDownLatch putFromLoadLatch;
-		if (!isUsingInvalidation()) {
-			putFromLoadLatch = new CountDownLatch(1);
-			// The command may fail to replicate if it can't acquire lock locally
-			ExpectingInterceptor.Condition remoteCondition = ExpectingInterceptor.get(remoteCache)
-            .when((ctx, cmd) -> {
-               final boolean isRemote = !ctx.isOriginLocal();
-               final boolean isExpectedReadWriteKey = isExpectedReadWriteKey(key, cmd);
-               final boolean cond = isRemote && isExpectedReadWriteKey;
-               log.debugf("Remote condition [test: isRemote=%b && isRWK=%b; should be true: %b]"
-                  , isRemote, isExpectedReadWriteKey, cond);
-               return cond;
-            });
-			ExpectingInterceptor.Condition localCondition = ExpectingInterceptor.get(localCache)
-            .whenFails((ctx, cmd) -> {
-               final boolean isLocal = ctx.isOriginLocal();
-               final boolean isExpectedReadWriteKey = isExpectedReadWriteKey(key, cmd);
-               final boolean cond = isLocal && isExpectedReadWriteKey;
-               log.debugf("Local condition [test: isLocal=%b && isRWK=%b; should be false: %b]"
-                  , isLocal, isExpectedReadWriteKey, cond);
-               return cond;
-            });
-			remoteCondition.run(() -> {
-				localCondition.cancel();
+      CountDownLatch putFromLoadLatch;
+      if (!isUsingInvalidation()) {
+         putFromLoadLatch = new CountDownLatch(1);
+         // The command may fail to replicate if it can't acquire lock locally
+         ExpectingInterceptor.Condition remoteCondition = ExpectingInterceptor.get(remoteCache)
+               .when((ctx, cmd) -> {
+                  final boolean isRemote = !ctx.isOriginLocal();
+                  final boolean isExpectedReadWriteKey = isExpectedReadWriteKey(key, cmd);
+                  final boolean cond = isRemote && isExpectedReadWriteKey;
+                  log.debugf("Remote condition [test: isRemote=%b && isRWK=%b; should be true: %b]"
+                        , isRemote, isExpectedReadWriteKey, cond);
+                  return cond;
+               });
+         ExpectingInterceptor.Condition localCondition = ExpectingInterceptor.get(localCache)
+               .whenFails((ctx, cmd) -> {
+                  final boolean isLocal = ctx.isOriginLocal();
+                  final boolean isExpectedReadWriteKey = isExpectedReadWriteKey(key, cmd);
+                  final boolean cond = isLocal && isExpectedReadWriteKey;
+                  log.debugf("Local condition [test: isLocal=%b && isRWK=%b; should be false: %b]"
+                        , isLocal, isExpectedReadWriteKey, cond);
+                  return cond;
+               });
+         remoteCondition.run(() -> {
+            localCondition.cancel();
             log.debugf("Counting down latch because remote condition succeed");
-				putFromLoadLatch.countDown();
-			});
-			localCondition.run(() -> {
-				remoteCondition.cancel();
+            putFromLoadLatch.countDown();
+         });
+         localCondition.run(() -> {
+            remoteCondition.cancel();
             log.debugf("Counting down latch because local condition succeed");
-				putFromLoadLatch.countDown();
-			});
-			// just for case the test fails and does not remove the interceptor itself
-			cleanup.add(() -> ExpectingInterceptor.cleanup(localCache, remoteCache));
-		} else {
-			putFromLoadLatch = new CountDownLatch(0);
-		}
-		return putFromLoadLatch;
-	}
+            putFromLoadLatch.countDown();
+         });
+         // just for case the test fails and does not remove the interceptor itself
+         cleanup.add(() -> ExpectingInterceptor.cleanup(localCache, remoteCache));
+      } else {
+         putFromLoadLatch = new CountDownLatch(0);
+      }
+      return putFromLoadLatch;
+   }
 
    private boolean isExpectedReadWriteKey(Object key, VisitableCommand cmd) {
       final boolean isPut = cmd instanceof ReadWriteKeyCommand;
@@ -641,7 +639,7 @@ public abstract class AbstractRegionAccessStrategyTest<S>
          final boolean isPutForKey = cmdKey.equals(key);
          if (!isPutForKey)
             log.warnf("Put received for key=%s, but expecting put for key=%s. Maybe there's a command leak?"
-               , cmdKey, key);
+                  , cmdKey, key);
 
          return isPutForKey;
       }
@@ -650,52 +648,52 @@ public abstract class AbstractRegionAccessStrategyTest<S>
    }
 
    public static class TestCacheEntry implements CacheEntry, Serializable {
-		private final Serializable value;
-		private final Serializable version;
+      private final Serializable value;
+      private final Serializable version;
 
-		public TestCacheEntry(Serializable value, Serializable version) {
-			this.value = value;
-			this.version = version;
-		}
+      public TestCacheEntry(Serializable value, Serializable version) {
+         this.value = value;
+         this.version = version;
+      }
 
-		@Override
-		public boolean isReferenceEntry() {
-			return false;
-		}
+      @Override
+      public boolean isReferenceEntry() {
+         return false;
+      }
 
-		@Override
-		public String getSubclass() {
-			return REGION_NAME;
-		}
+      @Override
+      public String getSubclass() {
+         return REGION_NAME;
+      }
 
-		@Override
-		public Object getVersion() {
-			return version;
-		}
+      @Override
+      public Object getVersion() {
+         return version;
+      }
 
-		@Override
-		public Serializable[] getDisassembledState() {
-			return new Serializable[] { value, version };
-		}
+      @Override
+      public Serializable[] getDisassembledState() {
+         return new Serializable[]{value, version};
+      }
 
-		@Override
-		public String toString() {
-			return value + "/" + version;
-		}
+      @Override
+      public String toString() {
+         return value + "/" + version;
+      }
 
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
-			TestCacheEntry that = (TestCacheEntry) o;
-			return Objects.equals(value, that.value) &&
-					Objects.equals(version, that.version);
-		}
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+         TestCacheEntry that = (TestCacheEntry) o;
+         return Objects.equals(value, that.value) &&
+               Objects.equals(version, that.version);
+      }
 
-		@Override
-		public int hashCode() {
+      @Override
+      public int hashCode() {
 
-			return Objects.hash(value, version);
-		}
-	}
+         return Objects.hash(value, version);
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/CacheKeySerializationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/CacheKeySerializationTest.java
@@ -33,108 +33,107 @@ import org.junit.Test;
  * @author Gail Badner
  */
 public class CacheKeySerializationTest extends BaseUnitTestCase {
-	@Rule
-	public InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
+   @Rule
+   public InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
 
-	private SessionFactoryImplementor getSessionFactory(String cacheKeysFactory) {
-		Configuration configuration = new Configuration()
-				.setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true")
-				.setProperty(Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName())
-				.setProperty(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional")
-				.setProperty("javax.persistence.sharedCache.mode", "ALL")
-				.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
-		if (cacheKeysFactory != null) {
-			configuration.setProperty(Environment.CACHE_KEYS_FACTORY, cacheKeysFactory);
-		}
-		configuration.addAnnotatedClass(WithSimpleId.class);
-		configuration.addAnnotatedClass(WithEmbeddedId.class);
-		return (SessionFactoryImplementor) configuration.buildSessionFactory();
-	}
+   private SessionFactoryImplementor getSessionFactory(String cacheKeysFactory) {
+      Configuration configuration = new Configuration()
+            .setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true")
+            .setProperty(Environment.CACHE_REGION_FACTORY, CachingRegionFactory.class.getName())
+            .setProperty(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional")
+            .setProperty("javax.persistence.sharedCache.mode", "ALL")
+            .setProperty(Environment.HBM2DDL_AUTO, "create-drop");
+      if (cacheKeysFactory != null) {
+         configuration.setProperty(Environment.CACHE_KEYS_FACTORY, cacheKeysFactory);
+      }
+      configuration.addAnnotatedClass(WithSimpleId.class);
+      configuration.addAnnotatedClass(WithEmbeddedId.class);
+      return (SessionFactoryImplementor) configuration.buildSessionFactory();
+   }
 
-	@Test
-	@JiraKey("HHH-11202")
-	public void testSimpleCacheKeySimpleId() throws Exception {
-		testId(SimpleCacheKeysFactory.INSTANCE, WithSimpleId.class.getName(), 1L);
-	}
+   @Test
+   @JiraKey("HHH-11202")
+   public void testSimpleCacheKeySimpleId() throws Exception {
+      testId(SimpleCacheKeysFactory.INSTANCE, WithSimpleId.class.getName(), 1L);
+   }
 
-	@Test
-	@JiraKey("HHH-11202")
-	public void testSimpleCacheKeyEmbeddedId() throws Exception {
-		testId(SimpleCacheKeysFactory.INSTANCE, WithEmbeddedId.class.getName(), new PK(1L));
-	}
+   @Test
+   @JiraKey("HHH-11202")
+   public void testSimpleCacheKeyEmbeddedId() throws Exception {
+      testId(SimpleCacheKeysFactory.INSTANCE, WithEmbeddedId.class.getName(), new PK(1L));
+   }
 
-	@Test
-	@JiraKey("HHH-11202")
-	public void testDefaultCacheKeySimpleId() throws Exception {
-		testId(DefaultCacheKeysFactory.INSTANCE, WithSimpleId.class.getName(), 1L);
-	}
+   @Test
+   @JiraKey("HHH-11202")
+   public void testDefaultCacheKeySimpleId() throws Exception {
+      testId(DefaultCacheKeysFactory.INSTANCE, WithSimpleId.class.getName(), 1L);
+   }
 
-	@Test
-	@JiraKey("HHH-11202")
-	public void testDefaultCacheKeyEmbeddedId() throws Exception {
-		testId(DefaultCacheKeysFactory.INSTANCE, WithEmbeddedId.class.getName(), new PK(1L));
-	}
+   @Test
+   @JiraKey("HHH-11202")
+   public void testDefaultCacheKeyEmbeddedId() throws Exception {
+      testId(DefaultCacheKeysFactory.INSTANCE, WithEmbeddedId.class.getName(), new PK(1L));
+   }
 
-	private void testId(CacheKeysFactory cacheKeysFactory, String entityName, Object id) throws Exception {
-		final SessionFactoryImplementor sessionFactory = getSessionFactory(cacheKeysFactory.getClass().getName());
-		final EntityPersister persister = sessionFactory.getRuntimeMetamodels().getMappingMetamodel().getEntityDescriptor(entityName);
-		final Object key = cacheKeysFactory.createEntityKey(
-				id,
-				persister,
-				sessionFactory,
-				null
-		);
+   private void testId(CacheKeysFactory cacheKeysFactory, String entityName, Object id) throws Exception {
+      final SessionFactoryImplementor sessionFactory = getSessionFactory(cacheKeysFactory.getClass().getName());
+      final EntityPersister persister = sessionFactory.getRuntimeMetamodels().getMappingMetamodel().getEntityDescriptor(entityName);
+      final Object key = cacheKeysFactory.createEntityKey(
+            id,
+            persister,
+            sessionFactory,
+            null
+      );
 
-		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		final ObjectOutputStream oos = new ObjectOutputStream(baos);
-		oos.writeObject( key );
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final ObjectOutputStream oos = new ObjectOutputStream(baos);
+      oos.writeObject(key);
 
-		final ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
-		final Object keyClone = ois.readObject();
+      final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+      final Object keyClone = ois.readObject();
 
-		try {
-			if (Version.getVersionString().contains("6.0")) {
-				assertEquals( key, keyClone );
-				assertEquals( keyClone, key );
+      try {
+         if (Version.getVersionString().contains("6.0")) {
+            assertEquals(key, keyClone);
+            assertEquals(keyClone, key);
 
-				assertEquals( key.hashCode(), keyClone.hashCode() );
+            assertEquals(key.hashCode(), keyClone.hashCode());
 
-				final Object idClone = cacheKeysFactory.getEntityId( keyClone );
+            final Object idClone = cacheKeysFactory.getEntityId(keyClone);
 
-				assertEquals( id.hashCode(), idClone.hashCode() );
-				assertEquals( id, idClone );
-				assertEquals( idClone, id );
-				assertTrue( persister.getIdentifierType().isEqual( id, idClone, sessionFactory ) );
-				assertTrue( persister.getIdentifierType().isEqual( idClone, id, sessionFactory ) );
-			} else {
-				assertEquals(key, keyClone);
-				assertEquals(keyClone, key);
+            assertEquals(id.hashCode(), idClone.hashCode());
+            assertEquals(id, idClone);
+            assertEquals(idClone, id);
+            assertTrue(persister.getIdentifierType().isEqual(id, idClone, sessionFactory));
+            assertTrue(persister.getIdentifierType().isEqual(idClone, id, sessionFactory));
+         } else {
+            assertEquals(key, keyClone);
+            assertEquals(keyClone, key);
 
-				assertEquals(key.hashCode(), keyClone.hashCode());
+            assertEquals(key.hashCode(), keyClone.hashCode());
 
-				final Object idClone;
-				if (cacheKeysFactory == SimpleCacheKeysFactory.INSTANCE) {
-					idClone = cacheKeysFactory.getEntityId(keyClone);
-				} else {
-					// DefaultCacheKeysFactory#getEntityId will return a disassembled version
-					try (Session session = sessionFactory.openSession()) {
-						idClone = persister.getIdentifierType().assemble(
-								(Serializable) cacheKeysFactory.getEntityId(keyClone),
-								(SharedSessionContractImplementor) session,
-								null
-						);
-					}
-				}
+            final Object idClone;
+            if (cacheKeysFactory == SimpleCacheKeysFactory.INSTANCE) {
+               idClone = cacheKeysFactory.getEntityId(keyClone);
+            } else {
+               // DefaultCacheKeysFactory#getEntityId will return a disassembled version
+               try (Session session = sessionFactory.openSession()) {
+                  idClone = persister.getIdentifierType().assemble(
+                        (Serializable) cacheKeysFactory.getEntityId(keyClone),
+                        (SharedSessionContractImplementor) session,
+                        null
+                  );
+               }
+            }
 
-				assertEquals(id.hashCode(), idClone.hashCode());
-				assertEquals(id, idClone);
-				assertEquals(idClone, id);
-				assertTrue(persister.getIdentifierType().isEqual(id, idClone, sessionFactory));
-				assertTrue(persister.getIdentifierType().isEqual(idClone, id, sessionFactory));
-			}
-		}
-		finally {
-			sessionFactory.close();
-		}
-	}
+            assertEquals(id.hashCode(), idClone.hashCode());
+            assertEquals(id, idClone);
+            assertEquals(idClone, id);
+            assertTrue(persister.getIdentifierType().isEqual(id, idClone, sessionFactory));
+            assertTrue(persister.getIdentifierType().isEqual(idClone, id, sessionFactory));
+         }
+      } finally {
+         sessionFactory.close();
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/CacheKeysFactoryTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/CacheKeysFactoryTest.java
@@ -30,11 +30,11 @@ public class CacheKeysFactoryTest extends BaseUnitTestCase {
 
    private SessionFactory getSessionFactory(String cacheKeysFactory) {
       Configuration configuration = new Configuration()
-         .setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true")
-         .setProperty(Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName())
-         .setProperty(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional")
-         .setProperty("javax.persistence.sharedCache.mode", "ALL")
-         .setProperty(Environment.HBM2DDL_AUTO, "create-drop");
+            .setProperty(Environment.USE_SECOND_LEVEL_CACHE, "true")
+            .setProperty(Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName())
+            .setProperty(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, "transactional")
+            .setProperty("javax.persistence.sharedCache.mode", "ALL")
+            .setProperty(Environment.HBM2DDL_AUTO, "create-drop");
       if (cacheKeysFactory != null) {
          configuration.setProperty(Environment.CACHE_KEYS_FACTORY, cacheKeysFactory);
       }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/InfinispanRegionFactoryTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/InfinispanRegionFactoryTestCase.java
@@ -50,7 +50,7 @@ import org.junit.Test;
  * @author Galder Zamarreño
  * @since 3.5
  */
-public class InfinispanRegionFactoryTestCase  {
+public class InfinispanRegionFactoryTestCase {
    @Rule
    public InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
 
@@ -62,527 +62,528 @@ public class InfinispanRegionFactoryTestCase  {
    }
 
    @Test
-	public void testConfigurationProcessing() {
-		final String person = "com.acme.Person";
-		final String addresses = "com.acme.Person.addresses";
-		Properties p = createProperties();
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.cfg", "person-cache");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.size", "5000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.wake_up_interval", "2000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.cfg", "person-addresses-cache");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.lifespan", "120000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.max_idle", "60000");
-		p.setProperty("hibernate.cache.infinispan.query.cfg", "my-query-cache");
-		p.setProperty("hibernate.cache.infinispan.query.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.query.expiration.wake_up_interval", "3000");
-		p.setProperty("hibernate.cache.infinispan.query.memory.size", "10000");
+   public void testConfigurationProcessing() {
+      final String person = "com.acme.Person";
+      final String addresses = "com.acme.Person.addresses";
+      Properties p = createProperties();
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.cfg", "person-cache");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.size", "5000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.wake_up_interval", "2000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.cfg", "person-addresses-cache");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.lifespan", "120000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.max_idle", "60000");
+      p.setProperty("hibernate.cache.infinispan.query.cfg", "my-query-cache");
+      p.setProperty("hibernate.cache.infinispan.query.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.query.expiration.wake_up_interval", "3000");
+      p.setProperty("hibernate.cache.infinispan.query.memory.size", "10000");
 
-		TestRegionFactory factory = createRegionFactory(p);
+      TestRegionFactory factory = createRegionFactory(p);
 
-		try {
-			assertEquals("person-cache", factory.getBaseConfiguration(person));
-			Configuration personOverride = factory.getConfigurationOverride(person);
-			assertEquals(5000, personOverride.memory().maxCount());
-			assertEquals(2000, personOverride.expiration().wakeUpInterval());
-			assertEquals(60000, personOverride.expiration().lifespan());
-			assertEquals(30000, personOverride.expiration().maxIdle());
+      try {
+         assertEquals("person-cache", factory.getBaseConfiguration(person));
+         Configuration personOverride = factory.getConfigurationOverride(person);
+         assertEquals(5000, personOverride.memory().maxCount());
+         assertEquals(2000, personOverride.expiration().wakeUpInterval());
+         assertEquals(60000, personOverride.expiration().lifespan());
+         assertEquals(30000, personOverride.expiration().maxIdle());
 
-			assertEquals("person-addresses-cache", factory.getBaseConfiguration(addresses));
-			Configuration addressesOverride = factory.getConfigurationOverride(addresses);
-			assertEquals(120000, addressesOverride.expiration().lifespan());
-			assertEquals(60000, addressesOverride.expiration().maxIdle());
+         assertEquals("person-addresses-cache", factory.getBaseConfiguration(addresses));
+         Configuration addressesOverride = factory.getConfigurationOverride(addresses);
+         assertEquals(120000, addressesOverride.expiration().lifespan());
+         assertEquals(60000, addressesOverride.expiration().maxIdle());
 
-			assertEquals("my-query-cache", factory.getBaseConfiguration(InfinispanProperties.QUERY));
-			Configuration queryOverride = factory.getConfigurationOverride(InfinispanProperties.QUERY);
-			assertEquals(10000, queryOverride.memory().maxCount());
-			assertEquals(3000, queryOverride.expiration().wakeUpInterval());
-		} finally {
-			factory.stop();
-		}
-	}
+         assertEquals("my-query-cache", factory.getBaseConfiguration(InfinispanProperties.QUERY));
+         Configuration queryOverride = factory.getConfigurationOverride(InfinispanProperties.QUERY);
+         assertEquals(10000, queryOverride.memory().maxCount());
+         assertEquals(3000, queryOverride.expiration().wakeUpInterval());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildEntityCollectionRegionsPersonPlusEntityCollectionOverrides() {
-		final String person = "com.acme.Person";
-		final String address = "com.acme.Address";
-		final String car = "com.acme.Car";
-		final String addresses = "com.acme.Person.addresses";
-		final String parts = "com.acme.Car.parts";
-		Properties p = createProperties();
-		// First option, cache defined for entity and overrides for generic entity data type and entity itself.
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.cfg", "person-cache");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.size", "5000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.wake_up_interval", "2000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
-		p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.size", "20000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.cfg", "addresses-cache");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.memory.size", "5500");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.wake_up_interval", "2500");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.lifespan", "65000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.max_idle", "35000");
-		p.setProperty("hibernate.cache.infinispan.collection.cfg", "mycollection-cache");
-		p.setProperty("hibernate.cache.infinispan.collection.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.collection.expiration.wake_up_interval", "3500");
-		p.setProperty("hibernate.cache.infinispan.collection.memory.size", "25000");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			EmbeddedCacheManager manager = factory.getCacheManager();
-			assertFalse(manager.getCacheManagerConfiguration().jmx().enabled());
-			assertNotNull(factory.getBaseConfiguration(person));
-			assertFalse(isDefinedCache(factory, person));
-			assertNotNull(factory.getBaseConfiguration(addresses));
-			assertFalse(isDefinedCache(factory, addresses));
-			assertNull(factory.getBaseConfiguration(address));
-			assertNull(factory.getBaseConfiguration(parts));
-			AdvancedCache cache;
+   @Test
+   public void testBuildEntityCollectionRegionsPersonPlusEntityCollectionOverrides() {
+      final String person = "com.acme.Person";
+      final String address = "com.acme.Address";
+      final String car = "com.acme.Car";
+      final String addresses = "com.acme.Person.addresses";
+      final String parts = "com.acme.Car.parts";
+      Properties p = createProperties();
+      // First option, cache defined for entity and overrides for generic entity data type and entity itself.
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.cfg", "person-cache");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.size", "5000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.wake_up_interval", "2000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
+      p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.size", "20000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.cfg", "addresses-cache");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.memory.size", "5500");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.wake_up_interval", "2500");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.lifespan", "65000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.addresses.expiration.max_idle", "35000");
+      p.setProperty("hibernate.cache.infinispan.collection.cfg", "mycollection-cache");
+      p.setProperty("hibernate.cache.infinispan.collection.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.collection.expiration.wake_up_interval", "3500");
+      p.setProperty("hibernate.cache.infinispan.collection.memory.size", "25000");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         EmbeddedCacheManager manager = factory.getCacheManager();
+         assertFalse(manager.getCacheManagerConfiguration().jmx().enabled());
+         assertNotNull(factory.getBaseConfiguration(person));
+         assertFalse(isDefinedCache(factory, person));
+         assertNotNull(factory.getBaseConfiguration(addresses));
+         assertFalse(isDefinedCache(factory, addresses));
+         assertNull(factory.getBaseConfiguration(address));
+         assertNull(factory.getBaseConfiguration(parts));
+         AdvancedCache cache;
 
          InfinispanBaseRegion region = factory.buildEntityRegion(person, AccessType.TRANSACTIONAL);
-			assertTrue(isDefinedCache(factory, person));
-			cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals(2000, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(5000, cacheCfg.memory().maxCount());
-			assertEquals(60000, cacheCfg.expiration().lifespan());
-			assertEquals(30000, cacheCfg.expiration().maxIdle());
-			assertFalse(cacheCfg.statistics().enabled());
+         assertTrue(isDefinedCache(factory, person));
+         cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(2000, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(5000, cacheCfg.memory().maxCount());
+         assertEquals(60000, cacheCfg.expiration().lifespan());
+         assertEquals(30000, cacheCfg.expiration().maxIdle());
+         assertFalse(cacheCfg.statistics().enabled());
 
          region = factory.buildEntityRegion(address, AccessType.TRANSACTIONAL);
-			assertTrue(isDefinedCache(factory, person));
-			cache = region.getCache();
-			cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(20000, cacheCfg.memory().maxCount());
-			assertFalse(cacheCfg.statistics().enabled());
+         assertTrue(isDefinedCache(factory, person));
+         cache = region.getCache();
+         cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(20000, cacheCfg.memory().maxCount());
+         assertFalse(cacheCfg.statistics().enabled());
 
          region = factory.buildEntityRegion(car, AccessType.TRANSACTIONAL);
-			assertTrue(isDefinedCache(factory, person));
-			cache = region.getCache();
-			cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(20000, cacheCfg.memory().maxCount());
-			assertFalse(cacheCfg.statistics().enabled());
+         assertTrue(isDefinedCache(factory, person));
+         cache = region.getCache();
+         cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(20000, cacheCfg.memory().maxCount());
+         assertFalse(cacheCfg.statistics().enabled());
 
-			InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion(addresses, AccessType.TRANSACTIONAL);
-			assertTrue(isDefinedCache(factory, person));
+         InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion(addresses, AccessType.TRANSACTIONAL);
+         assertTrue(isDefinedCache(factory, person));
 
-			cache = collectionRegion .getCache();
-			cacheCfg = cache.getCacheConfiguration();
-			assertEquals(2500, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(5500, cacheCfg.memory().maxCount());
-			assertEquals(65000, cacheCfg.expiration().lifespan());
-			assertEquals(35000, cacheCfg.expiration().maxIdle());
-			assertFalse(cacheCfg.statistics().enabled());
+         cache = collectionRegion.getCache();
+         cacheCfg = cache.getCacheConfiguration();
+         assertEquals(2500, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(5500, cacheCfg.memory().maxCount());
+         assertEquals(65000, cacheCfg.expiration().lifespan());
+         assertEquals(35000, cacheCfg.expiration().maxIdle());
+         assertFalse(cacheCfg.statistics().enabled());
 
-			collectionRegion = factory.buildCollectionRegion(parts, AccessType.TRANSACTIONAL);
-			assertTrue(isDefinedCache(factory, addresses));
-			cache = collectionRegion.getCache();
-			cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3500, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(25000, cacheCfg.memory().maxCount());
-			assertFalse(cacheCfg.statistics().enabled());
+         collectionRegion = factory.buildCollectionRegion(parts, AccessType.TRANSACTIONAL);
+         assertTrue(isDefinedCache(factory, addresses));
+         cache = collectionRegion.getCache();
+         cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3500, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(25000, cacheCfg.memory().maxCount());
+         assertFalse(cacheCfg.statistics().enabled());
 
-			collectionRegion = factory.buildCollectionRegion(parts, AccessType.TRANSACTIONAL);
-			assertTrue(isDefinedCache(factory, addresses));
-			cache = collectionRegion.getCache();
-			cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3500, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(25000, cacheCfg.memory().maxCount());
-			assertFalse(cacheCfg.statistics().enabled());
-		} finally {
-			factory.stop();
-		}
-	}
+         collectionRegion = factory.buildCollectionRegion(parts, AccessType.TRANSACTIONAL);
+         assertTrue(isDefinedCache(factory, addresses));
+         cache = collectionRegion.getCache();
+         cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3500, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(25000, cacheCfg.memory().maxCount());
+         assertFalse(cacheCfg.statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildEntityCollectionRegionOverridesOnly() {
-		final String address = "com.acme.Address";
-		final String personAddressses = "com.acme.Person.addresses";
-		AdvancedCache cache;
-		Properties p = createProperties();
-		p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.size", "30000");
-		p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
-		p.setProperty("hibernate.cache.infinispan.collection.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.collection.memory.size", "35000");
-		p.setProperty("hibernate.cache.infinispan.collection.expiration.wake_up_interval", "3500");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			factory.getCacheManager();
-			InfinispanBaseRegion region = factory.buildEntityRegion(address, AccessType.TRANSACTIONAL);
-			assertNull(factory.getBaseConfiguration(address));
-			cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(30000, cacheCfg.memory().maxCount());
-			// Max idle value comes from base XML configuration
-			assertEquals(100000, cacheCfg.expiration().maxIdle());
+   @Test
+   public void testBuildEntityCollectionRegionOverridesOnly() {
+      final String address = "com.acme.Address";
+      final String personAddressses = "com.acme.Person.addresses";
+      AdvancedCache cache;
+      Properties p = createProperties();
+      p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.size", "30000");
+      p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
+      p.setProperty("hibernate.cache.infinispan.collection.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.collection.memory.size", "35000");
+      p.setProperty("hibernate.cache.infinispan.collection.expiration.wake_up_interval", "3500");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         factory.getCacheManager();
+         InfinispanBaseRegion region = factory.buildEntityRegion(address, AccessType.TRANSACTIONAL);
+         assertNull(factory.getBaseConfiguration(address));
+         cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(30000, cacheCfg.memory().maxCount());
+         // Max idle value comes from base XML configuration
+         assertEquals(100000, cacheCfg.expiration().maxIdle());
 
-			InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion(personAddressses, AccessType.TRANSACTIONAL);
-			assertNull(factory.getBaseConfiguration(personAddressses));
-			cache = collectionRegion.getCache();
-			cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3500, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(35000, cacheCfg.memory().maxCount());
-			assertEquals(100000, cacheCfg.expiration().maxIdle());
-		} finally {
-			factory.stop();
-		}
-	}
-	@Test
-	public void testBuildEntityRegionPersonPlusEntityOverridesWithoutCfg() {
-		final String person = "com.acme.Person";
-		Properties p = createProperties();
-		// Third option, no cache defined for entity and overrides for generic entity data type and entity itself.
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
-		p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "FIFO");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.size", "10000");
-		p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			factory.getCacheManager();
-			assertFalse( isDefinedCache(factory, person ) );
-			InfinispanBaseRegion region = factory.buildEntityRegion(person, AccessType.TRANSACTIONAL);
-			assertTrue( isDefinedCache(factory, person ) );
-			AdvancedCache cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
-			assertEquals(10000, cacheCfg.memory().maxCount());
-			assertEquals(60000, cacheCfg.expiration().lifespan());
-			assertEquals(30000, cacheCfg.expiration().maxIdle());
-		} finally {
-			factory.stop();
-		}
-	}
+         InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion(personAddressses, AccessType.TRANSACTIONAL);
+         assertNull(factory.getBaseConfiguration(personAddressses));
+         cache = collectionRegion.getCache();
+         cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3500, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(35000, cacheCfg.memory().maxCount());
+         assertEquals(100000, cacheCfg.expiration().maxIdle());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildImmutableEntityRegion() {
-		AdvancedCache cache;
-		Properties p = new Properties();
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			factory.getCacheManager();
-			InfinispanBaseRegion region = factory.buildEntityRegion("com.acme.Address", AccessType.TRANSACTIONAL);
-			assertNull( factory.getBaseConfiguration( "com.acme.Address" ) );
-			cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals("Immutable entity should get non-transactional cache", TransactionMode.NON_TRANSACTIONAL, cacheCfg.transaction().transactionMode());
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildEntityRegionPersonPlusEntityOverridesWithoutCfg() {
+      final String person = "com.acme.Person";
+      Properties p = createProperties();
+      // Third option, no cache defined for entity and overrides for generic entity data type and entity itself.
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
+      p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "FIFO");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.size", "10000");
+      p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         factory.getCacheManager();
+         assertFalse(isDefinedCache(factory, person));
+         InfinispanBaseRegion region = factory.buildEntityRegion(person, AccessType.TRANSACTIONAL);
+         assertTrue(isDefinedCache(factory, person));
+         AdvancedCache cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(3000, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(10000, cacheCfg.memory().maxCount());
+         assertEquals(60000, cacheCfg.expiration().lifespan());
+         assertEquals(30000, cacheCfg.expiration().maxIdle());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testTimestampValidation() throws IOException {
-		final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-		Properties p = createProperties();
+   @Test
+   public void testBuildImmutableEntityRegion() {
+      AdvancedCache cache;
+      Properties p = new Properties();
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         factory.getCacheManager();
+         InfinispanBaseRegion region = factory.buildEntityRegion("com.acme.Address", AccessType.TRANSACTIONAL);
+         assertNull(factory.getBaseConfiguration("com.acme.Address"));
+         cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals("Immutable entity should get non-transactional cache", TransactionMode.NON_TRANSACTIONAL, cacheCfg.transaction().transactionMode());
+      } finally {
+         factory.stop();
+      }
+   }
+
+   @Test
+   public void testTimestampValidation() throws IOException {
+      final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+      Properties p = createProperties();
       URL url = FileLookupFactory.newInstance().lookupFileLocation(DEF_INFINISPAN_CONFIG_RESOURCE, getClass().getClassLoader());
       ConfigurationBuilderHolder cbh = new ParserRegistry().parse(url);
-      ConfigurationBuilder builder = cbh.getNamedConfigurationBuilders().get( DEF_TIMESTAMPS_RESOURCE );
-		builder.clustering().cacheMode(CacheMode.INVALIDATION_SYNC);
+      ConfigurationBuilder builder = cbh.getNamedConfigurationBuilders().get(DEF_TIMESTAMPS_RESOURCE);
+      builder.clustering().cacheMode(CacheMode.INVALIDATION_SYNC);
       DefaultCacheManager manager = new DefaultCacheManager(cbh, true);
-		try {
-			TestRegionFactory factory = createRegionFactory(manager, p, null);
+      try {
+         TestRegionFactory factory = createRegionFactory(manager, p, null);
          factory.start(serviceRegistry, p);
-			// Should have failed saying that invalidation is not allowed for timestamp caches.
-			Exceptions.expectException(CacheException.class, () -> factory.buildTimestampsRegion(timestamps));
-		} finally {
-			TestingUtil.killCacheManagers( manager );
-		}
-	}
+         // Should have failed saying that invalidation is not allowed for timestamp caches.
+         Exceptions.expectException(CacheException.class, () -> factory.buildTimestampsRegion(timestamps));
+      } finally {
+         TestingUtil.killCacheManagers(manager);
+      }
+   }
 
-	@Test
-	public void testBuildDefaultTimestampsRegion() {
-		final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-		Properties p = createProperties();
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			assertTrue(isDefinedCache(factory, DEF_TIMESTAMPS_RESOURCE));
-			InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
-			AdvancedCache cache = region.getCache();
-			assertEquals(timestamps, cache.getName());
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals( CacheMode.REPL_ASYNC, cacheCfg.clustering().cacheMode() );
-			assertFalse( cacheCfg.statistics().enabled() );
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildDefaultTimestampsRegion() {
+      final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+      Properties p = createProperties();
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         assertTrue(isDefinedCache(factory, DEF_TIMESTAMPS_RESOURCE));
+         InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
+         AdvancedCache cache = region.getCache();
+         assertEquals(timestamps, cache.getName());
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(CacheMode.REPL_ASYNC, cacheCfg.clustering().cacheMode());
+         assertFalse(cacheCfg.statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	protected boolean isDefinedCache(TestRegionFactory factory, String cacheName) {
-		return factory.getCacheManager().getCacheConfiguration(cacheName) != null;
-	}
+   protected boolean isDefinedCache(TestRegionFactory factory, String cacheName) {
+      return factory.getCacheManager().getCacheConfiguration(cacheName) != null;
+   }
 
-	@Test
-	public void testBuildDiffCacheNameTimestampsRegion() {
-		final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-		final String unrecommendedTimestamps = "unrecommended-timestamps";
-		Properties p = createProperties();
-		p.setProperty( TIMESTAMPS_CACHE_RESOURCE_PROP, unrecommendedTimestamps);
-		TestRegionFactory factory = createRegionFactory(p, m -> {
-			ConfigurationBuilder builder = new ConfigurationBuilder();
-			builder.clustering().stateTransfer().fetchInMemoryState(true);
-			builder.clustering().cacheMode( CacheMode.REPL_SYNC );
-			m.defineConfiguration(unrecommendedTimestamps, builder.build() );
-		});
-		try {
-			assertEquals(unrecommendedTimestamps, factory.getBaseConfiguration(InfinispanProperties.TIMESTAMPS));
-			InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
-			AdvancedCache cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals(CacheMode.REPL_SYNC, cacheCfg.clustering().cacheMode());
+   @Test
+   public void testBuildDiffCacheNameTimestampsRegion() {
+      final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+      final String unrecommendedTimestamps = "unrecommended-timestamps";
+      Properties p = createProperties();
+      p.setProperty(TIMESTAMPS_CACHE_RESOURCE_PROP, unrecommendedTimestamps);
+      TestRegionFactory factory = createRegionFactory(p, m -> {
+         ConfigurationBuilder builder = new ConfigurationBuilder();
+         builder.clustering().stateTransfer().fetchInMemoryState(true);
+         builder.clustering().cacheMode(CacheMode.REPL_SYNC);
+         m.defineConfiguration(unrecommendedTimestamps, builder.build());
+      });
+      try {
+         assertEquals(unrecommendedTimestamps, factory.getBaseConfiguration(InfinispanProperties.TIMESTAMPS));
+         InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
+         AdvancedCache cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(CacheMode.REPL_SYNC, cacheCfg.clustering().cacheMode());
          assertNotSame(StorageType.OFF_HEAP, cacheCfg.memory().storage());
-			assertFalse(cacheCfg.statistics().enabled());
-		} finally {
-			factory.stop();
-		}
-	}
+         assertFalse(cacheCfg.statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildTimestampsRegionWithCacheNameOverride() {
-		final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-		final String myTimestampsCache = "mytimestamps-cache";
-		Properties p = createProperties();
-		p.setProperty(TIMESTAMPS_CACHE_RESOURCE_PROP, myTimestampsCache);
-		TestRegionFactory factory = createRegionFactory(p, m -> {
-			ClusteringConfigurationBuilder builder = new ConfigurationBuilder().clustering().cacheMode(CacheMode.LOCAL);
-			m.defineConfiguration(myTimestampsCache, builder.build());
-		});
-		try {
-			InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
-			assertTrue(isDefinedCache(factory, timestamps));
-			// default timestamps cache is async replicated
-			assertEquals(CacheMode.LOCAL, region.getCache().getCacheConfiguration().clustering().cacheMode());
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildTimestampsRegionWithCacheNameOverride() {
+      final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+      final String myTimestampsCache = "mytimestamps-cache";
+      Properties p = createProperties();
+      p.setProperty(TIMESTAMPS_CACHE_RESOURCE_PROP, myTimestampsCache);
+      TestRegionFactory factory = createRegionFactory(p, m -> {
+         ClusteringConfigurationBuilder builder = new ConfigurationBuilder().clustering().cacheMode(CacheMode.LOCAL);
+         m.defineConfiguration(myTimestampsCache, builder.build());
+      });
+      try {
+         InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
+         assertTrue(isDefinedCache(factory, timestamps));
+         // default timestamps cache is async replicated
+         assertEquals(CacheMode.LOCAL, region.getCache().getCacheConfiguration().clustering().cacheMode());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildTimestampsRegionWithFifoEvictionOverride() {
-		final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-		final String myTimestampsCache = "mytimestamps-cache";
-		Properties p = createProperties();
-		p.setProperty(TIMESTAMPS_CACHE_RESOURCE_PROP, myTimestampsCache);
-		p.setProperty("hibernate.cache.infinispan.timestamps.memory.eviction.type", "FIFO");
-		p.setProperty("hibernate.cache.infinispan.timestamps.memory.size", "10000");
-		p.setProperty("hibernate.cache.infinispan.timestamps.expiration.wake_up_interval", "3000");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			Exceptions.expectException(CacheException.class, () -> factory.buildTimestampsRegion(timestamps));
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildTimestampsRegionWithFifoEvictionOverride() {
+      final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+      final String myTimestampsCache = "mytimestamps-cache";
+      Properties p = createProperties();
+      p.setProperty(TIMESTAMPS_CACHE_RESOURCE_PROP, myTimestampsCache);
+      p.setProperty("hibernate.cache.infinispan.timestamps.memory.eviction.type", "FIFO");
+      p.setProperty("hibernate.cache.infinispan.timestamps.memory.size", "10000");
+      p.setProperty("hibernate.cache.infinispan.timestamps.expiration.wake_up_interval", "3000");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         Exceptions.expectException(CacheException.class, () -> factory.buildTimestampsRegion(timestamps));
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildTimestampsRegionWithNoneEvictionOverride() {
-		final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-		final String timestampsNoEviction = "timestamps-no-eviction";
-		Properties p = createProperties();
-		p.setProperty("hibernate.cache.infinispan.timestamps.cfg", timestampsNoEviction);
-		p.setProperty("hibernate.cache.infinispan.timestamps.memory.size", "0");
-		p.setProperty("hibernate.cache.infinispan.timestamps.expiration.wake_up_interval", "3000");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
-			assertTrue( isDefinedCache(factory, timestamps) );
-			assertEquals(3000, region.getCache().getCacheConfiguration().expiration().wakeUpInterval());
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildTimestampsRegionWithNoneEvictionOverride() {
+      final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+      final String timestampsNoEviction = "timestamps-no-eviction";
+      Properties p = createProperties();
+      p.setProperty("hibernate.cache.infinispan.timestamps.cfg", timestampsNoEviction);
+      p.setProperty("hibernate.cache.infinispan.timestamps.memory.size", "0");
+      p.setProperty("hibernate.cache.infinispan.timestamps.expiration.wake_up_interval", "3000");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         InfinispanBaseRegion region = factory.buildTimestampsRegion(timestamps);
+         assertTrue(isDefinedCache(factory, timestamps));
+         assertEquals(3000, region.getCache().getCacheConfiguration().expiration().wakeUpInterval());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildQueryRegion() {
-		final String query = "org.hibernate.cache.internal.StandardQueryCache";
-		Properties p = createProperties();
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			assertTrue(isDefinedCache(factory, "local-query"));
-			InfinispanBaseRegion region = factory.buildQueryResultsRegion(query);
-			AdvancedCache cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals( CacheMode.LOCAL, cacheCfg.clustering().cacheMode() );
-			assertFalse( cacheCfg.statistics().enabled() );
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildQueryRegion() {
+      final String query = "org.hibernate.cache.internal.StandardQueryCache";
+      Properties p = createProperties();
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         assertTrue(isDefinedCache(factory, "local-query"));
+         InfinispanBaseRegion region = factory.buildQueryResultsRegion(query);
+         AdvancedCache cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(CacheMode.LOCAL, cacheCfg.clustering().cacheMode());
+         assertFalse(cacheCfg.statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testBuildQueryRegionWithCustomRegionName() {
-		final String queryRegionName = "myquery";
-		Properties p = createProperties();
-		p.setProperty("hibernate.cache.infinispan.myquery.cfg", "timestamps-none-eviction");
-		p.setProperty("hibernate.cache.infinispan.myquery.memory.eviction.type", "MEMORY");
-		p.setProperty("hibernate.cache.infinispan.myquery.expiration.wake_up_interval", "2222");
-		p.setProperty("hibernate.cache.infinispan.myquery.memory.size", "11111");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			assertTrue(isDefinedCache(factory, "local-query"));
-			InfinispanBaseRegion region = factory.buildQueryResultsRegion(queryRegionName);
-			assertNotNull(factory.getBaseConfiguration(queryRegionName));
-			assertTrue(isDefinedCache(factory, queryRegionName));
-			AdvancedCache cache = region.getCache();
-			Configuration cacheCfg = cache.getCacheConfiguration();
-			assertEquals(2222, cacheCfg.expiration().wakeUpInterval());
-			assertEquals( 11111, cacheCfg.memory().maxCount() );
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testBuildQueryRegionWithCustomRegionName() {
+      final String queryRegionName = "myquery";
+      Properties p = createProperties();
+      p.setProperty("hibernate.cache.infinispan.myquery.cfg", "timestamps-none-eviction");
+      p.setProperty("hibernate.cache.infinispan.myquery.memory.eviction.type", "MEMORY");
+      p.setProperty("hibernate.cache.infinispan.myquery.expiration.wake_up_interval", "2222");
+      p.setProperty("hibernate.cache.infinispan.myquery.memory.size", "11111");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         assertTrue(isDefinedCache(factory, "local-query"));
+         InfinispanBaseRegion region = factory.buildQueryResultsRegion(queryRegionName);
+         assertNotNull(factory.getBaseConfiguration(queryRegionName));
+         assertTrue(isDefinedCache(factory, queryRegionName));
+         AdvancedCache cache = region.getCache();
+         Configuration cacheCfg = cache.getCacheConfiguration();
+         assertEquals(2222, cacheCfg.expiration().wakeUpInterval());
+         assertEquals(11111, cacheCfg.memory().maxCount());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testEnableStatistics() {
-		Properties p = createProperties();
-		p.setProperty("hibernate.cache.infinispan.statistics", "true");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
-		p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "FIFO");
-		p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.size", "10000");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			EmbeddedCacheManager manager = factory.getCacheManager();
-			assertTrue(manager.getCacheManagerConfiguration().jmx().enabled());
-			InfinispanBaseRegion region = factory.buildEntityRegion("com.acme.Address", AccessType.TRANSACTIONAL);
-			AdvancedCache cache = region.getCache();
-			assertTrue(cache.getCacheConfiguration().statistics().enabled());
+   @Test
+   public void testEnableStatistics() {
+      Properties p = createProperties();
+      p.setProperty("hibernate.cache.infinispan.statistics", "true");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
+      p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "FIFO");
+      p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.size", "10000");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         EmbeddedCacheManager manager = factory.getCacheManager();
+         assertTrue(manager.getCacheManagerConfiguration().jmx().enabled());
+         InfinispanBaseRegion region = factory.buildEntityRegion("com.acme.Address", AccessType.TRANSACTIONAL);
+         AdvancedCache cache = region.getCache();
+         assertTrue(cache.getCacheConfiguration().statistics().enabled());
 
-			region = factory.buildEntityRegion("com.acme.Person", AccessType.TRANSACTIONAL);
-			cache = region.getCache();
-			assertTrue(cache.getCacheConfiguration().statistics().enabled());
+         region = factory.buildEntityRegion("com.acme.Person", AccessType.TRANSACTIONAL);
+         cache = region.getCache();
+         assertTrue(cache.getCacheConfiguration().statistics().enabled());
 
-			final String query = "org.hibernate.cache.internal.StandardQueryCache";
-			InfinispanBaseRegion queryRegion = factory.buildQueryResultsRegion(query);
-			cache = queryRegion.getCache();
-			assertTrue(cache.getCacheConfiguration().statistics().enabled());
+         final String query = "org.hibernate.cache.internal.StandardQueryCache";
+         InfinispanBaseRegion queryRegion = factory.buildQueryResultsRegion(query);
+         cache = queryRegion.getCache();
+         assertTrue(cache.getCacheConfiguration().statistics().enabled());
 
-			final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-			InfinispanBaseRegion timestampsRegion = factory.buildTimestampsRegion(timestamps);
-			cache = timestampsRegion.getCache();
-			assertTrue(cache.getCacheConfiguration().statistics().enabled());
+         final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+         InfinispanBaseRegion timestampsRegion = factory.buildTimestampsRegion(timestamps);
+         cache = timestampsRegion.getCache();
+         assertTrue(cache.getCacheConfiguration().statistics().enabled());
 
-			InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion("com.acme.Person.addresses", AccessType.TRANSACTIONAL);
-			cache = collectionRegion.getCache();
-			assertTrue(cache.getCacheConfiguration().statistics().enabled());
-		} finally {
-			factory.stop();
-		}
-	}
+         InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion("com.acme.Person.addresses", AccessType.TRANSACTIONAL);
+         cache = collectionRegion.getCache();
+         assertTrue(cache.getCacheConfiguration().statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testDisableStatistics() {
-		Properties p = createProperties();
-		p.setProperty("hibernate.cache.infinispan.statistics", "false");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
-		p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
-		p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "FIFO");
-		p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
-		p.setProperty("hibernate.cache.infinispan.entity.memory.size", "10000");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			InfinispanBaseRegion region = factory.buildEntityRegion("com.acme.Address", AccessType.TRANSACTIONAL);
-			AdvancedCache cache = region.getCache();
-			assertFalse( cache.getCacheConfiguration().statistics().enabled() );
+   @Test
+   public void testDisableStatistics() {
+      Properties p = createProperties();
+      p.setProperty("hibernate.cache.infinispan.statistics", "false");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.lifespan", "60000");
+      p.setProperty("hibernate.cache.infinispan.com.acme.Person.expiration.max_idle", "30000");
+      p.setProperty("hibernate.cache.infinispan.entity.cfg", "myentity-cache");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.eviction.type", "FIFO");
+      p.setProperty("hibernate.cache.infinispan.entity.expiration.wake_up_interval", "3000");
+      p.setProperty("hibernate.cache.infinispan.entity.memory.size", "10000");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         InfinispanBaseRegion region = factory.buildEntityRegion("com.acme.Address", AccessType.TRANSACTIONAL);
+         AdvancedCache cache = region.getCache();
+         assertFalse(cache.getCacheConfiguration().statistics().enabled());
 
-			region = factory.buildEntityRegion("com.acme.Person", AccessType.TRANSACTIONAL);
-			cache = region.getCache();
-			assertFalse( cache.getCacheConfiguration().statistics().enabled() );
+         region = factory.buildEntityRegion("com.acme.Person", AccessType.TRANSACTIONAL);
+         cache = region.getCache();
+         assertFalse(cache.getCacheConfiguration().statistics().enabled());
 
-			final String query = "org.hibernate.cache.internal.StandardQueryCache";
-			InfinispanBaseRegion queryRegion = factory.buildQueryResultsRegion(query);
-			cache = queryRegion.getCache();
-			assertFalse( cache.getCacheConfiguration().statistics().enabled() );
+         final String query = "org.hibernate.cache.internal.StandardQueryCache";
+         InfinispanBaseRegion queryRegion = factory.buildQueryResultsRegion(query);
+         cache = queryRegion.getCache();
+         assertFalse(cache.getCacheConfiguration().statistics().enabled());
 
-			final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
-			InfinispanBaseRegion timestampsRegion = factory.buildTimestampsRegion(timestamps);
-			cache = timestampsRegion.getCache();
-			assertFalse( cache.getCacheConfiguration().statistics().enabled() );
+         final String timestamps = "org.hibernate.cache.spi.UpdateTimestampsCache";
+         InfinispanBaseRegion timestampsRegion = factory.buildTimestampsRegion(timestamps);
+         cache = timestampsRegion.getCache();
+         assertFalse(cache.getCacheConfiguration().statistics().enabled());
 
-			InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion("com.acme.Person.addresses", AccessType.TRANSACTIONAL);
-			cache = collectionRegion.getCache();
-			assertFalse( cache.getCacheConfiguration().statistics().enabled() );
-		} finally {
-			factory.stop();
-		}
-	}
+         InfinispanBaseRegion collectionRegion = factory.buildCollectionRegion("com.acme.Person.addresses", AccessType.TRANSACTIONAL);
+         cache = collectionRegion.getCache();
+         assertFalse(cache.getCacheConfiguration().statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testDefaultPendingPutsCache() {
-		Properties p = createProperties();
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			Configuration ppConfig = factory.getCacheManager().getCacheConfiguration(DEF_PENDING_PUTS_RESOURCE);
+   @Test
+   public void testDefaultPendingPutsCache() {
+      Properties p = createProperties();
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         Configuration ppConfig = factory.getCacheManager().getCacheConfiguration(DEF_PENDING_PUTS_RESOURCE);
 
-			assertTrue(ppConfig.isTemplate());
-			assertFalse(ppConfig.clustering().cacheMode().isClustered());
-			assertTrue(ppConfig.simpleCache());
-			assertEquals(TransactionMode.NON_TRANSACTIONAL, ppConfig.transaction().transactionMode());
-			assertEquals(60000, ppConfig.expiration().maxIdle());
-			assertFalse(ppConfig.statistics().enabled());
-		} finally {
-			factory.stop();
-		}
-	}
+         assertTrue(ppConfig.isTemplate());
+         assertFalse(ppConfig.clustering().cacheMode().isClustered());
+         assertTrue(ppConfig.simpleCache());
+         assertEquals(TransactionMode.NON_TRANSACTIONAL, ppConfig.transaction().transactionMode());
+         assertEquals(60000, ppConfig.expiration().maxIdle());
+         assertFalse(ppConfig.statistics().enabled());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	@Test
-	public void testCustomPendingPutsCache() {
-		Properties p = createProperties();
-		p.setProperty(INFINISPAN_CONFIG_RESOURCE_PROP, "alternative-infinispan-configs.xml");
-		TestRegionFactory factory = createRegionFactory(p);
-		try {
-			Configuration ppConfig = factory.getCacheManager().getCacheConfiguration(DEF_PENDING_PUTS_RESOURCE);
-			assertEquals(120000, ppConfig.expiration().maxIdle());
-		} finally {
-			factory.stop();
-		}
-	}
+   @Test
+   public void testCustomPendingPutsCache() {
+      Properties p = createProperties();
+      p.setProperty(INFINISPAN_CONFIG_RESOURCE_PROP, "alternative-infinispan-configs.xml");
+      TestRegionFactory factory = createRegionFactory(p);
+      try {
+         Configuration ppConfig = factory.getCacheManager().getCacheConfiguration(DEF_PENDING_PUTS_RESOURCE);
+         assertEquals(120000, ppConfig.expiration().maxIdle());
+      } finally {
+         factory.stop();
+      }
+   }
 
-	private TestRegionFactory createRegionFactory(Properties p) {
-		return createRegionFactory(null, p, null);
-	}
+   private TestRegionFactory createRegionFactory(Properties p) {
+      return createRegionFactory(null, p, null);
+   }
 
-	private TestRegionFactory createRegionFactory(Properties p,
-		   Consumer<EmbeddedCacheManager> hook) {
-		return createRegionFactory(null, p, hook);
-	}
+   private TestRegionFactory createRegionFactory(Properties p,
+                                                 Consumer<EmbeddedCacheManager> hook) {
+      return createRegionFactory(null, p, hook);
+   }
 
-	private TestRegionFactory createRegionFactory(final EmbeddedCacheManager manager, Properties p,
-		   Consumer<EmbeddedCacheManager> hook) {
-		if (manager != null) {
-			p.put(TestRegionFactory.MANAGER, manager);
-		}
-		if (hook != null) {
-			p.put(TestRegionFactory.AFTER_MANAGER_CREATED, hook);
-		}
-		final TestRegionFactory factory = TestRegionFactoryProvider.load().create(p);
-		factory.start(serviceRegistry, p);
-		return factory;
-	}
+   private TestRegionFactory createRegionFactory(final EmbeddedCacheManager manager, Properties p,
+                                                 Consumer<EmbeddedCacheManager> hook) {
+      if (manager != null) {
+         p.put(TestRegionFactory.MANAGER, manager);
+      }
+      if (hook != null) {
+         p.put(TestRegionFactory.AFTER_MANAGER_CREATED, hook);
+      }
+      final TestRegionFactory factory = TestRegionFactoryProvider.load().create(p);
+      factory.start(serviceRegistry, p);
+      return factory;
+   }
 
-	private static Properties createProperties() {
-		final Properties properties = new Properties();
-		// If configured in the environment, add configuration file name to properties.
-		final String cfgFileName =
-				  (String) Environment.getProperties().get( INFINISPAN_CONFIG_RESOURCE_PROP );
-		if ( cfgFileName != null ) {
-			properties.put( INFINISPAN_CONFIG_RESOURCE_PROP, cfgFileName );
-		}
-		return properties;
-	}
+   private static Properties createProperties() {
+      final Properties properties = new Properties();
+      // If configured in the environment, add configuration file name to properties.
+      final String cfgFileName =
+            (String) Environment.getProperties().get(INFINISPAN_CONFIG_RESOURCE_PROP);
+      if (cfgFileName != null) {
+         properties.put(INFINISPAN_CONFIG_RESOURCE_PROP, cfgFileName);
+      }
+      return properties;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/NodeEnvironment.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/NodeEnvironment.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-
 import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.AccessType;
 import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
@@ -71,7 +70,7 @@ public class NodeEnvironment {
 
    public void prepare() throws Exception {
       serviceRegistry = ssrb.build();
-      regionFactory = CacheTestUtil.startRegionFactory( serviceRegistry );
+      regionFactory = CacheTestUtil.startRegionFactory(serviceRegistry);
    }
 
    public void release() throws Exception {
@@ -96,18 +95,16 @@ public class NodeEnvironment {
             }
             collectionRegionMap.clear();
          }
-      }
-      finally {
+      } finally {
          try {
             if (regionFactory != null) {
                // Currently the RegionFactory is shutdown by its registration
                // with the CacheTestSetup from CacheTestUtil when built
                regionFactory.stop();
             }
-         }
-         finally {
+         } finally {
             if (serviceRegistry != null) {
-               StandardServiceRegistryBuilder.destroy( serviceRegistry );
+               StandardServiceRegistryBuilder.destroy(serviceRegistry);
             }
          }
       }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/access/PutFromLoadValidatorUnitTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/access/PutFromLoadValidatorUnitTest.java
@@ -57,301 +57,310 @@ import jakarta.transaction.TransactionManager;
 @RunWith(CustomRunner.class)
 public class PutFromLoadValidatorUnitTest {
 
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(
-			PutFromLoadValidatorUnitTest.class);
-	private static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(
+         PutFromLoadValidatorUnitTest.class);
+   private static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
    protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
 
    private static ServiceRegistryTestingImpl serviceRegistry;
 
    private final Object KEY1 = "KEY1";
 
-	private TransactionManager tm;
-	private EmbeddedCacheManager cm;
-	private AdvancedCache<Object, Object> cache;
-	private final List<Runnable> cleanup = new ArrayList<>();
+   private TransactionManager tm;
+   private EmbeddedCacheManager cm;
+   private AdvancedCache<Object, Object> cache;
+   private final List<Runnable> cleanup = new ArrayList<>();
    private PutFromLoadValidator testee;
 
    @BeforeClassOnce
-	public void setUp() throws Exception {
-		TestResourceTracker.testStarted(getClass().getSimpleName());
+   public void setUp() throws Exception {
+      TestResourceTracker.testStarted(getClass().getSimpleName());
       serviceRegistry = ServiceRegistryTestingImpl.forUnitTesting();
-		tm = DualNodeJtaTransactionManagerImpl.getInstance("test");
-		cm = TestCacheManagerFactory.createCacheManager(true);
-		cache = cm.getCache().getAdvancedCache();
-	}
+      tm = DualNodeJtaTransactionManagerImpl.getInstance("test");
+      cm = TestCacheManagerFactory.createCacheManager(true);
+      cache = cm.getCache().getAdvancedCache();
+   }
 
-	@AfterClassOnce
-	public void stop() {
-		tm = null;
-		cm.stop();
+   @AfterClassOnce
+   public void stop() {
+      tm = null;
+      cm.stop();
       serviceRegistry.destroy();
-		TestResourceTracker.testFinished(getClass().getSimpleName());
-	}
+      TestResourceTracker.testFinished(getClass().getSimpleName());
+   }
 
-	@After
-	public void tearDown() throws Exception {
-		cleanup.forEach(Runnable::run);
-		cleanup.clear();
-		try {
-			DualNodeJtaTransactionManagerImpl.cleanupTransactions();
-		}
-		finally {
-			DualNodeJtaTransactionManagerImpl.cleanupTransactionManagers();
-		}
-		cache.clear();
-		cm.getCache(cache.getName() + "-" + InfinispanProperties.DEF_PENDING_PUTS_RESOURCE).clear();
+   @After
+   public void tearDown() throws Exception {
+      cleanup.forEach(Runnable::run);
+      cleanup.clear();
+      try {
+         DualNodeJtaTransactionManagerImpl.cleanupTransactions();
+      } finally {
+         DualNodeJtaTransactionManagerImpl.cleanupTransactionManagers();
+      }
+      cache.clear();
+      cm.getCache(cache.getName() + "-" + InfinispanProperties.DEF_PENDING_PUTS_RESOURCE).clear();
 
       testee.removePendingPutsCache();
-	}
+   }
 
-	private static TestRegionFactory regionFactory(EmbeddedCacheManager cm) {
-		Properties properties = new Properties();
-		properties.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
-		TestRegionFactory regionFactory = TestRegionFactoryProvider.load().create(properties);
-		regionFactory.setCacheManager(cm);
+   private static TestRegionFactory regionFactory(EmbeddedCacheManager cm) {
+      Properties properties = new Properties();
+      properties.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
+      TestRegionFactory regionFactory = TestRegionFactoryProvider.load().create(properties);
+      regionFactory.setCacheManager(cm);
       regionFactory.start(serviceRegistry, properties);
-		return regionFactory;
-	}
+      return regionFactory;
+   }
 
-	@Test
-	public void testNakedPut() {
-		nakedPutTest(false);
-	}
-	@Test
-	public void testNakedPutTransactional() {
-		nakedPutTest(true);
-	}
+   @Test
+   public void testNakedPut() {
+      nakedPutTest(false);
+   }
 
-	private void nakedPutTest(final boolean transactional) {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
-		exec(transactional, new NakedPut(testee, true));
-	}
+   @Test
+   public void testNakedPutTransactional() {
+      nakedPutTest(true);
+   }
 
-	@Test
-	public void testRegisteredPut() {
-		registeredPutTest(false);
-	}
-	@Test
-	public void testRegisteredPutTransactional() {
-		registeredPutTest(true);
-	}
+   private void nakedPutTest(final boolean transactional) {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+      exec(transactional, new NakedPut(testee, true));
+   }
 
-	private void registeredPutTest(final boolean transactional) {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
-		exec(transactional, new RegularPut(testee));
-	}
+   @Test
+   public void testRegisteredPut() {
+      registeredPutTest(false);
+   }
 
-	@Test
-	public void testNakedPutAfterKeyRemoval() {
-		nakedPutAfterRemovalTest(false, false);
-	}
-	@Test
-	public void testNakedPutAfterKeyRemovalTransactional() {
-		nakedPutAfterRemovalTest(true, false);
-	}
-	@Test
-	public void testNakedPutAfterRegionRemoval() {
-		nakedPutAfterRemovalTest(false, true);
-	}
-	@Test
-	public void testNakedPutAfterRegionRemovalTransactional() {
-		nakedPutAfterRemovalTest(true, true);
-	}
+   @Test
+   public void testRegisteredPutTransactional() {
+      registeredPutTest(true);
+   }
 
-	private void nakedPutAfterRemovalTest(final boolean transactional,
-			final boolean removeRegion) {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
-		Invalidation invalidation = new Invalidation(testee, removeRegion);
-		// the naked put can succeed because it has txTimestamp after invalidation
-		NakedPut nakedPut = new NakedPut(testee, true);
-		exec(transactional, invalidation, nakedPut);
-	}
+   private void registeredPutTest(final boolean transactional) {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+      exec(transactional, new RegularPut(testee));
+   }
 
-	@Test
-	public void testRegisteredPutAfterKeyRemoval() {
-		registeredPutAfterRemovalTest(false, false);
-	}
-	@Test
-	public void testRegisteredPutAfterKeyRemovalTransactional() {
-		registeredPutAfterRemovalTest(true, false);
-	}
-	 @Test
-	public void testRegisteredPutAfterRegionRemoval() {
-		registeredPutAfterRemovalTest(false, true);
-	}
-	 @Test
-	public void testRegisteredPutAfterRegionRemovalTransactional() {
-		registeredPutAfterRemovalTest(true, true);
-	}
+   @Test
+   public void testNakedPutAfterKeyRemoval() {
+      nakedPutAfterRemovalTest(false, false);
+   }
 
-	private void registeredPutAfterRemovalTest(final boolean transactional,
-			final boolean removeRegion) {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
-		Invalidation invalidation = new Invalidation(testee, removeRegion);
-		RegularPut regularPut = new RegularPut(testee);
-		exec(transactional, invalidation, regularPut);
-	}
-	 @Test
-	public void testRegisteredPutWithInterveningKeyRemoval() {
-		registeredPutWithInterveningRemovalTest(false, false);
-	}
-	 @Test
-	public void testRegisteredPutWithInterveningKeyRemovalTransactional() {
-		registeredPutWithInterveningRemovalTest(true, false);
-	}
-	 @Test
-	public void testRegisteredPutWithInterveningRegionRemoval() {
-		registeredPutWithInterveningRemovalTest(false, true);
-	}
-	 @Test
-	public void testRegisteredPutWithInterveningRegionRemovalTransactional() {
-		registeredPutWithInterveningRemovalTest(true, true);
-	}
+   @Test
+   public void testNakedPutAfterKeyRemovalTransactional() {
+      nakedPutAfterRemovalTest(true, false);
+   }
 
-	private void registeredPutWithInterveningRemovalTest(
-			final boolean transactional, final boolean removeRegion) {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
-		try {
-			long txTimestamp = TIME_SERVICE.wallClockTime();
-			if (transactional) {
-				tm.begin();
-			}
-			Object session1 = TEST_SESSION_ACCESS.mockSessionImplementor();
-			Object session2 = TEST_SESSION_ACCESS.mockSessionImplementor();
-			testee.registerPendingPut(session1, KEY1, txTimestamp);
-			if (removeRegion) {
-				testee.beginInvalidatingRegion();
-			} else {
-				testee.beginInvalidatingKey(session2, KEY1);
-			}
+   @Test
+   public void testNakedPutAfterRegionRemoval() {
+      nakedPutAfterRemovalTest(false, true);
+   }
 
-			PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session1, KEY1, txTimestamp);
-			try {
-				assertNull(lock);
-			}
-			finally {
-				if (lock != null) {
-					testee.releasePutFromLoadLock(KEY1, lock);
-				}
-				if (removeRegion) {
-					testee.endInvalidatingRegion();
-				} else {
-					testee.endInvalidatingKey(session2, KEY1);
-				}
-			}
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+   @Test
+   public void testNakedPutAfterRegionRemovalTransactional() {
+      nakedPutAfterRemovalTest(true, true);
+   }
 
-	@Test
-	public void testMultipleRegistrations() throws Exception {
-		multipleRegistrationtest(false);
-	}
+   private void nakedPutAfterRemovalTest(final boolean transactional,
+                                         final boolean removeRegion) {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+      Invalidation invalidation = new Invalidation(testee, removeRegion);
+      // the naked put can succeed because it has txTimestamp after invalidation
+      NakedPut nakedPut = new NakedPut(testee, true);
+      exec(transactional, invalidation, nakedPut);
+   }
 
-	@Test
-	public void testMultipleRegistrationsTransactional() throws Exception {
-		multipleRegistrationtest(true);
-	}
+   @Test
+   public void testRegisteredPutAfterKeyRemoval() {
+      registeredPutAfterRemovalTest(false, false);
+   }
 
-	private void multipleRegistrationtest(final boolean transactional) throws Exception {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+   @Test
+   public void testRegisteredPutAfterKeyRemovalTransactional() {
+      registeredPutAfterRemovalTest(true, false);
+   }
 
-		final CountDownLatch registeredLatch = new CountDownLatch(3);
-		final CountDownLatch finishedLatch = new CountDownLatch(3);
-		final AtomicInteger success = new AtomicInteger();
+   @Test
+   public void testRegisteredPutAfterRegionRemoval() {
+      registeredPutAfterRemovalTest(false, true);
+   }
 
-		Runnable r = () -> {
-			try {
-				long txTimestamp = TIME_SERVICE.wallClockTime();
-				if (transactional) {
-					tm.begin();
-				}
-				Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
-				testee.registerPendingPut(session, KEY1, txTimestamp);
-				registeredLatch.countDown();
-				registeredLatch.await(5, TimeUnit.SECONDS);
-				PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
-				if (lock != null) {
-					try {
-						log.trace("Put from load lock acquired for key = " + KEY1);
-						success.incrementAndGet();
-					} finally {
-						testee.releasePutFromLoadLock(KEY1, lock);
-					}
-				} else {
-					log.trace("Unable to acquired putFromLoad lock for key = " + KEY1);
-				}
-				finishedLatch.countDown();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		};
+   @Test
+   public void testRegisteredPutAfterRegionRemovalTransactional() {
+      registeredPutAfterRemovalTest(true, true);
+   }
 
-		ExecutorService executor = Executors.newFixedThreadPool(3);
-		cleanup.add(() -> executor.shutdownNow());
+   private void registeredPutAfterRemovalTest(final boolean transactional,
+                                              final boolean removeRegion) {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+      Invalidation invalidation = new Invalidation(testee, removeRegion);
+      RegularPut regularPut = new RegularPut(testee);
+      exec(transactional, invalidation, regularPut);
+   }
 
-		// Start with a removal so the "isPutValid" calls will fail if
-		// any of the concurrent activity isn't handled properly
+   @Test
+   public void testRegisteredPutWithInterveningKeyRemoval() {
+      registeredPutWithInterveningRemovalTest(false, false);
+   }
 
-		testee.beginInvalidatingRegion();
-		testee.endInvalidatingRegion();
-		TIME_SERVICE.advance(1);
+   @Test
+   public void testRegisteredPutWithInterveningKeyRemovalTransactional() {
+      registeredPutWithInterveningRemovalTest(true, false);
+   }
 
-		// Do the registration + isPutValid calls
-		executor.execute(r);
-		executor.execute(r);
-		executor.execute(r);
+   @Test
+   public void testRegisteredPutWithInterveningRegionRemoval() {
+      registeredPutWithInterveningRemovalTest(false, true);
+   }
 
-		assertTrue(finishedLatch.await(5, TimeUnit.SECONDS));
+   @Test
+   public void testRegisteredPutWithInterveningRegionRemovalTransactional() {
+      registeredPutWithInterveningRemovalTest(true, true);
+   }
 
-		assertEquals("All threads succeeded", 3, success.get());
-	}
+   private void registeredPutWithInterveningRemovalTest(
+         final boolean transactional, final boolean removeRegion) {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+      try {
+         long txTimestamp = TIME_SERVICE.wallClockTime();
+         if (transactional) {
+            tm.begin();
+         }
+         Object session1 = TEST_SESSION_ACCESS.mockSessionImplementor();
+         Object session2 = TEST_SESSION_ACCESS.mockSessionImplementor();
+         testee.registerPendingPut(session1, KEY1, txTimestamp);
+         if (removeRegion) {
+            testee.beginInvalidatingRegion();
+         } else {
+            testee.beginInvalidatingKey(session2, KEY1);
+         }
 
-	@Test
-	public void testInvalidateKeyBlocksForInProgressPut() throws Exception {
-		invalidationBlocksForInProgressPutTest(true);
-	}
+         PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session1, KEY1, txTimestamp);
+         try {
+            assertNull(lock);
+         } finally {
+            if (lock != null) {
+               testee.releasePutFromLoadLock(KEY1, lock);
+            }
+            if (removeRegion) {
+               testee.endInvalidatingRegion();
+            } else {
+               testee.endInvalidatingKey(session2, KEY1);
+            }
+         }
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
 
-	@Test
-	public void testInvalidateRegionBlocksForInProgressPut() throws Exception {
-		invalidationBlocksForInProgressPutTest(false);
-	}
+   @Test
+   public void testMultipleRegistrations() throws Exception {
+      multipleRegistrationtest(false);
+   }
 
-	private void invalidationBlocksForInProgressPutTest(final boolean keyOnly) throws Exception {
-		TestRegionFactory regionFactory = regionFactory(cm);
-		testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
-		final CountDownLatch removeLatch = new CountDownLatch(1);
-		final CountDownLatch pferLatch = new CountDownLatch(1);
-		final AtomicReference<Object> cache = new AtomicReference<>("INITIAL");
+   @Test
+   public void testMultipleRegistrationsTransactional() throws Exception {
+      multipleRegistrationtest(true);
+   }
 
-		Callable<Boolean> pferCallable = () -> {
-			long txTimestamp = TIME_SERVICE.wallClockTime();
-			Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
-			testee.registerPendingPut(session, KEY1, txTimestamp);
-			PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
-			if (lock != null) {
-				try {
-					removeLatch.countDown();
-					pferLatch.await();
-					cache.set("PFER");
-					return Boolean.TRUE;
-				}
-				finally {
-					testee.releasePutFromLoadLock(KEY1, lock);
-				}
-			}
-			return Boolean.FALSE;
-		};
+   private void multipleRegistrationtest(final boolean transactional) throws Exception {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
 
-		Callable<Void> invalidateCallable = () -> {
+      final CountDownLatch registeredLatch = new CountDownLatch(3);
+      final CountDownLatch finishedLatch = new CountDownLatch(3);
+      final AtomicInteger success = new AtomicInteger();
+
+      Runnable r = () -> {
+         try {
+            long txTimestamp = TIME_SERVICE.wallClockTime();
+            if (transactional) {
+               tm.begin();
+            }
+            Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
+            testee.registerPendingPut(session, KEY1, txTimestamp);
+            registeredLatch.countDown();
+            registeredLatch.await(5, TimeUnit.SECONDS);
+            PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
+            if (lock != null) {
+               try {
+                  log.trace("Put from load lock acquired for key = " + KEY1);
+                  success.incrementAndGet();
+               } finally {
+                  testee.releasePutFromLoadLock(KEY1, lock);
+               }
+            } else {
+               log.trace("Unable to acquired putFromLoad lock for key = " + KEY1);
+            }
+            finishedLatch.countDown();
+         } catch (Exception e) {
+            e.printStackTrace();
+         }
+      };
+
+      ExecutorService executor = Executors.newFixedThreadPool(3);
+      cleanup.add(() -> executor.shutdownNow());
+
+      // Start with a removal so the "isPutValid" calls will fail if
+      // any of the concurrent activity isn't handled properly
+
+      testee.beginInvalidatingRegion();
+      testee.endInvalidatingRegion();
+      TIME_SERVICE.advance(1);
+
+      // Do the registration + isPutValid calls
+      executor.execute(r);
+      executor.execute(r);
+      executor.execute(r);
+
+      assertTrue(finishedLatch.await(5, TimeUnit.SECONDS));
+
+      assertEquals("All threads succeeded", 3, success.get());
+   }
+
+   @Test
+   public void testInvalidateKeyBlocksForInProgressPut() throws Exception {
+      invalidationBlocksForInProgressPutTest(true);
+   }
+
+   @Test
+   public void testInvalidateRegionBlocksForInProgressPut() throws Exception {
+      invalidationBlocksForInProgressPutTest(false);
+   }
+
+   private void invalidationBlocksForInProgressPutTest(final boolean keyOnly) throws Exception {
+      TestRegionFactory regionFactory = regionFactory(cm);
+      testee = new PutFromLoadValidator(cache, regionFactory, regionFactory.getPendingPutsCacheConfiguration());
+      final CountDownLatch removeLatch = new CountDownLatch(1);
+      final CountDownLatch pferLatch = new CountDownLatch(1);
+      final AtomicReference<Object> cache = new AtomicReference<>("INITIAL");
+
+      Callable<Boolean> pferCallable = () -> {
+         long txTimestamp = TIME_SERVICE.wallClockTime();
+         Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
+         testee.registerPendingPut(session, KEY1, txTimestamp);
+         PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
+         if (lock != null) {
+            try {
+               removeLatch.countDown();
+               pferLatch.await();
+               cache.set("PFER");
+               return Boolean.TRUE;
+            } finally {
+               testee.releasePutFromLoadLock(KEY1, lock);
+            }
+         }
+         return Boolean.FALSE;
+      };
+
+      Callable<Void> invalidateCallable = () -> {
          removeLatch.await();
          if (keyOnly) {
             Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
@@ -363,168 +372,167 @@ public class PutFromLoadValidatorUnitTest {
          return null;
       };
 
-		ExecutorService executor = Executors.newCachedThreadPool();
-		cleanup.add(() -> executor.shutdownNow());
-		Future<Boolean> pferFuture = executor.submit(pferCallable);
-		Future<Void> invalidateFuture = executor.submit(invalidateCallable);
+      ExecutorService executor = Executors.newCachedThreadPool();
+      cleanup.add(() -> executor.shutdownNow());
+      Future<Boolean> pferFuture = executor.submit(pferCallable);
+      Future<Void> invalidateFuture = executor.submit(invalidateCallable);
 
-		expectException(TimeoutException.class, () -> invalidateFuture.get(1, TimeUnit.SECONDS));
+      expectException(TimeoutException.class, () -> invalidateFuture.get(1, TimeUnit.SECONDS));
 
-		pferLatch.countDown();
+      pferLatch.countDown();
 
-		assertTrue(pferFuture.get(5, TimeUnit.SECONDS));
-		invalidateFuture.get(5, TimeUnit.SECONDS);
+      assertTrue(pferFuture.get(5, TimeUnit.SECONDS));
+      invalidateFuture.get(5, TimeUnit.SECONDS);
 
-		assertNull(cache.get());
-	}
+      assertNull(cache.get());
+   }
 
-	protected void exec(boolean transactional, Callable<?>... callables) {
-		try {
-			if (transactional) {
-				for (Callable<?> c : callables) {
-					withTx(tm, c);
-				}
-			} else {
-				for (Callable<?> c : callables) {
-					c.call();
-				}
-			}
-		} catch (RuntimeException e) {
-			throw e;
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+   protected void exec(boolean transactional, Callable<?>... callables) {
+      try {
+         if (transactional) {
+            for (Callable<?> c : callables) {
+               withTx(tm, c);
+            }
+         } else {
+            for (Callable<?> c : callables) {
+               c.call();
+            }
+         }
+      } catch (RuntimeException e) {
+         throw e;
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
 
-	private class Invalidation implements Callable<Void> {
-		private final PutFromLoadValidator putFromLoadValidator;
-		private final boolean removeRegion;
+   private class Invalidation implements Callable<Void> {
+      private final PutFromLoadValidator putFromLoadValidator;
+      private final boolean removeRegion;
 
-		public Invalidation(PutFromLoadValidator putFromLoadValidator, boolean removeRegion) {
-			this.putFromLoadValidator = putFromLoadValidator;
-			this.removeRegion = removeRegion;
-		}
+      public Invalidation(PutFromLoadValidator putFromLoadValidator, boolean removeRegion) {
+         this.putFromLoadValidator = putFromLoadValidator;
+         this.removeRegion = removeRegion;
+      }
 
-		@Override
-		public Void call() throws Exception {
-			if (removeRegion) {
-				boolean success = putFromLoadValidator.beginInvalidatingRegion();
-				assertTrue(success);
-				putFromLoadValidator.endInvalidatingRegion();
-			} else {
+      @Override
+      public Void call() throws Exception {
+         if (removeRegion) {
+            boolean success = putFromLoadValidator.beginInvalidatingRegion();
+            assertTrue(success);
+            putFromLoadValidator.endInvalidatingRegion();
+         } else {
             Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
-				boolean success = putFromLoadValidator.beginInvalidatingKey(session, KEY1);
-				assertTrue(success);
-				success = putFromLoadValidator.endInvalidatingKey(session, KEY1);
-				assertTrue(success);
-			}
-			// if we go for the timestamp-based approach, invalidation in the same millisecond
-			// as the registerPendingPut/acquirePutFromLoad lock results in failure.
-			TIME_SERVICE.advance(1);
-			return null;
-		}
-	}
+            boolean success = putFromLoadValidator.beginInvalidatingKey(session, KEY1);
+            assertTrue(success);
+            success = putFromLoadValidator.endInvalidatingKey(session, KEY1);
+            assertTrue(success);
+         }
+         // if we go for the timestamp-based approach, invalidation in the same millisecond
+         // as the registerPendingPut/acquirePutFromLoad lock results in failure.
+         TIME_SERVICE.advance(1);
+         return null;
+      }
+   }
 
-	private class RegularPut implements Callable<Void> {
-		private final PutFromLoadValidator putFromLoadValidator;
+   private class RegularPut implements Callable<Void> {
+      private final PutFromLoadValidator putFromLoadValidator;
 
-		public RegularPut(PutFromLoadValidator putFromLoadValidator) {
-			this.putFromLoadValidator = putFromLoadValidator;
-		}
+      public RegularPut(PutFromLoadValidator putFromLoadValidator) {
+         this.putFromLoadValidator = putFromLoadValidator;
+      }
 
-		@Override
-		public Void call() throws Exception {
-			try {
-				long txTimestamp = TIME_SERVICE.wallClockTime(); // this should be acquired before UserTransaction.begin()
+      @Override
+      public Void call() throws Exception {
+         try {
+            long txTimestamp = TIME_SERVICE.wallClockTime(); // this should be acquired before UserTransaction.begin()
             Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
-				putFromLoadValidator.registerPendingPut(session, KEY1, txTimestamp);
+            putFromLoadValidator.registerPendingPut(session, KEY1, txTimestamp);
 
-				PutFromLoadValidator.Lock lock = putFromLoadValidator.acquirePutFromLoadLock(session, KEY1, txTimestamp);
-				try {
-					assertNotNull(lock);
-				} finally {
-					if (lock != null) {
-						putFromLoadValidator.releasePutFromLoadLock(KEY1, lock);
-					}
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-			return null;
-		}
-	}
+            PutFromLoadValidator.Lock lock = putFromLoadValidator.acquirePutFromLoadLock(session, KEY1, txTimestamp);
+            try {
+               assertNotNull(lock);
+            } finally {
+               if (lock != null) {
+                  putFromLoadValidator.releasePutFromLoadLock(KEY1, lock);
+               }
+            }
+         } catch (Exception e) {
+            throw new RuntimeException(e);
+         }
+         return null;
+      }
+   }
 
-	private class NakedPut implements Callable<Void> {
-		private final PutFromLoadValidator testee;
-		private final boolean expectSuccess;
+   private class NakedPut implements Callable<Void> {
+      private final PutFromLoadValidator testee;
+      private final boolean expectSuccess;
 
-		public NakedPut(PutFromLoadValidator testee, boolean expectSuccess) {
-			this.testee = testee;
-			this.expectSuccess = expectSuccess;
-		}
+      public NakedPut(PutFromLoadValidator testee, boolean expectSuccess) {
+         this.testee = testee;
+         this.expectSuccess = expectSuccess;
+      }
 
-		@Override
-		public Void call() throws Exception {
-			try {
-				long txTimestamp = TIME_SERVICE.wallClockTime(); // this should be acquired before UserTransaction.begin()
+      @Override
+      public Void call() throws Exception {
+         try {
+            long txTimestamp = TIME_SERVICE.wallClockTime(); // this should be acquired before UserTransaction.begin()
             Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
-				PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
-				try {
-					if (expectSuccess) {
-						assertNotNull(lock);
-					} else {
-						assertNull(lock);
-					}
-				}
-				finally {
-					if (lock != null) {
-						testee.releasePutFromLoadLock(KEY1, lock);
-					}
-				}
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-			return null;
-		}
-	}
+            PutFromLoadValidator.Lock lock = testee.acquirePutFromLoadLock(session, KEY1, txTimestamp);
+            try {
+               if (expectSuccess) {
+                  assertNotNull(lock);
+               } else {
+                  assertNull(lock);
+               }
+            } finally {
+               if (lock != null) {
+                  testee.releasePutFromLoadLock(KEY1, lock);
+               }
+            }
+         } catch (Exception e) {
+            throw new RuntimeException(e);
+         }
+         return null;
+      }
+   }
 
-	@Test
-	@JiraKey(value = "HHH-9928")
-	public void testGetForNullReleasePuts() {
-		ConfigurationBuilder cb = new ConfigurationBuilder();
-		cb.simpleCache(true).expiration().maxIdle(500);
-		Configuration ppCfg = cb.build();
+   @Test
+   @JiraKey(value = "HHH-9928")
+   public void testGetForNullReleasePuts() {
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.simpleCache(true).expiration().maxIdle(500);
+      Configuration ppCfg = cb.build();
 
-		testee = new PutFromLoadValidator(cache, TIME_SERVICE::wallClockTime, cm, ppCfg);
+      testee = new PutFromLoadValidator(cache, TIME_SERVICE::wallClockTime, cm, ppCfg);
 
-		for (int i = 0; i < 100; ++i) {
-			try {
-				withTx(tm, () -> {
+      for (int i = 0; i < 100; ++i) {
+         try {
+            withTx(tm, () -> {
                Object session = TEST_SESSION_ACCESS.mockSessionImplementor();
-					testee.registerPendingPut(session, KEY1, 0);
-					return null;
-				});
-				TIME_SERVICE.advance(10);
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-		String ppName = cm.getCache().getName() + "-" + InfinispanProperties.DEF_PENDING_PUTS_RESOURCE;
-		Map ppCache = cm.getCache(ppName, false);
-		assertNotNull(ppCache);
-		Object pendingPutMap = ppCache.get(KEY1);
-		assertNotNull(pendingPutMap);
-		int size;
-		try {
-			Method sizeMethod = pendingPutMap.getClass().getMethod("size");
-			sizeMethod.setAccessible(true);
-			size = (Integer) sizeMethod.invoke(pendingPutMap);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-		// some of the pending puts need to be expired by now
-		assertTrue(size < 100);
-		// but some are still registered
-		assertTrue(size > 0);
-	}
+               testee.registerPendingPut(session, KEY1, 0);
+               return null;
+            });
+            TIME_SERVICE.advance(10);
+         } catch (Exception e) {
+            throw new RuntimeException(e);
+         }
+      }
+      String ppName = cm.getCache().getName() + "-" + InfinispanProperties.DEF_PENDING_PUTS_RESOURCE;
+      Map ppCache = cm.getCache(ppName, false);
+      assertNotNull(ppCache);
+      Object pendingPutMap = ppCache.get(KEY1);
+      assertNotNull(pendingPutMap);
+      int size;
+      try {
+         Method sizeMethod = pendingPutMap.getClass().getMethod("size");
+         sizeMethod.setAccessible(true);
+         size = (Integer) sizeMethod.invoke(pendingPutMap);
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+      // some of the pending puts need to be expired by now
+      assertTrue(size < 100);
+      // but some are still registered
+      assertTrue(size > 0);
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/collection/CollectionRegionAccessExtraAPITest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/collection/CollectionRegionAccessExtraAPITest.java
@@ -7,8 +7,8 @@ import org.infinispan.test.hibernate.cache.commons.AbstractExtraAPITest;
  * @since 3.5
  */
 public class CollectionRegionAccessExtraAPITest extends AbstractExtraAPITest<Object> {
-	@Override
-	protected Object getAccessStrategy() {
-		return TEST_SESSION_ACCESS.collectionAccess(environment.getCollectionRegion( REGION_NAME, accessType), accessType);
-	}
+   @Override
+   protected Object getAccessStrategy() {
+      return TEST_SESSION_ACCESS.collectionAccess(environment.getCollectionRegion(REGION_NAME, accessType), accessType);
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/collection/CollectionRegionAccessStrategyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/collection/CollectionRegionAccessStrategyTest.java
@@ -36,106 +36,104 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Smoke.class)
 public class CollectionRegionAccessStrategyTest extends AbstractRegionAccessStrategyTest<Object> {
-	protected static int testCount;
+   protected static int testCount;
 
-	@Override
-	protected Object generateNextKey() {
-		return TestingKeyFactory.generateCollectionCacheKey(KEY_BASE + testCount++);
-	}
+   @Override
+   protected Object generateNextKey() {
+      return TestingKeyFactory.generateCollectionCacheKey(KEY_BASE + testCount++);
+   }
 
-	@Override
-	protected InfinispanBaseRegion getRegion(NodeEnvironment environment) {
-		return environment.getCollectionRegion(REGION_NAME, accessType);
-	}
+   @Override
+   protected InfinispanBaseRegion getRegion(NodeEnvironment environment) {
+      return environment.getCollectionRegion(REGION_NAME, accessType);
+   }
 
-	@Override
-	protected Object getAccessStrategy(InfinispanBaseRegion region) {
-		return TEST_SESSION_ACCESS.collectionAccess(region, accessType);
-	}
+   @Override
+   protected Object getAccessStrategy(InfinispanBaseRegion region) {
+      return TEST_SESSION_ACCESS.collectionAccess(region, accessType);
+   }
 
-	@Test
-	public void testPutFromLoadRemoveDoesNotProduceStaleData() throws Exception {
-		if (!cacheMode.isInvalidation()) {
-			return;
-		}
-		final CountDownLatch pferLatch = new CountDownLatch( 1 );
-		final CountDownLatch removeLatch = new CountDownLatch( 1 );
-		// remove the interceptor inserted by default PutFromLoadValidator, we're using different one
-		PutFromLoadValidator originalValidator = PutFromLoadValidator.removeFromCache(localRegion.getCache());
-		PutFromLoadValidator mockValidator = spy(originalValidator);
-		doAnswer(invocation -> {
-			try {
-				return invocation.callRealMethod();
-			} finally {
-				try {
-					removeLatch.countDown();
-					// the remove should be blocked because the putFromLoad has been acquired
-					// and the remove can continue only after we've inserted the entry
-					assertFalse(pferLatch.await( 2, TimeUnit.SECONDS ) );
-				}
-				catch (InterruptedException e) {
-					log.debug( "Interrupted" );
-					Thread.currentThread().interrupt();
-				}
-				catch (Exception e) {
-					log.error( "Error", e );
-					throw new RuntimeException( "Error", e );
-				}
-			}
-		}).when(mockValidator).acquirePutFromLoadLock(any(), any(), anyLong());
-		PutFromLoadValidator.addToCache(localRegion.getCache(), mockValidator);
-		cleanup.add(() -> {
-			PutFromLoadValidator.removeFromCache(localRegion.getCache());
-			PutFromLoadValidator.addToCache(localRegion.getCache(), originalValidator);
-		});
+   @Test
+   public void testPutFromLoadRemoveDoesNotProduceStaleData() throws Exception {
+      if (!cacheMode.isInvalidation()) {
+         return;
+      }
+      final CountDownLatch pferLatch = new CountDownLatch(1);
+      final CountDownLatch removeLatch = new CountDownLatch(1);
+      // remove the interceptor inserted by default PutFromLoadValidator, we're using different one
+      PutFromLoadValidator originalValidator = PutFromLoadValidator.removeFromCache(localRegion.getCache());
+      PutFromLoadValidator mockValidator = spy(originalValidator);
+      doAnswer(invocation -> {
+         try {
+            return invocation.callRealMethod();
+         } finally {
+            try {
+               removeLatch.countDown();
+               // the remove should be blocked because the putFromLoad has been acquired
+               // and the remove can continue only after we've inserted the entry
+               assertFalse(pferLatch.await(2, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+               log.debug("Interrupted");
+               Thread.currentThread().interrupt();
+            } catch (Exception e) {
+               log.error("Error", e);
+               throw new RuntimeException("Error", e);
+            }
+         }
+      }).when(mockValidator).acquirePutFromLoadLock(any(), any(), anyLong());
+      PutFromLoadValidator.addToCache(localRegion.getCache(), mockValidator);
+      cleanup.add(() -> {
+         PutFromLoadValidator.removeFromCache(localRegion.getCache());
+         PutFromLoadValidator.addToCache(localRegion.getCache(), originalValidator);
+      });
 
-		final AccessDelegate delegate = localRegion.getCache().getCacheConfiguration().transaction().transactionMode().isTransactional() ?
-			new TxInvalidationCacheAccessDelegate((InfinispanDataRegion) localRegion, mockValidator) :
-			new NonTxInvalidationCacheAccessDelegate((InfinispanDataRegion) localRegion, mockValidator);
+      final AccessDelegate delegate = localRegion.getCache().getCacheConfiguration().transaction().transactionMode().isTransactional() ?
+            new TxInvalidationCacheAccessDelegate((InfinispanDataRegion) localRegion, mockValidator) :
+            new NonTxInvalidationCacheAccessDelegate((InfinispanDataRegion) localRegion, mockValidator);
 
-		ExecutorService executorService = Executors.newCachedThreadPool();
-		cleanup.add(() -> executorService.shutdownNow());
+      ExecutorService executorService = Executors.newCachedThreadPool();
+      cleanup.add(() -> executorService.shutdownNow());
 
-		final String KEY = "k1";
-		Future<Void> pferFuture = executorService.submit(() -> {
+      final String KEY = "k1";
+      Future<Void> pferFuture = executorService.submit(() -> {
          Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-			delegate.putFromLoad(session, KEY, "v1", SESSION_ACCESS.getTimestamp(session), null);
-			return null;
-		});
+         delegate.putFromLoad(session, KEY, "v1", SESSION_ACCESS.getTimestamp(session), null);
+         return null;
+      });
 
-		Future<Void> removeFuture = executorService.submit(() -> {
-			removeLatch.await();
+      Future<Void> removeFuture = executorService.submit(() -> {
+         removeLatch.await();
          Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-			withTx(localEnvironment, session, () -> {
-				delegate.remove(session, KEY);
-				return null;
-			});
-			pferLatch.countDown();
-			return null;
-		});
+         withTx(localEnvironment, session, () -> {
+            delegate.remove(session, KEY);
+            return null;
+         });
+         pferLatch.countDown();
+         return null;
+      });
 
-		pferFuture.get();
-		removeFuture.get();
+      pferFuture.get();
+      removeFuture.get();
 
-		assertFalse(localRegion.getCache().containsKey(KEY));
-		assertFalse(remoteRegion.getCache().containsKey(KEY));
-	}
+      assertFalse(localRegion.getCache().containsKey(KEY));
+      assertFalse(remoteRegion.getCache().containsKey(KEY));
+   }
 
-	@Test
-	public void testPutFromLoad() throws Exception {
-		putFromLoadTest(false, true);
-	}
+   @Test
+   public void testPutFromLoad() throws Exception {
+      putFromLoadTest(false, true);
+   }
 
-	@Test
-	public void testPutFromLoadMinimal() throws Exception {
-		putFromLoadTest(true, true);
-	}
+   @Test
+   public void testPutFromLoadMinimal() throws Exception {
+      putFromLoadTest(true, true);
+   }
 
-	@Override
-	protected void doUpdate(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry) {
-		SoftLock softLock = strategy.lockItem(session, key, null);
-		strategy.remove(session, key);
+   @Override
+   protected void doUpdate(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry) {
+      SoftLock softLock = strategy.lockItem(session, key, null);
+      strategy.remove(session, key);
       SESSION_ACCESS.getTransactionCoordinator(session).registerLocalSynchronization(
-			new TestSynchronization.UnlockItem(strategy, session, key, softLock));
-	}
+            new TestSynchronization.UnlockItem(strategy, session, key, softLock));
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/collection/CollectionRegionImplTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/collection/CollectionRegionImplTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.test.hibernate.cache.commons.collection;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Properties;
 
 import org.hibernate.cache.spi.access.AccessType;
@@ -8,29 +10,27 @@ import org.infinispan.test.hibernate.cache.commons.AbstractEntityCollectionRegio
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess.TestRegionAccessStrategy;
 
-import static org.junit.Assert.assertNotNull;
-
 /**
  * @author Galder Zamarreño
  */
 public class CollectionRegionImplTest extends AbstractEntityCollectionRegionTest {
-	protected static final String CACHE_NAME = "test";
+   protected static final String CACHE_NAME = "test";
 
-	@Override
-	protected void supportedAccessTypeTest(TestRegionFactory regionFactory, Properties properties) {
-		InfinispanBaseRegion region = regionFactory.buildCollectionRegion(CACHE_NAME, accessType);
-		assertNotNull(TEST_SESSION_ACCESS.collectionAccess(region, accessType));
-		regionFactory.getCacheManager().administration().removeCache(CACHE_NAME);
-	}
+   @Override
+   protected void supportedAccessTypeTest(TestRegionFactory regionFactory, Properties properties) {
+      InfinispanBaseRegion region = regionFactory.buildCollectionRegion(CACHE_NAME, accessType);
+      assertNotNull(TEST_SESSION_ACCESS.collectionAccess(region, accessType));
+      regionFactory.getCacheManager().administration().removeCache(CACHE_NAME);
+   }
 
-	@Override
-	protected InfinispanBaseRegion createRegion(TestRegionFactory regionFactory, String regionName) {
-		return regionFactory.buildCollectionRegion(regionName, accessType);
-	}
+   @Override
+   protected InfinispanBaseRegion createRegion(TestRegionFactory regionFactory, String regionName) {
+      return regionFactory.buildCollectionRegion(regionName, accessType);
+   }
 
-	private TestRegionAccessStrategy collectionAccess(InfinispanBaseRegion region) {
-		Object access = TEST_SESSION_ACCESS.collectionAccess(region, AccessType.TRANSACTIONAL);
-		return TEST_SESSION_ACCESS.fromAccess(access);
-	}
+   private TestRegionAccessStrategy collectionAccess(InfinispanBaseRegion region) {
+      Object access = TEST_SESSION_ACCESS.collectionAccess(region, AccessType.TRANSACTIONAL);
+      return TEST_SESSION_ACCESS.fromAccess(access);
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionAccessStrategyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionAccessStrategyTest.java
@@ -28,334 +28,334 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Smoke.class)
 public class EntityRegionAccessStrategyTest extends
-		AbstractRegionAccessStrategyTest<Object> {
-	protected static int testCount;
+      AbstractRegionAccessStrategyTest<Object> {
+   protected static int testCount;
 
-	@Override
-	protected Object generateNextKey() {
-		return TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
-	}
+   @Override
+   protected Object generateNextKey() {
+      return TestingKeyFactory.generateEntityCacheKey(KEY_BASE + testCount++);
+   }
 
-	@Override
-	protected InfinispanBaseRegion getRegion(NodeEnvironment environment) {
-		return environment.getEntityRegion(REGION_NAME, accessType);
-	}
+   @Override
+   protected InfinispanBaseRegion getRegion(NodeEnvironment environment) {
+      return environment.getEntityRegion(REGION_NAME, accessType);
+   }
 
-	@Override
-	protected Object getAccessStrategy(InfinispanBaseRegion region) {
-		return TEST_SESSION_ACCESS.entityAccess(region, accessType);
-	}
+   @Override
+   protected Object getAccessStrategy(InfinispanBaseRegion region) {
+      return TEST_SESSION_ACCESS.entityAccess(region, accessType);
+   }
 
-	@Test
-	public void testPutFromLoad() throws Exception {
-		if (accessType == AccessType.READ_ONLY) {
-			putFromLoadTestReadOnly(false);
-		} else {
-			putFromLoadTest(false, false);
-		}
-	}
+   @Test
+   public void testPutFromLoad() throws Exception {
+      if (accessType == AccessType.READ_ONLY) {
+         putFromLoadTestReadOnly(false);
+      } else {
+         putFromLoadTest(false, false);
+      }
+   }
 
-	@Test
-	public void testPutFromLoadMinimal() throws Exception {
-		if (accessType == AccessType.READ_ONLY) {
-			putFromLoadTestReadOnly(true);
-		} else {
-			putFromLoadTest(true, false);
-		}
-	}
+   @Test
+   public void testPutFromLoadMinimal() throws Exception {
+      if (accessType == AccessType.READ_ONLY) {
+         putFromLoadTestReadOnly(true);
+      } else {
+         putFromLoadTest(true, false);
+      }
+   }
 
-	@Test
-	public void testInsert() throws Exception {
-		final Object KEY = generateNextKey();
+   @Test
+   public void testInsert() throws Exception {
+      final Object KEY = generateNextKey();
 
-		final CountDownLatch readLatch = new CountDownLatch(1);
-		final CountDownLatch commitLatch = new CountDownLatch(1);
-		final CountDownLatch completionLatch = new CountDownLatch(2);
+      final CountDownLatch readLatch = new CountDownLatch(1);
+      final CountDownLatch commitLatch = new CountDownLatch(1);
+      final CountDownLatch completionLatch = new CountDownLatch(2);
 
-		CountDownLatch asyncInsertLatch = expectAfterUpdate(KEY);
+      CountDownLatch asyncInsertLatch = expectAfterUpdate(KEY);
 
-		Thread inserter = new Thread(() -> {
-				try {
-               Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-					withTx(localEnvironment, session, () -> {
-						assertNull("Correct initial value", testLocalAccessStrategy.get(session, KEY));
+      Thread inserter = new Thread(() -> {
+         try {
+            Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+            withTx(localEnvironment, session, () -> {
+               assertNull("Correct initial value", testLocalAccessStrategy.get(session, KEY));
 
-						doInsert(testLocalAccessStrategy, session, KEY, VALUE1);
+               doInsert(testLocalAccessStrategy, session, KEY, VALUE1);
 
-						readLatch.countDown();
-						commitLatch.await();
-						return null;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
+               readLatch.countDown();
+               commitLatch.await();
+               return null;
+            });
+         } catch (Exception e) {
+            log.error("node1 caught exception", e);
+            node1Exception = e;
+         } catch (AssertionError e) {
+            node1Failure = e;
+         } finally {
 
-					completionLatch.countDown();
-				}
-			}, "testInsert-inserter");
+            completionLatch.countDown();
+         }
+      }, "testInsert-inserter");
 
-		Thread reader = new Thread(() -> {
-				try {
-					Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-					withTx(localEnvironment, session, () -> {
-						readLatch.await();
+      Thread reader = new Thread(() -> {
+         try {
+            Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+            withTx(localEnvironment, session, () -> {
+               readLatch.await();
 
-						assertNull("Correct initial value", testLocalAccessStrategy.get(session, KEY));
-						return null;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
-					commitLatch.countDown();
-					completionLatch.countDown();
-				}
-			}, "testInsert-reader");
+               assertNull("Correct initial value", testLocalAccessStrategy.get(session, KEY));
+               return null;
+            });
+         } catch (Exception e) {
+            log.error("node1 caught exception", e);
+            node1Exception = e;
+         } catch (AssertionError e) {
+            node1Failure = e;
+         } finally {
+            commitLatch.countDown();
+            completionLatch.countDown();
+         }
+      }, "testInsert-reader");
 
-		inserter.setDaemon(true);
-		reader.setDaemon(true);
-		inserter.start();
-		reader.start();
+      inserter.setDaemon(true);
+      reader.setDaemon(true);
+      inserter.start();
+      reader.start();
 
-		assertTrue("Threads completed", completionLatch.await(10, TimeUnit.SECONDS));
+      assertTrue("Threads completed", completionLatch.await(10, TimeUnit.SECONDS));
 
-		assertThreadsRanCleanly();
+      assertThreadsRanCleanly();
 
-		Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals("Correct node1 value", VALUE1, testLocalAccessStrategy.get(s1, KEY));
+      Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      assertEquals("Correct node1 value", VALUE1, testLocalAccessStrategy.get(s1, KEY));
 
-		assertTrue(asyncInsertLatch.await(10, TimeUnit.SECONDS));
-		Object expected = isUsingInvalidation() ? null : VALUE1;
-		Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertEquals("Correct node2 value", expected, testRemoteAccessStrategy.get(s2, KEY));
-	}
+      assertTrue(asyncInsertLatch.await(10, TimeUnit.SECONDS));
+      Object expected = isUsingInvalidation() ? null : VALUE1;
+      Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      assertEquals("Correct node2 value", expected, testRemoteAccessStrategy.get(s2, KEY));
+   }
 
-	protected void doInsert(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry) {
-		strategy.insert(session, key, entry, entry.getVersion());
+   protected void doInsert(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry) {
+      strategy.insert(session, key, entry, entry.getVersion());
       SESSION_ACCESS.getTransactionCoordinator(session).registerLocalSynchronization(
-				new TestSynchronization.AfterInsert(strategy, session, key, entry, entry.getVersion()));
-	}
+            new TestSynchronization.AfterInsert(strategy, session, key, entry, entry.getVersion()));
+   }
 
-	protected void putFromLoadTestReadOnly(boolean minimal) throws Exception {
-		final Object KEY = TestingKeyFactory.generateEntityCacheKey( KEY_BASE + testCount++ );
+   protected void putFromLoadTestReadOnly(boolean minimal) throws Exception {
+      final Object KEY = TestingKeyFactory.generateEntityCacheKey(KEY_BASE + testCount++);
 
-		CountDownLatch remotePutFromLoadLatch = expectPutFromLoad(KEY);
+      CountDownLatch remotePutFromLoadLatch = expectPutFromLoad(KEY);
 
-		Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		withTx(localEnvironment, session, () -> {
-			assertNull(testLocalAccessStrategy.get(session, KEY));
-			if (minimal)
+      Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      withTx(localEnvironment, session, () -> {
+         assertNull(testLocalAccessStrategy.get(session, KEY));
+         if (minimal)
             testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.getVersion(), true);
-			else
+         else
             testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.getVersion());
-			return null;
-		});
+         return null;
+      });
 
-		Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals(VALUE1, testLocalAccessStrategy.get(s2, KEY));
-		Object s3 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		Object expected;
-		if (isUsingInvalidation()) {
-			expected = null;
-		} else {
-			if (accessType != AccessType.NONSTRICT_READ_WRITE) {
-				assertTrue(remotePutFromLoadLatch.await(2, TimeUnit.SECONDS));
-			}
-			expected = VALUE1;
-		}
-		assertEquals(expected, testRemoteAccessStrategy.get(s3, KEY));
-	}
+      Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      assertEquals(VALUE1, testLocalAccessStrategy.get(s2, KEY));
+      Object s3 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      Object expected;
+      if (isUsingInvalidation()) {
+         expected = null;
+      } else {
+         if (accessType != AccessType.NONSTRICT_READ_WRITE) {
+            assertTrue(remotePutFromLoadLatch.await(2, TimeUnit.SECONDS));
+         }
+         expected = VALUE1;
+      }
+      assertEquals(expected, testRemoteAccessStrategy.get(s3, KEY));
+   }
 
-	@Test
-	public void testUpdate() throws Exception {
+   @Test
+   public void testUpdate() throws Exception {
       log.infof(name.getMethodName());
-		if (accessType == AccessType.READ_ONLY) {
-			return;
-		}
+      if (accessType == AccessType.READ_ONLY) {
+         return;
+      }
 
-		final Object KEY = generateNextKey();
+      final Object KEY = generateNextKey();
 
-		// Set up initial state
-		Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      // Set up initial state
+      Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
       testLocalAccessStrategy.putFromLoad(s1, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s1), VALUE1.getVersion());
-		Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      Object s2 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
       testRemoteAccessStrategy.putFromLoad(s2, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s2), VALUE1.getVersion());
 
-		// both nodes are updated, we don't have to wait for any async replication of putFromLoad
-		CountDownLatch asyncUpdateLatch = expectAfterUpdate(KEY);
+      // both nodes are updated, we don't have to wait for any async replication of putFromLoad
+      CountDownLatch asyncUpdateLatch = expectAfterUpdate(KEY);
 
-		final CountDownLatch readLatch = new CountDownLatch(1);
-		final CountDownLatch commitLatch = new CountDownLatch(1);
-		final CountDownLatch completionLatch = new CountDownLatch(2);
+      final CountDownLatch readLatch = new CountDownLatch(1);
+      final CountDownLatch commitLatch = new CountDownLatch(1);
+      final CountDownLatch completionLatch = new CountDownLatch(2);
 
-		Thread updater = new Thread(() -> {
-				try {
-					Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-					withTx(localEnvironment, session, () -> {
-						log.debug("Transaction began, get initial value");
-						assertEquals("Correct initial value", VALUE1, testLocalAccessStrategy.get(session, KEY));
-						log.debug("Now update value");
-						doUpdate(testLocalAccessStrategy, session, KEY, VALUE2);
-						log.debug("Notify the read latch");
-						readLatch.countDown();
-						log.debug("Await commit");
-						commitLatch.await();
-						return null;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
-					if (readLatch.getCount() > 0) {
-						readLatch.countDown();
-					}
-					log.debug("Completion latch countdown");
-					completionLatch.countDown();
-				}
-			}, "testUpdate-updater");
+      Thread updater = new Thread(() -> {
+         try {
+            Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+            withTx(localEnvironment, session, () -> {
+               log.debug("Transaction began, get initial value");
+               assertEquals("Correct initial value", VALUE1, testLocalAccessStrategy.get(session, KEY));
+               log.debug("Now update value");
+               doUpdate(testLocalAccessStrategy, session, KEY, VALUE2);
+               log.debug("Notify the read latch");
+               readLatch.countDown();
+               log.debug("Await commit");
+               commitLatch.await();
+               return null;
+            });
+         } catch (Exception e) {
+            log.error("node1 caught exception", e);
+            node1Exception = e;
+         } catch (AssertionError e) {
+            node1Failure = e;
+         } finally {
+            if (readLatch.getCount() > 0) {
+               readLatch.countDown();
+            }
+            log.debug("Completion latch countdown");
+            completionLatch.countDown();
+         }
+      }, "testUpdate-updater");
 
-		Thread reader = new Thread(() -> {
-				try {
-					Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-					withTx(localEnvironment, session, () -> {
-						log.debug("Transaction began, await read latch");
-						readLatch.await();
-						log.debug("Read latch acquired, verify local access strategy");
+      Thread reader = new Thread(() -> {
+         try {
+            Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+            withTx(localEnvironment, session, () -> {
+               log.debug("Transaction began, await read latch");
+               readLatch.await();
+               log.debug("Read latch acquired, verify local access strategy");
 
-						// This won't block w/ mvc and will read the old value (if transactional as the transaction
-						// is not being committed yet, or if non-strict as we do the actual update only after transaction)
-						// or null if non-transactional
-						Object expected = isTransactional() || accessType == AccessType.NONSTRICT_READ_WRITE ? VALUE1 : null;
-						assertEquals("Correct value", expected, testLocalAccessStrategy.get(session, KEY));
-						return null;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
-					commitLatch.countDown();
-					log.debug("Completion latch countdown");
-					completionLatch.countDown();
-				}
-			}, "testUpdate-reader");
+               // This won't block w/ mvc and will read the old value (if transactional as the transaction
+               // is not being committed yet, or if non-strict as we do the actual update only after transaction)
+               // or null if non-transactional
+               Object expected = isTransactional() || accessType == AccessType.NONSTRICT_READ_WRITE ? VALUE1 : null;
+               assertEquals("Correct value", expected, testLocalAccessStrategy.get(session, KEY));
+               return null;
+            });
+         } catch (Exception e) {
+            log.error("node1 caught exception", e);
+            node1Exception = e;
+         } catch (AssertionError e) {
+            node1Failure = e;
+         } finally {
+            commitLatch.countDown();
+            log.debug("Completion latch countdown");
+            completionLatch.countDown();
+         }
+      }, "testUpdate-reader");
 
-		updater.setDaemon(true);
-		reader.setDaemon(true);
-		updater.start();
-		reader.start();
+      updater.setDaemon(true);
+      reader.setDaemon(true);
+      updater.start();
+      reader.start();
 
-		assertTrue(completionLatch.await(2, TimeUnit.SECONDS));
+      assertTrue(completionLatch.await(2, TimeUnit.SECONDS));
 
-		assertThreadsRanCleanly();
+      assertThreadsRanCleanly();
 
-		Object s3 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals("Correct node1 value", VALUE2, testLocalAccessStrategy.get(s3, KEY));
-		assertTrue(asyncUpdateLatch.await(10, TimeUnit.SECONDS));
-		Object expected = isUsingInvalidation() ? null : VALUE2;
-		Object s4 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
-		assertEquals("Correct node2 value", expected, testRemoteAccessStrategy.get(s4, KEY));
-	}
+      Object s3 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      assertEquals("Correct node1 value", VALUE2, testLocalAccessStrategy.get(s3, KEY));
+      assertTrue(asyncUpdateLatch.await(10, TimeUnit.SECONDS));
+      Object expected = isUsingInvalidation() ? null : VALUE2;
+      Object s4 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, remoteEnvironment.getRegionFactory());
+      assertEquals("Correct node2 value", expected, testRemoteAccessStrategy.get(s4, KEY));
+   }
 
-	@Override
-	protected void doUpdate(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry) {
-		SoftLock softLock = strategy.lockItem(session, key, null);
-		strategy.update(session, key, entry, null, entry.getVersion());
+   @Override
+   protected void doUpdate(TestRegionAccessStrategy strategy, Object session, Object key, TestCacheEntry entry) {
+      SoftLock softLock = strategy.lockItem(session, key, null);
+      strategy.update(session, key, entry, null, entry.getVersion());
       SESSION_ACCESS.getTransactionCoordinator(session).registerLocalSynchronization(
-				new TestSynchronization.AfterUpdate(strategy, session, key, entry, entry.getVersion(), softLock));
-	}
+            new TestSynchronization.AfterUpdate(strategy, session, key, entry, entry.getVersion(), softLock));
+   }
 
-	/**
-	 * This test fails in CI too often because it depends on very short timeout. The behaviour is basically
-	 * non-testable as we want to make sure that the "Putter" is always progressing; however, it is sometimes
-	 * progressing in different thread (on different node), and sometimes even in system, sending a message
-	 * over network. Therefore even checking that some OOB/remote thread is in RUNNABLE/RUNNING state is prone
-	 * to spurious failure (and we can't grab the state of all threads atomically).
+   /**
+    * This test fails in CI too often because it depends on very short timeout. The behaviour is basically
+    * non-testable as we want to make sure that the "Putter" is always progressing; however, it is sometimes
+    * progressing in different thread (on different node), and sometimes even in system, sending a message
+    * over network. Therefore even checking that some OOB/remote thread is in RUNNABLE/RUNNING state is prone
+    * to spurious failure (and we can't grab the state of all threads atomically).
     */
-	@Ignore
-	@Test
-	public void testContestedPutFromLoad() throws Exception {
-		if (accessType == AccessType.READ_ONLY) {
-			return;
-		}
+   @Ignore
+   @Test
+   public void testContestedPutFromLoad() throws Exception {
+      if (accessType == AccessType.READ_ONLY) {
+         return;
+      }
 
-		final Object KEY = TestingKeyFactory.generateEntityCacheKey(KEY_BASE + testCount++);
+      final Object KEY = TestingKeyFactory.generateEntityCacheKey(KEY_BASE + testCount++);
 
-		Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      Object s1 = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
       testLocalAccessStrategy.putFromLoad(s1, KEY, VALUE1, SESSION_ACCESS.getTimestamp(s1), VALUE1.getVersion());
 
-		final CountDownLatch pferLatch = new CountDownLatch(1);
-		final CountDownLatch pferCompletionLatch = new CountDownLatch(1);
-		final CountDownLatch commitLatch = new CountDownLatch(1);
-		final CountDownLatch completionLatch = new CountDownLatch(1);
+      final CountDownLatch pferLatch = new CountDownLatch(1);
+      final CountDownLatch pferCompletionLatch = new CountDownLatch(1);
+      final CountDownLatch commitLatch = new CountDownLatch(1);
+      final CountDownLatch completionLatch = new CountDownLatch(1);
 
-		Thread blocker = new Thread("Blocker") {
-			@Override
-			public void run() {
-				try {
-					Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-					withTx(localEnvironment, session, () -> {
-						assertEquals("Correct initial value", VALUE1, testLocalAccessStrategy.get(session, KEY));
+      Thread blocker = new Thread("Blocker") {
+         @Override
+         public void run() {
+            try {
+               Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+               withTx(localEnvironment, session, () -> {
+                  assertEquals("Correct initial value", VALUE1, testLocalAccessStrategy.get(session, KEY));
 
-						doUpdate(testLocalAccessStrategy, session, KEY, VALUE2);
+                  doUpdate(testLocalAccessStrategy, session, KEY, VALUE2);
 
-						pferLatch.countDown();
-						commitLatch.await();
-						return null;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
-					completionLatch.countDown();
-				}
-			}
-		};
+                  pferLatch.countDown();
+                  commitLatch.await();
+                  return null;
+               });
+            } catch (Exception e) {
+               log.error("node1 caught exception", e);
+               node1Exception = e;
+            } catch (AssertionError e) {
+               node1Failure = e;
+            } finally {
+               completionLatch.countDown();
+            }
+         }
+      };
 
-		Thread putter = new Thread("Putter") {
-			@Override
-			public void run() {
-				try {
-					Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-					withTx(localEnvironment, session, () -> {
+      Thread putter = new Thread("Putter") {
+         @Override
+         public void run() {
+            try {
+               Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+               withTx(localEnvironment, session, () -> {
                   testLocalAccessStrategy.putFromLoad(session, KEY, VALUE1, SESSION_ACCESS.getTimestamp(session), VALUE1.getVersion());
-						return null;
-					});
-				} catch (Exception e) {
-					log.error("node1 caught exception", e);
-					node1Exception = e;
-				} catch (AssertionError e) {
-					node1Failure = e;
-				} finally {
-					pferCompletionLatch.countDown();
-				}
-			}
-		};
+                  return null;
+               });
+            } catch (Exception e) {
+               log.error("node1 caught exception", e);
+               node1Exception = e;
+            } catch (AssertionError e) {
+               node1Failure = e;
+            } finally {
+               pferCompletionLatch.countDown();
+            }
+         }
+      };
 
-		blocker.start();
-		assertTrue("Active tx has done an update", pferLatch.await(1, TimeUnit.SECONDS));
-		putter.start();
-		assertTrue("putFromLoad returns promptly", pferCompletionLatch.await(10, TimeUnit.MILLISECONDS));
+      blocker.start();
+      assertTrue("Active tx has done an update", pferLatch.await(1, TimeUnit.SECONDS));
+      putter.start();
+      assertTrue("putFromLoad returns promptly", pferCompletionLatch.await(10, TimeUnit.MILLISECONDS));
 
-		commitLatch.countDown();
+      commitLatch.countDown();
 
-		assertTrue("Threads completed", completionLatch.await(1, TimeUnit.SECONDS));
+      assertTrue("Threads completed", completionLatch.await(1, TimeUnit.SECONDS));
 
-		assertThreadsRanCleanly();
+      assertThreadsRanCleanly();
 
-		Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
-		assertEquals("Correct node1 value", VALUE2, testLocalAccessStrategy.get(session, KEY));
-	}
+      Object session = TEST_SESSION_ACCESS.mockSession(jtaPlatform, TIME_SERVICE, localEnvironment.getRegionFactory());
+      assertEquals("Correct node1 value", VALUE2, testLocalAccessStrategy.get(session, KEY));
+   }
 
    @Test
    @Ignore("ISPN-9175")

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionExtraAPITest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionExtraAPITest.java
@@ -1,10 +1,10 @@
 package org.infinispan.test.hibernate.cache.commons.entity;
 
+import static org.junit.Assert.assertEquals;
+
 import org.hibernate.cache.spi.access.AccessType;
 import org.infinispan.test.hibernate.cache.commons.AbstractExtraAPITest;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the "extra API" in EntityRegionAccessStrategy;.
@@ -17,28 +17,28 @@ import static org.junit.Assert.assertEquals;
  * @since 3.5
  */
 public class EntityRegionExtraAPITest extends AbstractExtraAPITest<Object> {
-	public static final String VALUE1 = "VALUE1";
-	public static final String VALUE2 = "VALUE2";
+   public static final String VALUE1 = "VALUE1";
+   public static final String VALUE2 = "VALUE2";
 
-	@Override
-	protected Object getAccessStrategy() {
-		return TEST_SESSION_ACCESS.entityAccess(environment.getEntityRegion( REGION_NAME, accessType), accessType);
-	}
+   @Override
+   protected Object getAccessStrategy() {
+      return TEST_SESSION_ACCESS.entityAccess(environment.getEntityRegion(REGION_NAME, accessType), accessType);
+   }
 
-	@Test
-	@SuppressWarnings( {"UnnecessaryBoxing"})
-	public void testAfterInsert() {
-		boolean retval = testAccessStrategy.afterInsert(SESSION, KEY, VALUE1, Integer.valueOf( 1 ));
-		assertEquals(accessType == AccessType.NONSTRICT_READ_WRITE, retval);
-	}
+   @Test
+   @SuppressWarnings({"UnnecessaryBoxing"})
+   public void testAfterInsert() {
+      boolean retval = testAccessStrategy.afterInsert(SESSION, KEY, VALUE1, Integer.valueOf(1));
+      assertEquals(accessType == AccessType.NONSTRICT_READ_WRITE, retval);
+   }
 
-	@Test
-	@SuppressWarnings( {"UnnecessaryBoxing"})
-	public void testAfterUpdate() {
-		if (accessType == AccessType.READ_ONLY) {
-			return;
-		}
-		boolean retval = testAccessStrategy.afterUpdate(SESSION,	KEY, VALUE2, Integer.valueOf( 1 ), Integer.valueOf( 2 ),	new MockSoftLock());
-		assertEquals(accessType == AccessType.NONSTRICT_READ_WRITE, retval);
-	}
+   @Test
+   @SuppressWarnings({"UnnecessaryBoxing"})
+   public void testAfterUpdate() {
+      if (accessType == AccessType.READ_ONLY) {
+         return;
+      }
+      boolean retval = testAccessStrategy.afterUpdate(SESSION, KEY, VALUE2, Integer.valueOf(1), Integer.valueOf(2), new MockSoftLock());
+      assertEquals(accessType == AccessType.NONSTRICT_READ_WRITE, retval);
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionImplTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/entity/EntityRegionImplTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.test.hibernate.cache.commons.entity;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Properties;
 
 import org.hibernate.cache.spi.access.AccessType;
@@ -8,8 +10,6 @@ import org.infinispan.test.hibernate.cache.commons.AbstractEntityCollectionRegio
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
 import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess;
 
-import static org.junit.Assert.assertNotNull;
-
 /**
  * Tests of EntityRegionImpl.
  *
@@ -17,23 +17,23 @@ import static org.junit.Assert.assertNotNull;
  * @since 3.5
  */
 public class EntityRegionImplTest extends AbstractEntityCollectionRegionTest {
-	protected static final String CACHE_NAME = "test";
+   protected static final String CACHE_NAME = "test";
 
-	@Override
-	protected void supportedAccessTypeTest(TestRegionFactory regionFactory, Properties properties) {
-		InfinispanBaseRegion region = regionFactory.buildEntityRegion("test", accessType);
-		assertNotNull(TEST_SESSION_ACCESS.entityAccess(region, accessType));
-		regionFactory.getCacheManager().administration().removeCache(CACHE_NAME);
-	}
+   @Override
+   protected void supportedAccessTypeTest(TestRegionFactory regionFactory, Properties properties) {
+      InfinispanBaseRegion region = regionFactory.buildEntityRegion("test", accessType);
+      assertNotNull(TEST_SESSION_ACCESS.entityAccess(region, accessType));
+      regionFactory.getCacheManager().administration().removeCache(CACHE_NAME);
+   }
 
-	private TestSessionAccess.TestRegionAccessStrategy entityAccess(InfinispanBaseRegion region) {
-		Object access = TEST_SESSION_ACCESS.entityAccess(region, AccessType.TRANSACTIONAL);
-		return TEST_SESSION_ACCESS.fromAccess(access);
-	}
+   private TestSessionAccess.TestRegionAccessStrategy entityAccess(InfinispanBaseRegion region) {
+      Object access = TEST_SESSION_ACCESS.entityAccess(region, AccessType.TRANSACTIONAL);
+      return TEST_SESSION_ACCESS.fromAccess(access);
+   }
 
-	@Override
-	protected InfinispanBaseRegion createRegion(TestRegionFactory regionFactory, String regionName) {
-		return regionFactory.buildEntityRegion(regionName, accessType);
-	}
+   @Override
+   protected InfinispanBaseRegion createRegion(TestRegionFactory regionFactory, String regionName) {
+      return regionFactory.buildEntityRegion(regionName, accessType);
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractFunctionalTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractFunctionalTest.java
@@ -59,107 +59,107 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(CustomParameterized.class)
 public abstract class AbstractFunctionalTest extends BaseNonConfigCoreFunctionalTestCase {
-	protected static final Object[] TRANSACTIONAL = new Object[]{"transactional", JtaPlatformImpl.class, JtaTransactionCoordinatorBuilderImpl.class, XaConnectionProvider.class, AccessType.TRANSACTIONAL, CacheMode.INVALIDATION_SYNC, false, false };
-	protected static final Object[] READ_WRITE_INVALIDATION = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.INVALIDATION_SYNC, false, false };
-	protected static final Object[] READ_ONLY_INVALIDATION = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.INVALIDATION_SYNC, false, false };
-	protected static final Object[] READ_WRITE_REPLICATED = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.REPL_SYNC, false, false };
-   protected static final Object[] READ_WRITE_REPLICATED_STATS = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.REPL_SYNC, false, true };
-	protected static final Object[] READ_ONLY_REPLICATED = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.REPL_SYNC, false, false };
-	protected static final Object[] READ_ONLY_REPLICATED_STATS = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.REPL_SYNC, false, true };
-	protected static final Object[] READ_WRITE_DISTRIBUTED = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.DIST_SYNC, false, false };
-	protected static final Object[] READ_WRITE_DISTRIBUTED_STATS = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.DIST_SYNC, false, true };
-	protected static final Object[] READ_ONLY_DISTRIBUTED = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.DIST_SYNC, false, false };
-	protected static final Object[] READ_ONLY_DISTRIBUTED_STATS = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.DIST_SYNC, false, true };
-	protected static final Object[] NONSTRICT_REPLICATED = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.REPL_SYNC, true, false };
-   protected static final Object[] NONSTRICT_REPLICATED_STATS = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.REPL_SYNC, true, true };
-	protected static final Object[] NONSTRICT_DISTRIBUTED = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.DIST_SYNC, true, false };
-   protected static final Object[] NONSTRICT_DISTRIBUTED_STATS = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.DIST_SYNC, true, true };
+   protected static final Object[] TRANSACTIONAL = new Object[]{"transactional", JtaPlatformImpl.class, JtaTransactionCoordinatorBuilderImpl.class, XaConnectionProvider.class, AccessType.TRANSACTIONAL, CacheMode.INVALIDATION_SYNC, false, false};
+   protected static final Object[] READ_WRITE_INVALIDATION = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.INVALIDATION_SYNC, false, false};
+   protected static final Object[] READ_ONLY_INVALIDATION = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.INVALIDATION_SYNC, false, false};
+   protected static final Object[] READ_WRITE_REPLICATED = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.REPL_SYNC, false, false};
+   protected static final Object[] READ_WRITE_REPLICATED_STATS = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.REPL_SYNC, false, true};
+   protected static final Object[] READ_ONLY_REPLICATED = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.REPL_SYNC, false, false};
+   protected static final Object[] READ_ONLY_REPLICATED_STATS = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.REPL_SYNC, false, true};
+   protected static final Object[] READ_WRITE_DISTRIBUTED = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.DIST_SYNC, false, false};
+   protected static final Object[] READ_WRITE_DISTRIBUTED_STATS = new Object[]{"read-write", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_WRITE, CacheMode.DIST_SYNC, false, true};
+   protected static final Object[] READ_ONLY_DISTRIBUTED = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.DIST_SYNC, false, false};
+   protected static final Object[] READ_ONLY_DISTRIBUTED_STATS = new Object[]{"read-only", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.READ_ONLY, CacheMode.DIST_SYNC, false, true};
+   protected static final Object[] NONSTRICT_REPLICATED = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.REPL_SYNC, true, false};
+   protected static final Object[] NONSTRICT_REPLICATED_STATS = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.REPL_SYNC, true, true};
+   protected static final Object[] NONSTRICT_DISTRIBUTED = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.DIST_SYNC, true, false};
+   protected static final Object[] NONSTRICT_DISTRIBUTED_STATS = new Object[]{"nonstrict", NoJtaPlatform.class, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class, null, AccessType.NONSTRICT_READ_WRITE, CacheMode.DIST_SYNC, true, true};
 
-	// We need to use @ClassRule here since in @BeforeClassOnce startUp we're preparing the session factory,
-	// constructing CacheManager along - and there we check that the test has the name already set
-	@ClassRule
-	public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
+   // We need to use @ClassRule here since in @BeforeClassOnce startUp we're preparing the session factory,
+   // constructing CacheManager along - and there we check that the test has the name already set
+   @ClassRule
+   public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
 
-	@Parameterized.Parameter(value = 0)
-	public String mode;
+   @Parameterized.Parameter(value = 0)
+   public String mode;
 
-	@Parameterized.Parameter(value = 1)
-	public Class<? extends JtaPlatform> jtaPlatformClass;
+   @Parameterized.Parameter(value = 1)
+   public Class<? extends JtaPlatform> jtaPlatformClass;
 
-	@Parameterized.Parameter(value = 2)
-	public Class<?> transactionCoordinatorBuilderClass;
+   @Parameterized.Parameter(value = 2)
+   public Class<?> transactionCoordinatorBuilderClass;
 
-	@Parameterized.Parameter(value = 3)
-	public Class<? extends ConnectionProvider> connectionProviderClass;
+   @Parameterized.Parameter(value = 3)
+   public Class<? extends ConnectionProvider> connectionProviderClass;
 
-	@Parameterized.Parameter(value = 4)
-	public AccessType accessType;
+   @Parameterized.Parameter(value = 4)
+   public AccessType accessType;
 
-	@Parameterized.Parameter(value = 5)
-	public CacheMode cacheMode;
+   @Parameterized.Parameter(value = 5)
+   public CacheMode cacheMode;
 
-	@Parameterized.Parameter(value = 6)
-	public boolean addVersions;
+   @Parameterized.Parameter(value = 6)
+   public boolean addVersions;
 
    @Parameterized.Parameter(value = 7)
    public boolean stats;
 
    protected boolean useJta;
-	protected List<Runnable> cleanup = new ArrayList<>();
+   protected List<Runnable> cleanup = new ArrayList<>();
 
-	@CustomParameterized.Order(0)
-	@Parameterized.Parameters(name = "{0}, {5}, stats={7}")
-	public abstract List<Object[]> getParameters();
+   @CustomParameterized.Order(0)
+   @Parameterized.Parameters(name = "{0}, {5}, stats={7}")
+   public abstract List<Object[]> getParameters();
 
-	public List<Object[]> getParameters(boolean tx, boolean rw, boolean ro, boolean nonstrict, boolean stats) {
-		ArrayList<Object[]> parameters = new ArrayList<>();
-		if (tx) {
-			parameters.add(TRANSACTIONAL);
-		}
-		if (rw) {
-			parameters.add(READ_WRITE_INVALIDATION);
-			parameters.add(READ_WRITE_REPLICATED);
-			parameters.add(READ_WRITE_DISTRIBUTED);
+   public List<Object[]> getParameters(boolean tx, boolean rw, boolean ro, boolean nonstrict, boolean stats) {
+      ArrayList<Object[]> parameters = new ArrayList<>();
+      if (tx) {
+         parameters.add(TRANSACTIONAL);
+      }
+      if (rw) {
+         parameters.add(READ_WRITE_INVALIDATION);
+         parameters.add(READ_WRITE_REPLICATED);
+         parameters.add(READ_WRITE_DISTRIBUTED);
          if (stats) {
             parameters.add(READ_WRITE_REPLICATED_STATS);
             parameters.add(READ_WRITE_DISTRIBUTED_STATS);
          }
-		}
-		if (ro) {
-			parameters.add(READ_ONLY_INVALIDATION);
-			parameters.add(READ_ONLY_REPLICATED);
-			parameters.add(READ_ONLY_DISTRIBUTED);
+      }
+      if (ro) {
+         parameters.add(READ_ONLY_INVALIDATION);
+         parameters.add(READ_ONLY_REPLICATED);
+         parameters.add(READ_ONLY_DISTRIBUTED);
          if (stats) {
             parameters.add(READ_ONLY_REPLICATED_STATS);
             parameters.add(READ_ONLY_DISTRIBUTED_STATS);
          }
-		}
-		if (nonstrict) {
-			parameters.add(NONSTRICT_REPLICATED);
-			parameters.add(NONSTRICT_DISTRIBUTED);
+      }
+      if (nonstrict) {
+         parameters.add(NONSTRICT_REPLICATED);
+         parameters.add(NONSTRICT_DISTRIBUTED);
          if (stats) {
             parameters.add(NONSTRICT_REPLICATED_STATS);
             parameters.add(NONSTRICT_DISTRIBUTED_STATS);
          }
-		}
-		return parameters;
-	}
+      }
+      return parameters;
+   }
 
-	@BeforeClassOnce
-	public void setUseJta() {
-		useJta = jtaPlatformClass != NoJtaPlatform.class;
-	}
+   @BeforeClassOnce
+   public void setUseJta() {
+      useJta = jtaPlatformClass != NoJtaPlatform.class;
+   }
 
-	@Override
-	protected void prepareTest() throws Exception {
-		infinispanTestIdentifier.joinContext();
-	}
+   @Override
+   protected void prepareTest() throws Exception {
+      infinispanTestIdentifier.joinContext();
+   }
 
-	@After
-	public void runCleanup() {
-		cleanup.forEach(Runnable::run);
-		cleanup.clear();
-	}
+   @After
+   public void runCleanup() {
+      cleanup.forEach(Runnable::run);
+      cleanup.clear();
+   }
 
    @Override
    protected String getBaseForMappings() {
@@ -167,98 +167,98 @@ public abstract class AbstractFunctionalTest extends BaseNonConfigCoreFunctional
    }
 
    @Override
-	public String[] getMappings() {
-		return new String[] {
-				"hibernate/cache/commons/functional/entities/Item.hbm.xml",
-				"hibernate/cache/commons/functional/entities/Customer.hbm.xml",
-				"hibernate/cache/commons/functional/entities/Contact.hbm.xml"
-		};
-	}
+   public String[] getMappings() {
+      return new String[]{
+            "hibernate/cache/commons/functional/entities/Item.hbm.xml",
+            "hibernate/cache/commons/functional/entities/Customer.hbm.xml",
+            "hibernate/cache/commons/functional/entities/Contact.hbm.xml"
+      };
+   }
 
-	@Override
-	protected void afterMetadataBuilt(Metadata metadata) {
-		if (addVersions) {
-			for (PersistentClass clazz : metadata.getEntityBindings()) {
-				if (clazz.getVersion() != null) {
-					continue;
-				}
-				try {
-					clazz.getMappedClass().getMethod("getVersion");
-					clazz.getMappedClass().getMethod("setVersion", long.class);
-				} catch (NoSuchMethodException e) {
-					continue;
-				}
-				RootClass rootClazz = clazz.getRootClass();
-				Property versionProperty = new Property();
-				versionProperty.setName("version");
-				SimpleValue value = new BasicValue(((MetadataImplementor) metadata).getTypeConfiguration().getMetadataBuildingContext(), rootClazz.getTable());
-				value.setTypeName("long");
-				Column column = new Column();
-				column.setValue(value);
-				column.setName("version");
-				value.addColumn(column);
-				rootClazz.getTable().addColumn(column);
-				versionProperty.setValue(value);
-				rootClazz.setVersion(versionProperty);
-				rootClazz.addProperty(versionProperty);
-			}
-		}
-	}
+   @Override
+   protected void afterMetadataBuilt(Metadata metadata) {
+      if (addVersions) {
+         for (PersistentClass clazz : metadata.getEntityBindings()) {
+            if (clazz.getVersion() != null) {
+               continue;
+            }
+            try {
+               clazz.getMappedClass().getMethod("getVersion");
+               clazz.getMappedClass().getMethod("setVersion", long.class);
+            } catch (NoSuchMethodException e) {
+               continue;
+            }
+            RootClass rootClazz = clazz.getRootClass();
+            Property versionProperty = new Property();
+            versionProperty.setName("version");
+            SimpleValue value = new BasicValue(((MetadataImplementor) metadata).getTypeConfiguration().getMetadataBuildingContext(), rootClazz.getTable());
+            value.setTypeName("long");
+            Column column = new Column();
+            column.setValue(value);
+            column.setName("version");
+            value.addColumn(column);
+            rootClazz.getTable().addColumn(column);
+            versionProperty.setValue(value);
+            rootClazz.setVersion(versionProperty);
+            rootClazz.addProperty(versionProperty);
+         }
+      }
+   }
 
-	@Override
-	public String getCacheConcurrencyStrategy() {
-		return accessType.getExternalName();
-	}
+   @Override
+   public String getCacheConcurrencyStrategy() {
+      return accessType.getExternalName();
+   }
 
-	protected boolean getUseQueryCache() {
-		return true;
-	}
+   protected boolean getUseQueryCache() {
+      return true;
+   }
 
-	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
-		super.addSettings( settings );
+   @Override
+   @SuppressWarnings("unchecked")
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
 
-		settings.put( Environment.USE_SECOND_LEVEL_CACHE, "true" );
-		settings.put( Environment.GENERATE_STATISTICS, "true" );
-		settings.put( Environment.USE_QUERY_CACHE, String.valueOf( getUseQueryCache() ) );
-		settings.put( Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName() );
-		settings.put( Environment.CACHE_KEYS_FACTORY, SimpleCacheKeysFactory.SHORT_NAME );
-		settings.put( TestRegionFactory.TRANSACTIONAL, useTransactionalCache() );
-		settings.put( TestRegionFactory.CACHE_MODE, cacheMode);
-      settings.put( TestRegionFactory.STATS, stats);
+      settings.put(Environment.USE_SECOND_LEVEL_CACHE, "true");
+      settings.put(Environment.GENERATE_STATISTICS, "true");
+      settings.put(Environment.USE_QUERY_CACHE, String.valueOf(getUseQueryCache()));
+      settings.put(Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName());
+      settings.put(Environment.CACHE_KEYS_FACTORY, SimpleCacheKeysFactory.SHORT_NAME);
+      settings.put(TestRegionFactory.TRANSACTIONAL, useTransactionalCache());
+      settings.put(TestRegionFactory.CACHE_MODE, cacheMode);
+      settings.put(TestRegionFactory.STATS, stats);
 
-		settings.put( AvailableSettings.JTA_PLATFORM, jtaPlatformClass.getName() );
-		settings.put( Environment.TRANSACTION_COORDINATOR_STRATEGY, transactionCoordinatorBuilderClass.getName() );
-		if ( connectionProviderClass != null) {
-			settings.put(Environment.CONNECTION_PROVIDER, connectionProviderClass.getName());
-		}
-	}
+      settings.put(AvailableSettings.JTA_PLATFORM, jtaPlatformClass.getName());
+      settings.put(Environment.TRANSACTION_COORDINATOR_STRATEGY, transactionCoordinatorBuilderClass.getName());
+      if (connectionProviderClass != null) {
+         settings.put(Environment.CONNECTION_PROVIDER, connectionProviderClass.getName());
+      }
+   }
 
-	protected void markRollbackOnly(Session session) {
-		TxUtil.markRollbackOnly(useJta, session);
-	}
+   protected void markRollbackOnly(Session session) {
+      TxUtil.markRollbackOnly(useJta, session);
+   }
 
-	protected CountDownLatch expectAfterUpdate(AdvancedCache cache, int numUpdates) {
-		return expectReadWriteKeyCommand(cache, FutureUpdate.class::isInstance, numUpdates);
-	}
+   protected CountDownLatch expectAfterUpdate(AdvancedCache cache, int numUpdates) {
+      return expectReadWriteKeyCommand(cache, FutureUpdate.class::isInstance, numUpdates);
+   }
 
-	protected CountDownLatch expectEvict(AdvancedCache cache, int numUpdates) {
-		return expectReadWriteKeyCommand(cache, f -> f instanceof TombstoneUpdate && ((TombstoneUpdate) f).getValue() == null, numUpdates);
-	}
+   protected CountDownLatch expectEvict(AdvancedCache cache, int numUpdates) {
+      return expectReadWriteKeyCommand(cache, f -> f instanceof TombstoneUpdate && ((TombstoneUpdate) f).getValue() == null, numUpdates);
+   }
 
-	protected CountDownLatch expectReadWriteKeyCommand(AdvancedCache cache, Predicate<Object> valuePredicate, int numUpdates) {
-		if (!cacheMode.isInvalidation()) {
-			CountDownLatch latch = new CountDownLatch(numUpdates);
-			ExpectingInterceptor.get(cache)
-				.when((ctx, cmd) -> cmd instanceof ReadWriteKeyCommand && valuePredicate.test(((ReadWriteKeyCommand) cmd).getFunction()))
-				.countDown(latch);
-			cleanup.add(() -> ExpectingInterceptor.cleanup(cache));
-			return latch;
-		} else {
-			return new CountDownLatch(0);
-		}
-	}
+   protected CountDownLatch expectReadWriteKeyCommand(AdvancedCache cache, Predicate<Object> valuePredicate, int numUpdates) {
+      if (!cacheMode.isInvalidation()) {
+         CountDownLatch latch = new CountDownLatch(numUpdates);
+         ExpectingInterceptor.get(cache)
+               .when((ctx, cmd) -> cmd instanceof ReadWriteKeyCommand && valuePredicate.test(((ReadWriteKeyCommand) cmd).getFunction()))
+               .countDown(latch);
+         cleanup.add(() -> ExpectingInterceptor.cleanup(cache));
+         return latch;
+      } else {
+         return new CountDownLatch(0);
+      }
+   }
 
    protected CountDownLatch expectAfterEndInvalidation(AdvancedCache cache, int numInvalidates) {
       CountDownLatch latch = new CountDownLatch(numInvalidates);
@@ -270,11 +270,11 @@ public abstract class AbstractFunctionalTest extends BaseNonConfigCoreFunctional
       wrapInboundInvocationHandler(cache, handler -> ((ExpectingInboundInvocationHandler) handler).getDelegate());
    }
 
-	protected boolean useTransactionalCache() {
-		return TestRegionFactoryProvider.load().supportTransactionalCaches() && accessType == AccessType.TRANSACTIONAL;
-	}
+   protected boolean useTransactionalCache() {
+      return TestRegionFactoryProvider.load().supportTransactionalCaches() && accessType == AccessType.TRANSACTIONAL;
+   }
 
-	private static final class ExpectingInboundInvocationHandler extends AbstractDelegatingHandler {
+   private static final class ExpectingInboundInvocationHandler extends AbstractDelegatingHandler {
 
       private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider
             .getLog(ExpectingInboundInvocationHandler.class);

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractNonInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/AbstractNonInvalidationTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
 
          @Override
          public Thread newThread(Runnable r) {
-            return new Thread(r, "Executor-" +  counter.incrementAndGet());
+            return new Thread(r, "Executor-" + counter.incrementAndGet());
          }
       });
    }
@@ -160,7 +160,7 @@ public abstract class AbstractNonInvalidationTest extends SingleNodeTest {
             }
             s.flush();
          } catch (StaleStateException | OptimisticLockException
-            | PessimisticLockException | org.hibernate.PessimisticLockException | LockTimeoutException e) {
+                  | PessimisticLockException | org.hibernate.PessimisticLockException | LockTimeoutException e) {
             log.info("Exception thrown: ", e);
             markRollbackOnly(s);
             return false;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/BulkOperationsTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/BulkOperationsTest.java
@@ -11,13 +11,13 @@ import java.util.Set;
 
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.stat.CacheRegionStatistics;
+import org.infinispan.commons.time.ControlledTimeService;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Contact;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Customer;
 import org.infinispan.test.hibernate.cache.commons.util.InfinispanTestingSetup;
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
-import org.infinispan.commons.time.ControlledTimeService;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,13 +37,13 @@ public class BulkOperationsTest extends SingleNodeTest {
    @Rule
    public TestName name = new TestName();
 
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(true, true, false, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, false, true, true);
+   }
 
-	@ClassRule
-	public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
+   @ClassRule
+   public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
 
    @Override
    protected String getBaseForMappings() {
@@ -51,12 +51,12 @@ public class BulkOperationsTest extends SingleNodeTest {
    }
 
    @Override
-	public String[] getMappings() {
-		return new String[] {
-				"hibernate/cache/commons/functional/entities/Contact.hbm.xml",
-				"hibernate/cache/commons/functional/entities/Customer.hbm.xml"
-		};
-	}
+   public String[] getMappings() {
+      return new String[]{
+            "hibernate/cache/commons/functional/entities/Contact.hbm.xml",
+            "hibernate/cache/commons/functional/entities/Customer.hbm.xml"
+      };
+   }
 
    @Override
    protected void addSettings(Map settings) {
@@ -64,188 +64,185 @@ public class BulkOperationsTest extends SingleNodeTest {
       settings.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
    }
 
-	@Test
-	public void testBulkOperations() throws Throwable {
+   @Test
+   public void testBulkOperations() throws Throwable {
       log.infof("*** %s", name.getMethodName());
 
-		boolean cleanedUp = false;
-		try {
-			createContacts();
+      boolean cleanedUp = false;
+      try {
+         createContacts();
 
-			List<Integer> rhContacts = getContactsByCustomer("Red Hat");
-			assertNotNull("Red Hat contacts exist", rhContacts);
-			assertEquals("Created expected number of Red Hat contacts", 10, rhContacts.size());
+         List<Integer> rhContacts = getContactsByCustomer("Red Hat");
+         assertNotNull("Red Hat contacts exist", rhContacts);
+         assertEquals("Created expected number of Red Hat contacts", 10, rhContacts.size());
 
-			CacheRegionStatistics contactSlcs = sessionFactory()
-					.getStatistics()
-					.getCacheRegionStatistics(Contact.class.getName());
-			assertEquals(20, contactSlcs.getElementCountInMemory());
+         CacheRegionStatistics contactSlcs = sessionFactory()
+               .getStatistics()
+               .getCacheRegionStatistics(Contact.class.getName());
+         assertEquals(20, contactSlcs.getElementCountInMemory());
 
-			assertEquals("Deleted all Red Hat contacts", 10, deleteContacts());
-			assertEquals(0, contactSlcs.getElementCountInMemory());
+         assertEquals("Deleted all Red Hat contacts", 10, deleteContacts());
+         assertEquals(0, contactSlcs.getElementCountInMemory());
 
-			List<Integer> jbContacts = getContactsByCustomer("JBoss");
-			assertNotNull("JBoss contacts exist", jbContacts);
-			assertEquals("JBoss contacts remain", 10, jbContacts.size());
+         List<Integer> jbContacts = getContactsByCustomer("JBoss");
+         assertNotNull("JBoss contacts exist", jbContacts);
+         assertEquals("JBoss contacts remain", 10, jbContacts.size());
 
-			for (Integer id : rhContacts) {
-				assertNull("Red Hat contact " + id + " cannot be retrieved", getContact(id));
-			}
-			rhContacts = getContactsByCustomer("Red Hat");
-			if (rhContacts != null) {
-				assertEquals("No Red Hat contacts remain", 0, rhContacts.size());
-			}
+         for (Integer id : rhContacts) {
+            assertNull("Red Hat contact " + id + " cannot be retrieved", getContact(id));
+         }
+         rhContacts = getContactsByCustomer("Red Hat");
+         if (rhContacts != null) {
+            assertEquals("No Red Hat contacts remain", 0, rhContacts.size());
+         }
 
-			updateContacts("Kabir", "Updated");
-			assertEquals(0, contactSlcs.getElementCountInMemory());
+         updateContacts("Kabir", "Updated");
+         assertEquals(0, contactSlcs.getElementCountInMemory());
 
-			// Advance so that invalidation can be seen as past and data can be loaded
-			TIME_SERVICE.advance(1);
+         // Advance so that invalidation can be seen as past and data can be loaded
+         TIME_SERVICE.advance(1);
 
-			for (Integer id : jbContacts) {
-				Contact contact = getContact(id);
-				assertNotNull("JBoss contact " + id + " exists", contact);
-				String expected = ("Kabir".equals(contact.getName())) ? "Updated" : "2222";
-				assertEquals("JBoss contact " + id + " has correct TLF", expected, contact.getTlf());
-			}
+         for (Integer id : jbContacts) {
+            Contact contact = getContact(id);
+            assertNotNull("JBoss contact " + id + " exists", contact);
+            String expected = ("Kabir".equals(contact.getName())) ? "Updated" : "2222";
+            assertEquals("JBoss contact " + id + " has correct TLF", expected, contact.getTlf());
+         }
 
-			List<Integer> updated = getContactsByTLF("Updated");
-			assertNotNull("Got updated contacts", updated);
-			assertEquals("Updated contacts", 5, updated.size());
+         List<Integer> updated = getContactsByTLF("Updated");
+         assertNotNull("Got updated contacts", updated);
+         assertEquals("Updated contacts", 5, updated.size());
 
-			assertEquals(10, contactSlcs.getElementCountInMemory());
-			updateContactsWithOneManual("Kabir", "UpdatedAgain");
-			// In the other types the
-			assertEquals((accessType == AccessType.TRANSACTIONAL ||
-							(accessType == AccessType.READ_WRITE && cacheMode == CacheMode.INVALIDATION_SYNC)) ? 1 : 0,
-					contactSlcs.getElementCountInMemory());
-			for (Integer id : jbContacts) {
-				Contact contact = getContact(id);
-				assertNotNull("JBoss contact " + id + " exists", contact);
-				String expected = ("Kabir".equals(contact.getName())) ? "UpdatedAgain" : "2222";
-				assertEquals("JBoss contact " + id + " has correct TLF", expected, contact.getTlf());
-			}
+         assertEquals(10, contactSlcs.getElementCountInMemory());
+         updateContactsWithOneManual("Kabir", "UpdatedAgain");
+         // In the other types the
+         assertEquals((accessType == AccessType.TRANSACTIONAL ||
+                     (accessType == AccessType.READ_WRITE && cacheMode == CacheMode.INVALIDATION_SYNC)) ? 1 : 0,
+               contactSlcs.getElementCountInMemory());
+         for (Integer id : jbContacts) {
+            Contact contact = getContact(id);
+            assertNotNull("JBoss contact " + id + " exists", contact);
+            String expected = ("Kabir".equals(contact.getName())) ? "UpdatedAgain" : "2222";
+            assertEquals("JBoss contact " + id + " has correct TLF", expected, contact.getTlf());
+         }
 
-			updated = getContactsByTLF("UpdatedAgain");
-			assertNotNull("Got updated contacts", updated);
-			assertEquals("Updated contacts", 5, updated.size());
-		}
-		catch (Throwable t) {
-			cleanedUp = true;
-			cleanup( true );
-			throw t;
-		}
-		finally {
-			// cleanup the db so we can run this test multiple times w/o restarting the cluster
-			if ( !cleanedUp ) {
-				cleanup( false );
-			}
-		}
-	}
+         updated = getContactsByTLF("UpdatedAgain");
+         assertNotNull("Got updated contacts", updated);
+         assertEquals("Updated contacts", 5, updated.size());
+      } catch (Throwable t) {
+         cleanedUp = true;
+         cleanup(true);
+         throw t;
+      } finally {
+         // cleanup the db so we can run this test multiple times w/o restarting the cluster
+         if (!cleanedUp) {
+            cleanup(false);
+         }
+      }
+   }
 
-	public void createContacts() throws Exception {
-		withTxSession(s -> {
-			for ( int i = 0; i < 10; i++ ) {
-				Customer c = createCustomer( i );
-				s.persist(c);
-			}
-		});
-	}
+   public void createContacts() throws Exception {
+      withTxSession(s -> {
+         for (int i = 0; i < 10; i++) {
+            Customer c = createCustomer(i);
+            s.persist(c);
+         }
+      });
+   }
 
-	public int deleteContacts() throws Exception {
-		String deleteHQL = "delete Contact where customer in "
-			+ " (select customer FROM Customer as customer where customer.name = :cName)";
+   public int deleteContacts() throws Exception {
+      String deleteHQL = "delete Contact where customer in "
+            + " (select customer FROM Customer as customer where customer.name = :cName)";
 
-		int rowsAffected = withTxSessionApply(s ->
-				TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, deleteHQL, new String[]{"cName", "Red Hat"}));
-		return rowsAffected;
-	}
+      int rowsAffected = withTxSessionApply(s ->
+            TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, deleteHQL, new String[]{"cName", "Red Hat"}));
+      return rowsAffected;
+   }
 
-	@SuppressWarnings( {"unchecked"})
-	public List<Integer> getContactsByCustomer(String customerName) throws Exception {
-		String selectHQL = "select contact.id from Contact contact"
-			+ " where contact.customer.name = :cName";
+   @SuppressWarnings({"unchecked"})
+   public List<Integer> getContactsByCustomer(String customerName) throws Exception {
+      String selectHQL = "select contact.id from Contact contact"
+            + " where contact.customer.name = :cName";
 
-		return (List<Integer>) withTxSessionApply(s ->
-         TEST_SESSION_ACCESS.execQueryListAutoFlush(s, selectHQL, new String[]{"cName", customerName}));
-	}
+      return (List<Integer>) withTxSessionApply(s ->
+            TEST_SESSION_ACCESS.execQueryListAutoFlush(s, selectHQL, new String[]{"cName", customerName}));
+   }
 
-	@SuppressWarnings( {"unchecked"})
-	public List<Integer> getContactsByTLF(String tlf) throws Exception {
-		String selectHQL = "select contact.id from Contact contact"
-			+ " where contact.tlf = :cTLF";
+   @SuppressWarnings({"unchecked"})
+   public List<Integer> getContactsByTLF(String tlf) throws Exception {
+      String selectHQL = "select contact.id from Contact contact"
+            + " where contact.tlf = :cTLF";
 
-		return (List<Integer>) withTxSessionApply(s ->
-         TEST_SESSION_ACCESS.execQueryListAutoFlush(s, selectHQL, new String[]{"cTLF", tlf}));
-	}
+      return (List<Integer>) withTxSessionApply(s ->
+            TEST_SESSION_ACCESS.execQueryListAutoFlush(s, selectHQL, new String[]{"cTLF", tlf}));
+   }
 
-	public int updateContacts(String name, String newTLF) throws Exception {
-		String updateHQL = "update Contact set tlf = :cNewTLF where name = :cName";
-		return withTxSessionApply(s ->
-         TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, updateHQL,
-            new String[]{"cNewTLF", newTLF},
-            new String[]{"cName", name}));
-	}
+   public int updateContacts(String name, String newTLF) throws Exception {
+      String updateHQL = "update Contact set tlf = :cNewTLF where name = :cName";
+      return withTxSessionApply(s ->
+            TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, updateHQL,
+                  new String[]{"cNewTLF", newTLF},
+                  new String[]{"cName", name}));
+   }
 
-	public int updateContactsWithOneManual(String name, String newTLF) throws Exception {
-		String queryHQL = "from Contact c where c.name = :cName";
-		String updateHQL = "update Contact set tlf = :cNewTLF where name = :cName";
-		return withTxSessionApply(s -> {
-			List<Contact> list = TEST_SESSION_ACCESS.execQueryList(s, queryHQL, new String[]{"cName", name});
-			list.get(0).setTlf(newTLF);
-			return TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, updateHQL,
+   public int updateContactsWithOneManual(String name, String newTLF) throws Exception {
+      String queryHQL = "from Contact c where c.name = :cName";
+      String updateHQL = "update Contact set tlf = :cNewTLF where name = :cName";
+      return withTxSessionApply(s -> {
+         List<Contact> list = TEST_SESSION_ACCESS.execQueryList(s, queryHQL, new String[]{"cName", name});
+         list.get(0).setTlf(newTLF);
+         return TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, updateHQL,
                new String[]{"cNewTLF", newTLF},
                new String[]{"cName", name});
-		});
-	}
+      });
+   }
 
-	public Contact getContact(Integer id) throws Exception {
-		return withTxSessionApply(s -> s.get( Contact.class, id ));
-	}
+   public Contact getContact(Integer id) throws Exception {
+      return withTxSessionApply(s -> s.get(Contact.class, id));
+   }
 
-	public void cleanup(boolean ignore) throws Exception {
-		String deleteContactHQL = "delete from Contact";
-		String deleteCustomerHQL = "delete from Customer";
-		withTxSession(s -> {
+   public void cleanup(boolean ignore) throws Exception {
+      String deleteContactHQL = "delete from Contact";
+      String deleteCustomerHQL = "delete from Customer";
+      withTxSession(s -> {
          TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, deleteContactHQL);
          TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, deleteCustomerHQL);
-		});
-	}
+      });
+   }
 
-	private Customer createCustomer(int id) throws Exception {
-		log.trace("CREATE CUSTOMER " + id);
-		try {
-			Customer customer = new Customer();
-			customer.setName( (id % 2 == 0) ? "JBoss" : "Red Hat" );
-			Set<Contact> contacts = new HashSet<Contact>();
+   private Customer createCustomer(int id) throws Exception {
+      log.trace("CREATE CUSTOMER " + id);
+      try {
+         Customer customer = new Customer();
+         customer.setName((id % 2 == 0) ? "JBoss" : "Red Hat");
+         Set<Contact> contacts = new HashSet<Contact>();
 
-			Contact kabir = new Contact();
-			kabir.setCustomer( customer );
-			kabir.setName( "Kabir" );
-			kabir.setTlf( "1111" );
-			contacts.add( kabir );
+         Contact kabir = new Contact();
+         kabir.setCustomer(customer);
+         kabir.setName("Kabir");
+         kabir.setTlf("1111");
+         contacts.add(kabir);
 
-			Contact bill = new Contact();
-			bill.setCustomer( customer );
-			bill.setName( "Bill" );
-			bill.setTlf( "2222" );
-			contacts.add( bill );
+         Contact bill = new Contact();
+         bill.setCustomer(customer);
+         bill.setName("Bill");
+         bill.setTlf("2222");
+         contacts.add(bill);
 
-			customer.setContacts( contacts );
+         customer.setContacts(contacts);
 
-			return customer;
-		}
-		finally {
-			log.trace("CREATE CUSTOMER " + id + " -  END");
-		}
-	}
+         return customer;
+      } finally {
+         log.trace("CREATE CUSTOMER " + id + " -  END");
+      }
+   }
 
    /**
     * A time service that whenever you ask it for the time, it moves the clock forward.
-    *
+    * <p>
     * This time service guarantees that after a session timestamp has been generated,
     * the next time the region is invalidated and the time is checked, this time is forward in time.
-    *
+    * <p>
     * By doing that, we can guarantee that when a region is invalidated in same session,
     * the region invalidation timestamp will be in the future and we avoid potential invalid things being added to second level cache.
     * More info can be found in {@link org.infinispan.hibernate.cache.commons.access.FutureUpdateSynchronization}.

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ConcurrentWriteTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ConcurrentWriteTest.java
@@ -34,394 +34,388 @@ import org.junit.Test;
  * @author Galder Zamarreño
  */
 public class ConcurrentWriteTest extends SingleNodeTest {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( ConcurrentWriteTest.class );
-	/**
-	 * when USER_COUNT==1, tests pass, when >4 tests fail
-	 */
-	private static final int USER_COUNT = 5;
-	private static final int ITERATION_COUNT = 150;
-	private static final int THINK_TIME_MILLIS = 10;
-	private static final long LAUNCH_INTERVAL_MILLIS = 10;
-	private static final Random random = new Random();
-	private static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(ConcurrentWriteTest.class);
+   /**
+    * when USER_COUNT==1, tests pass, when >4 tests fail
+    */
+   private static final int USER_COUNT = 5;
+   private static final int ITERATION_COUNT = 150;
+   private static final int THINK_TIME_MILLIS = 10;
+   private static final long LAUNCH_INTERVAL_MILLIS = 10;
+   private static final Random random = new Random();
+   private static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
 
-	/**
-	 * kill switch used to stop all users when one fails
-	 */
-	private static volatile boolean TERMINATE_ALL_USERS = false;
+   /**
+    * kill switch used to stop all users when one fails
+    */
+   private static volatile boolean TERMINATE_ALL_USERS = false;
 
-	/**
-	 * collection of IDs of all customers participating in this test
-	 */
-	private final Set<Integer> customerIDs = new HashSet<Integer>();
+   /**
+    * collection of IDs of all customers participating in this test
+    */
+   private final Set<Integer> customerIDs = new HashSet<Integer>();
 
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(true, true, false, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, false, true, true);
+   }
 
-	@Override
-	protected void prepareTest() throws Exception {
-		super.prepareTest();
-		TERMINATE_ALL_USERS = false;
-	}
+   @Override
+   protected void prepareTest() throws Exception {
+      super.prepareTest();
+      TERMINATE_ALL_USERS = false;
+   }
 
-	@Override
-	protected void addSettings(Map settings) {
-		super.addSettings(settings);
-		settings.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
-	}
+   @Override
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
+      settings.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
+   }
 
-	@Override
-	protected void cleanupTest() throws Exception {
-		try {
-			super.cleanupTest();
-		}
-		finally {
-			cleanup();
-		}
-	}
+   @Override
+   protected void cleanupTest() throws Exception {
+      try {
+         super.cleanupTest();
+      } finally {
+         cleanup();
+      }
+   }
 
-	@Test
-	public void testPingDb() throws Exception {
-		withTxSession(s -> TEST_SESSION_ACCESS.execQueryList(s, "from " + Customer.class.getName()));
-	}
+   @Test
+   public void testPingDb() throws Exception {
+      withTxSession(s -> TEST_SESSION_ACCESS.execQueryList(s, "from " + Customer.class.getName()));
+   }
 
-	@Test
-	public void testSingleUser() throws Exception {
-		// setup
-		sessionFactory().getStatistics().clear();
-		// wait a while to make sure that timestamp comparison works after invalidateRegion
-		TIME_SERVICE.advance(1);
+   @Test
+   public void testSingleUser() throws Exception {
+      // setup
+      sessionFactory().getStatistics().clear();
+      // wait a while to make sure that timestamp comparison works after invalidateRegion
+      TIME_SERVICE.advance(1);
 
-		Customer customer = createCustomer( 0 );
-		final Integer customerId = customer.getId();
-		getCustomerIDs().add( customerId );
+      Customer customer = createCustomer(0);
+      final Integer customerId = customer.getId();
+      getCustomerIDs().add(customerId);
 
-		// wait a while to make sure that timestamp comparison works after collection remove (during insert)
-		TIME_SERVICE.advance(1);
+      // wait a while to make sure that timestamp comparison works after collection remove (during insert)
+      TIME_SERVICE.advance(1);
 
-		assertNull( "contact exists despite not being added", getFirstContact( customerId ) );
+      assertNull("contact exists despite not being added", getFirstContact(customerId));
 
-		// check that cache was hit
-		CacheRegionStatistics customerSlcs = sessionFactory()
-				.getStatistics()
-				.getCacheRegionStatistics(Customer.class.getName());
-		assertEquals( 1, customerSlcs.getPutCount() );
-		assertEquals( 1, customerSlcs.getElementCountInMemory() );
-		assertEquals( 1, TEST_SESSION_ACCESS.getRegion(sessionFactory(), Customer.class.getName()).getElementCountInMemory());
+      // check that cache was hit
+      CacheRegionStatistics customerSlcs = sessionFactory()
+            .getStatistics()
+            .getCacheRegionStatistics(Customer.class.getName());
+      assertEquals(1, customerSlcs.getPutCount());
+      assertEquals(1, customerSlcs.getElementCountInMemory());
+      assertEquals(1, TEST_SESSION_ACCESS.getRegion(sessionFactory(), Customer.class.getName()).getElementCountInMemory());
 
-		log.infof( "Add contact to customer {0}", customerId );
-		String contactsRegionName = Customer.class.getName() + ".contacts";
-		CacheRegionStatistics contactsCollectionSlcs = sessionFactory()
-				.getStatistics()
-				.getCacheRegionStatistics(contactsRegionName);
-		assertEquals( 1, contactsCollectionSlcs.getPutCount() );
-		assertEquals( 1, contactsCollectionSlcs.getElementCountInMemory() );
-		assertEquals( 1, TEST_SESSION_ACCESS.getRegion(sessionFactory(), contactsRegionName).getElementCountInMemory());
+      log.infof("Add contact to customer {0}", customerId);
+      String contactsRegionName = Customer.class.getName() + ".contacts";
+      CacheRegionStatistics contactsCollectionSlcs = sessionFactory()
+            .getStatistics()
+            .getCacheRegionStatistics(contactsRegionName);
+      assertEquals(1, contactsCollectionSlcs.getPutCount());
+      assertEquals(1, contactsCollectionSlcs.getElementCountInMemory());
+      assertEquals(1, TEST_SESSION_ACCESS.getRegion(sessionFactory(), contactsRegionName).getElementCountInMemory());
 
-		final Contact contact = addContact( customerId );
-		assertNotNull( "contact returned by addContact is null", contact );
-		assertEquals(
-				"Customer.contacts cache was not invalidated after addContact", 0,
-				contactsCollectionSlcs.getElementCountInMemory()
-		);
+      final Contact contact = addContact(customerId);
+      assertNotNull("contact returned by addContact is null", contact);
+      assertEquals(
+            "Customer.contacts cache was not invalidated after addContact", 0,
+            contactsCollectionSlcs.getElementCountInMemory()
+      );
 
-		assertNotNull( "Contact missing after successful add call", getFirstContact( customerId ) );
+      assertNotNull("Contact missing after successful add call", getFirstContact(customerId));
 
-		// read everyone's contacts
-		readEveryonesFirstContact();
+      // read everyone's contacts
+      readEveryonesFirstContact();
 
-		removeContact( customerId );
-		assertNull( "contact still exists after successful remove call", getFirstContact( customerId ) );
+      removeContact(customerId);
+      assertNull("contact still exists after successful remove call", getFirstContact(customerId));
 
-	}
+   }
 
-	// Ignoring the test as it's more of a stress-test: this should be enabled manually
-	@Ignore
-	@Test
-	public void testManyUsers() throws Throwable {
-		try {
-			// setup - create users
-			for ( int i = 0; i < USER_COUNT; i++ ) {
-				Customer customer = createCustomer( 0 );
-				getCustomerIDs().add( customer.getId() );
-			}
-			assertEquals( "failed to create enough Customers", USER_COUNT, getCustomerIDs().size() );
+   // Ignoring the test as it's more of a stress-test: this should be enabled manually
+   @Ignore
+   @Test
+   public void testManyUsers() throws Throwable {
+      try {
+         // setup - create users
+         for (int i = 0; i < USER_COUNT; i++) {
+            Customer customer = createCustomer(0);
+            getCustomerIDs().add(customer.getId());
+         }
+         assertEquals("failed to create enough Customers", USER_COUNT, getCustomerIDs().size());
 
-			final ExecutorService executor = Executors.newFixedThreadPool( USER_COUNT );
+         final ExecutorService executor = Executors.newFixedThreadPool(USER_COUNT);
 
-			CyclicBarrier barrier = new CyclicBarrier( USER_COUNT + 1 );
-			List<Future<Void>> futures = new ArrayList<Future<Void>>( USER_COUNT );
-			for ( Integer customerId : getCustomerIDs() ) {
-				Future<Void> future = executor.submit( new UserRunner( customerId, barrier ) );
-				futures.add( future );
-				Thread.sleep( LAUNCH_INTERVAL_MILLIS ); // rampup
-			}
-			barrier.await( 2, TimeUnit.MINUTES ); // wait for all threads to finish
-			log.info( "All threads finished, let's shutdown the executor and check whether any exceptions were reported" );
-			for ( Future<Void> future : futures ) {
-				future.get();
-			}
-			executor.shutdown();
-			log.info( "All future gets checked" );
-		}
-		catch (Throwable t) {
-			log.error( "Error running test", t );
-			throw t;
-		}
-	}
+         CyclicBarrier barrier = new CyclicBarrier(USER_COUNT + 1);
+         List<Future<Void>> futures = new ArrayList<Future<Void>>(USER_COUNT);
+         for (Integer customerId : getCustomerIDs()) {
+            Future<Void> future = executor.submit(new UserRunner(customerId, barrier));
+            futures.add(future);
+            Thread.sleep(LAUNCH_INTERVAL_MILLIS); // rampup
+         }
+         barrier.await(2, TimeUnit.MINUTES); // wait for all threads to finish
+         log.info("All threads finished, let's shutdown the executor and check whether any exceptions were reported");
+         for (Future<Void> future : futures) {
+            future.get();
+         }
+         executor.shutdown();
+         log.info("All future gets checked");
+      } catch (Throwable t) {
+         log.error("Error running test", t);
+         throw t;
+      }
+   }
 
-	public void cleanup() throws Exception {
-		getCustomerIDs().clear();
-		String deleteContactHQL = "delete from Contact";
-		String deleteCustomerHQL = "delete from Customer";
-		withTxSession(s -> {
+   public void cleanup() throws Exception {
+      getCustomerIDs().clear();
+      String deleteContactHQL = "delete from Contact";
+      String deleteCustomerHQL = "delete from Customer";
+      withTxSession(s -> {
          TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, deleteContactHQL);
          TEST_SESSION_ACCESS.execQueryUpdateAutoFlush(s, deleteCustomerHQL);
-		});
-	}
+      });
+   }
 
-	private Customer createCustomer(int nameSuffix) throws Exception {
-		return withTxSessionApply(s -> {
-			Customer customer = new Customer();
-			customer.setName( "customer_" + nameSuffix );
-			customer.setContacts( new HashSet<Contact>() );
-			s.persist( customer );
-			return customer;
-		});
-	}
+   private Customer createCustomer(int nameSuffix) throws Exception {
+      return withTxSessionApply(s -> {
+         Customer customer = new Customer();
+         customer.setName("customer_" + nameSuffix);
+         customer.setContacts(new HashSet<Contact>());
+         s.persist(customer);
+         return customer;
+      });
+   }
 
-	/**
-	 * read first contact of every Customer participating in this test. this forces concurrent cache
-	 * writes of Customer.contacts Collection cache node
-	 *
-	 * @return who cares
-	 * @throws java.lang.Exception
-	 */
-	private void readEveryonesFirstContact() throws Exception {
-		withTxSession(s -> {
-			for ( Integer customerId : getCustomerIDs() ) {
-				if ( TERMINATE_ALL_USERS ) {
-					markRollbackOnly(s);
-					return;
-				}
-				Customer customer = s.getReference( Customer.class, customerId );
-				Set<Contact> contacts = customer.getContacts();
-				if ( !contacts.isEmpty() ) {
-					contacts.iterator().next();
-				}
-			}
-		});
-	}
+   /**
+    * read first contact of every Customer participating in this test. this forces concurrent cache
+    * writes of Customer.contacts Collection cache node
+    *
+    * @return who cares
+    * @throws java.lang.Exception
+    */
+   private void readEveryonesFirstContact() throws Exception {
+      withTxSession(s -> {
+         for (Integer customerId : getCustomerIDs()) {
+            if (TERMINATE_ALL_USERS) {
+               markRollbackOnly(s);
+               return;
+            }
+            Customer customer = s.getReference(Customer.class, customerId);
+            Set<Contact> contacts = customer.getContacts();
+            if (!contacts.isEmpty()) {
+               contacts.iterator().next();
+            }
+         }
+      });
+   }
 
-	/**
-	 * -load existing Customer -get customer's contacts; return 1st one
-	 *
-	 * @param customerId
-	 * @return first Contact or null if customer has none
-	 */
-	private Contact getFirstContact(Integer customerId) throws Exception {
-		assert customerId != null;
-		return withTxSessionApply(s -> {
-			Customer customer = s.getReference(Customer.class, customerId);
-			Set<Contact> contacts = customer.getContacts();
-			Contact firstContact = contacts.isEmpty() ? null : contacts.iterator().next();
-			if (TERMINATE_ALL_USERS) {
-				markRollbackOnly(s);
-			}
-			return firstContact;
-		});
-	}
+   /**
+    * -load existing Customer -get customer's contacts; return 1st one
+    *
+    * @param customerId
+    * @return first Contact or null if customer has none
+    */
+   private Contact getFirstContact(Integer customerId) throws Exception {
+      assert customerId != null;
+      return withTxSessionApply(s -> {
+         Customer customer = s.getReference(Customer.class, customerId);
+         Set<Contact> contacts = customer.getContacts();
+         Contact firstContact = contacts.isEmpty() ? null : contacts.iterator().next();
+         if (TERMINATE_ALL_USERS) {
+            markRollbackOnly(s);
+         }
+         return firstContact;
+      });
+   }
 
-	/**
-	 * -load existing Customer -create a new Contact and add to customer's contacts
-	 *
-	 * @param customerId
-	 * @return added Contact
-	 */
-	private Contact addContact(Integer customerId) throws Exception {
-		assert customerId != null;
-		return withTxSessionApply(s -> {
-			final Customer customer = s.getReference(Customer.class, customerId);
-			Contact contact = new Contact();
-			contact.setName("contact name");
-			contact.setTlf("wtf is tlf?");
-			contact.setCustomer(customer);
-			customer.getContacts().add(contact);
-			s.persist(contact);
-			// assuming contact is persisted via cascade from customer
-			if (TERMINATE_ALL_USERS) {
-				markRollbackOnly(s);
-			}
-			return contact;
-		});
-	}
+   /**
+    * -load existing Customer -create a new Contact and add to customer's contacts
+    *
+    * @param customerId
+    * @return added Contact
+    */
+   private Contact addContact(Integer customerId) throws Exception {
+      assert customerId != null;
+      return withTxSessionApply(s -> {
+         final Customer customer = s.getReference(Customer.class, customerId);
+         Contact contact = new Contact();
+         contact.setName("contact name");
+         contact.setTlf("wtf is tlf?");
+         contact.setCustomer(customer);
+         customer.getContacts().add(contact);
+         s.persist(contact);
+         // assuming contact is persisted via cascade from customer
+         if (TERMINATE_ALL_USERS) {
+            markRollbackOnly(s);
+         }
+         return contact;
+      });
+   }
 
-	/**
-	 * remove existing 'contact' from customer's list of contacts
-	 *
-	 * @param customerId
-	 * @throws IllegalStateException
-	 *            if customer does not own a contact
-	 */
-	private void removeContact(Integer customerId) throws Exception {
-		assert customerId != null;
+   /**
+    * remove existing 'contact' from customer's list of contacts
+    *
+    * @param customerId
+    * @throws IllegalStateException if customer does not own a contact
+    */
+   private void removeContact(Integer customerId) throws Exception {
+      assert customerId != null;
 
-		withTxSession(s -> {
-			Customer customer = s.getReference( Customer.class, customerId );
-			Set<Contact> contacts = customer.getContacts();
-			if ( contacts.size() != 1 ) {
-				throw new IllegalStateException(
-						"can't remove contact: customer id=" + customerId
-								+ " expected exactly 1 contact, " + "actual count=" + contacts.size()
-				);
-			}
+      withTxSession(s -> {
+         Customer customer = s.getReference(Customer.class, customerId);
+         Set<Contact> contacts = customer.getContacts();
+         if (contacts.size() != 1) {
+            throw new IllegalStateException(
+                  "can't remove contact: customer id=" + customerId
+                        + " expected exactly 1 contact, " + "actual count=" + contacts.size()
+            );
+         }
 
-			Contact contact = contacts.iterator().next();
-			// H2 version 1.3 (without MVCC fails with deadlock on Contacts/Customers modification, therefore,
-			// we have to enforce locking Contacts first
-			s.lock(contact, LockMode.PESSIMISTIC_WRITE);
-			contacts.remove( contact );
-			contact.setCustomer( null );
+         Contact contact = contacts.iterator().next();
+         // H2 version 1.3 (without MVCC fails with deadlock on Contacts/Customers modification, therefore,
+         // we have to enforce locking Contacts first
+         s.lock(contact, LockMode.PESSIMISTIC_WRITE);
+         contacts.remove(contact);
+         contact.setCustomer(null);
 
-			// explicitly delete Contact because hbm has no 'DELETE_ORPHAN' cascade?
-			// getEnvironment().getSessionFactory().getCurrentSession().delete(contact); //appears to
-			// not be needed
+         // explicitly delete Contact because hbm has no 'DELETE_ORPHAN' cascade?
+         // getEnvironment().getSessionFactory().getCurrentSession().delete(contact); //appears to
+         // not be needed
 
-			// assuming contact is persisted via cascade from customer
+         // assuming contact is persisted via cascade from customer
 
-			if ( TERMINATE_ALL_USERS ) {
-				markRollbackOnly(s);
-			}
-		});
-	}
+         if (TERMINATE_ALL_USERS) {
+            markRollbackOnly(s);
+         }
+      });
+   }
 
-	/**
-	 * @return the customerIDs
-	 */
-	public Set<Integer> getCustomerIDs() {
-		return customerIDs;
-	}
+   /**
+    * @return the customerIDs
+    */
+   public Set<Integer> getCustomerIDs() {
+      return customerIDs;
+   }
 
-	private String statusOfRunnersToString(Set<UserRunner> runners) {
-		assert runners != null;
+   private String statusOfRunnersToString(Set<UserRunner> runners) {
+      assert runners != null;
 
-		StringBuilder sb = new StringBuilder(
-				"TEST CONFIG [userCount=" + USER_COUNT
-						+ ", iterationsPerUser=" + ITERATION_COUNT + ", thinkTimeMillis="
-						+ THINK_TIME_MILLIS + "] " + " STATE of UserRunners: "
-		);
+      StringBuilder sb = new StringBuilder(
+            "TEST CONFIG [userCount=" + USER_COUNT
+                  + ", iterationsPerUser=" + ITERATION_COUNT + ", thinkTimeMillis="
+                  + THINK_TIME_MILLIS + "] " + " STATE of UserRunners: "
+      );
 
-		for ( UserRunner r : runners ) {
-			sb.append( r.toString() ).append( System.lineSeparator() );
-		}
-		return sb.toString();
-	}
+      for (UserRunner r : runners) {
+         sb.append(r.toString()).append(System.lineSeparator());
+      }
+      return sb.toString();
+   }
 
-	class UserRunner implements Callable<Void> {
-		private final CyclicBarrier barrier;
-		private final Integer customerId;
-		private int completedIterations = 0;
-		private Throwable causeOfFailure;
+   class UserRunner implements Callable<Void> {
+      private final CyclicBarrier barrier;
+      private final Integer customerId;
+      private int completedIterations = 0;
+      private Throwable causeOfFailure;
 
-		public UserRunner(Integer cId, CyclicBarrier barrier) {
-			assert cId != null;
-			this.customerId = cId;
-			this.barrier = barrier;
-		}
+      public UserRunner(Integer cId, CyclicBarrier barrier) {
+         assert cId != null;
+         this.customerId = cId;
+         this.barrier = barrier;
+      }
 
-		private boolean contactExists() throws Exception {
-			return getFirstContact( customerId ) != null;
-		}
+      private boolean contactExists() throws Exception {
+         return getFirstContact(customerId) != null;
+      }
 
-		public Void call() throws Exception {
-			// name this thread for easier log tracing
-			Thread.currentThread().setName( "UserRunnerThread-" + getCustomerId() );
-			log.info( "Wait for all executions paths to be ready to perform calls" );
-			try {
-				for ( int i = 0; i < ITERATION_COUNT && !TERMINATE_ALL_USERS; i++ ) {
-					contactExists();
-					log.trace( "Add contact for customer " + customerId );
-					addContact( customerId );
-					log.trace( "Added contact" );
-					thinkRandomTime();
-					contactExists();
-					thinkRandomTime();
-					log.trace( "Read all customers' first contact" );
-					// read everyone's contacts
-					readEveryonesFirstContact();
-					log.trace( "Read completed" );
-					thinkRandomTime();
-					log.trace( "Remove contact of customer" + customerId );
-					removeContact( customerId );
-					log.trace( "Removed contact" );
-					contactExists();
-					thinkRandomTime();
-					++completedIterations;
-					log.tracef( "Iteration completed %d", completedIterations );
-				}
-			}
-			catch (Throwable t) {
-				TERMINATE_ALL_USERS = true;
-				log.error( "Error", t );
-				throw new Exception( t );
-			}
-			finally {
-				log.info( "Wait for all execution paths to finish" );
-				barrier.await();
-			}
-			return null;
-		}
+      public Void call() throws Exception {
+         // name this thread for easier log tracing
+         Thread.currentThread().setName("UserRunnerThread-" + getCustomerId());
+         log.info("Wait for all executions paths to be ready to perform calls");
+         try {
+            for (int i = 0; i < ITERATION_COUNT && !TERMINATE_ALL_USERS; i++) {
+               contactExists();
+               log.trace("Add contact for customer " + customerId);
+               addContact(customerId);
+               log.trace("Added contact");
+               thinkRandomTime();
+               contactExists();
+               thinkRandomTime();
+               log.trace("Read all customers' first contact");
+               // read everyone's contacts
+               readEveryonesFirstContact();
+               log.trace("Read completed");
+               thinkRandomTime();
+               log.trace("Remove contact of customer" + customerId);
+               removeContact(customerId);
+               log.trace("Removed contact");
+               contactExists();
+               thinkRandomTime();
+               ++completedIterations;
+               log.tracef("Iteration completed %d", completedIterations);
+            }
+         } catch (Throwable t) {
+            TERMINATE_ALL_USERS = true;
+            log.error("Error", t);
+            throw new Exception(t);
+         } finally {
+            log.info("Wait for all execution paths to finish");
+            barrier.await();
+         }
+         return null;
+      }
 
-		public boolean isSuccess() {
-			return ITERATION_COUNT == getCompletedIterations();
-		}
+      public boolean isSuccess() {
+         return ITERATION_COUNT == getCompletedIterations();
+      }
 
-		public int getCompletedIterations() {
-			return completedIterations;
-		}
+      public int getCompletedIterations() {
+         return completedIterations;
+      }
 
-		public Throwable getCauseOfFailure() {
-			return causeOfFailure;
-		}
+      public Throwable getCauseOfFailure() {
+         return causeOfFailure;
+      }
 
-		public Integer getCustomerId() {
-			return customerId;
-		}
+      public Integer getCustomerId() {
+         return customerId;
+      }
 
-		@Override
-		public String toString() {
-			return super.toString() + "[customerId=" + getCustomerId() + " iterationsCompleted="
-					+ getCompletedIterations() + " completedAll=" + isSuccess() + " causeOfFailure="
-					+ (this.causeOfFailure != null ? getStackTrace( causeOfFailure ) : "") + "] ";
-		}
-	}
+      @Override
+      public String toString() {
+         return super.toString() + "[customerId=" + getCustomerId() + " iterationsCompleted="
+               + getCompletedIterations() + " completedAll=" + isSuccess() + " causeOfFailure="
+               + (this.causeOfFailure != null ? getStackTrace(causeOfFailure) : "") + "] ";
+      }
+   }
 
-	public static String getStackTrace(Throwable throwable) {
-		StringWriter sw = new StringWriter();
-		PrintWriter pw = new PrintWriter( sw, true );
-		throwable.printStackTrace( pw );
-		return sw.getBuffer().toString();
-	}
+   public static String getStackTrace(Throwable throwable) {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw, true);
+      throwable.printStackTrace(pw);
+      return sw.getBuffer().toString();
+   }
 
-	/**
-	 * sleep between 0 and THINK_TIME_MILLIS.
-	 *
-	 * @throws RuntimeException if sleep is interrupted or TERMINATE_ALL_USERS flag was set to true i n the
-	 * meantime
-	 */
-	private void thinkRandomTime() {
-		try {
-			Thread.sleep( random.nextInt( THINK_TIME_MILLIS ) );
-		}
-		catch (InterruptedException ex) {
-			throw new RuntimeException( "sleep interrupted", ex );
-		}
+   /**
+    * sleep between 0 and THINK_TIME_MILLIS.
+    *
+    * @throws RuntimeException if sleep is interrupted or TERMINATE_ALL_USERS flag was set to true i n the
+    *                          meantime
+    */
+   private void thinkRandomTime() {
+      try {
+         Thread.sleep(random.nextInt(THINK_TIME_MILLIS));
+      } catch (InterruptedException ex) {
+         throw new RuntimeException("sleep interrupted", ex);
+      }
 
-		if ( TERMINATE_ALL_USERS ) {
-			throw new RuntimeException( "told to terminate (because a UserRunner had failed)" );
-		}
-	}
+      if (TERMINATE_ALL_USERS) {
+         throw new RuntimeException("told to terminate (because a UserRunner had failed)");
+      }
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/CustomConfigTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/CustomConfigTest.java
@@ -40,7 +40,7 @@ public class CustomConfigTest extends AbstractFunctionalTest {
 
    @Override
    protected Class[] getAnnotatedClasses() {
-      return new Class[] { TestEntity.class, OtherTestEntity.class };
+      return new Class[]{TestEntity.class, OtherTestEntity.class};
    }
 
    @Test

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/EntitiesAndCollectionsInSameRegionTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/EntitiesAndCollectionsInSameRegionTest.java
@@ -52,8 +52,8 @@ public class EntitiesAndCollectionsInSameRegionTest extends SingleNodeTest {
    @Override
    public Class[] getAnnotatedClasses() {
       return new Class[]{
-         AnEntity.class,
-         AnotherEntity.class
+            AnEntity.class,
+            AnotherEntity.class
       };
    }
 
@@ -72,10 +72,10 @@ public class EntitiesAndCollectionsInSameRegionTest extends SingleNodeTest {
       stats.clear();
 
       withTxSession(
-         s -> {
-            s.persist(anEntity);
-            s.persist(anotherEntity);
-         }
+            s -> {
+               s.persist(anEntity);
+               s.persist(anotherEntity);
+            }
       );
 
       // Then entities should have been cached, but not their collections.
@@ -90,10 +90,10 @@ public class EntitiesAndCollectionsInSameRegionTest extends SingleNodeTest {
    @After
    public void cleanup() throws Exception {
       withTxSession(
-         s -> {
-            s.remove(s.get(AnEntity.class, 1));
-            s.remove(s.get(AnotherEntity.class, 1));
-         }
+            s -> {
+               s.remove(s.get(AnEntity.class, 1));
+               s.remove(s.get(AnotherEntity.class, 1));
+            }
       );
    }
 
@@ -106,98 +106,98 @@ public class EntitiesAndCollectionsInSameRegionTest extends SingleNodeTest {
       stats.clear();
 
       withTxSession(
-         s -> {
-            AnEntity anEntity1 = s.get(AnEntity.class, anEntity.id);
+            s -> {
+               AnEntity anEntity1 = s.get(AnEntity.class, anEntity.id);
 
-            CacheRegionStatistics cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               CacheRegionStatistics cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
 
-            // anEntity1 was cached when it was persisted
-            assertEquals(0, cacheStatistics.getMissCount());
-            assertEquals(1, cacheStatistics.getHitCount());
-            assertEquals(0, cacheStatistics.getPutCount());
+               // anEntity1 was cached when it was persisted
+               assertEquals(0, cacheStatistics.getMissCount());
+               assertEquals(1, cacheStatistics.getHitCount());
+               assertEquals(0, cacheStatistics.getPutCount());
 
-            stats.clear();
+               stats.clear();
 
-            assertFalse(Hibernate.isInitialized(anEntity1.valuesSet));
-            Hibernate.initialize(anEntity1.valuesSet);
+               assertFalse(Hibernate.isInitialized(anEntity1.valuesSet));
+               Hibernate.initialize(anEntity1.valuesSet);
 
-            // anEntity1.values gets cached when it gets loadead
-            cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
-            assertEquals(1, cacheStatistics.getMissCount());
-            assertEquals(0, cacheStatistics.getHitCount());
-            assertEquals(1, cacheStatistics.getPutCount());
+               // anEntity1.values gets cached when it gets loadead
+               cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               assertEquals(1, cacheStatistics.getMissCount());
+               assertEquals(0, cacheStatistics.getHitCount());
+               assertEquals(1, cacheStatistics.getPutCount());
 
-            stats.clear();
+               stats.clear();
 
-            AnotherEntity anotherEntity1 = s.get(AnotherEntity.class, anotherEntity.id);
+               AnotherEntity anotherEntity1 = s.get(AnotherEntity.class, anotherEntity.id);
 
-            // anotherEntity1 was cached when it was persisted
-            cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
-            assertEquals(0, cacheStatistics.getMissCount());
-            assertEquals(1, cacheStatistics.getHitCount());
-            assertEquals(0, cacheStatistics.getPutCount());
+               // anotherEntity1 was cached when it was persisted
+               cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               assertEquals(0, cacheStatistics.getMissCount());
+               assertEquals(1, cacheStatistics.getHitCount());
+               assertEquals(0, cacheStatistics.getPutCount());
 
-            stats.clear();
+               stats.clear();
 
-            assertFalse(Hibernate.isInitialized(anotherEntity1.valuesSet));
-            Hibernate.initialize(anotherEntity1.valuesSet);
+               assertFalse(Hibernate.isInitialized(anotherEntity1.valuesSet));
+               Hibernate.initialize(anotherEntity1.valuesSet);
 
-            // anotherEntity1.values gets cached when it gets loadead
-            cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
-            assertEquals(1, cacheStatistics.getMissCount());
-            assertEquals(0, cacheStatistics.getHitCount());
-            assertEquals(1, cacheStatistics.getPutCount());
-         }
+               // anotherEntity1.values gets cached when it gets loadead
+               cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               assertEquals(1, cacheStatistics.getMissCount());
+               assertEquals(0, cacheStatistics.getHitCount());
+               assertEquals(1, cacheStatistics.getPutCount());
+            }
       );
 
       // The entities and their collections should all be cached now.
 
       withTxSession(
-         s -> {
+            s -> {
 
-            stats.clear();
+               stats.clear();
 
-            AnEntity anEntity1 = s.get(AnEntity.class, anEntity.id);
+               AnEntity anEntity1 = s.get(AnEntity.class, anEntity.id);
 
-            CacheRegionStatistics cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               CacheRegionStatistics cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
 
-            assertEquals(0, cacheStatistics.getMissCount());
-            assertEquals(1, cacheStatistics.getHitCount());
-            assertEquals(0, cacheStatistics.getPutCount());
+               assertEquals(0, cacheStatistics.getMissCount());
+               assertEquals(1, cacheStatistics.getHitCount());
+               assertEquals(0, cacheStatistics.getPutCount());
 
-            stats.clear();
+               stats.clear();
 
-            assertFalse(Hibernate.isInitialized(anEntity1.valuesSet));
-            Hibernate.initialize(anEntity1.valuesSet);
+               assertFalse(Hibernate.isInitialized(anEntity1.valuesSet));
+               Hibernate.initialize(anEntity1.valuesSet);
 
-            cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
-            assertEquals(0, cacheStatistics.getMissCount());
-            assertEquals(1, cacheStatistics.getHitCount());
-            assertEquals(0, cacheStatistics.getPutCount());
+               cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               assertEquals(0, cacheStatistics.getMissCount());
+               assertEquals(1, cacheStatistics.getHitCount());
+               assertEquals(0, cacheStatistics.getPutCount());
 
-            assertEquals(anEntity.valuesSet, anEntity1.valuesSet);
+               assertEquals(anEntity.valuesSet, anEntity1.valuesSet);
 
-            stats.clear();
+               stats.clear();
 
-            AnotherEntity anotherEntity1 = s.get(AnotherEntity.class, anotherEntity.id);
+               AnotherEntity anotherEntity1 = s.get(AnotherEntity.class, anotherEntity.id);
 
-            cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
-            assertEquals(0, cacheStatistics.getMissCount());
-            assertEquals(1, cacheStatistics.getHitCount());
-            assertEquals(0, cacheStatistics.getPutCount());
+               cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               assertEquals(0, cacheStatistics.getMissCount());
+               assertEquals(1, cacheStatistics.getHitCount());
+               assertEquals(0, cacheStatistics.getPutCount());
 
-            stats.clear();
+               stats.clear();
 
-            assertFalse(Hibernate.isInitialized(anotherEntity1.valuesSet));
-            Hibernate.initialize(anotherEntity1.valuesSet);
+               assertFalse(Hibernate.isInitialized(anotherEntity1.valuesSet));
+               Hibernate.initialize(anotherEntity1.valuesSet);
 
-            cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
-            assertEquals(0, cacheStatistics.getMissCount());
-            assertEquals(1, cacheStatistics.getHitCount());
-            assertEquals(0, cacheStatistics.getPutCount());
+               cacheStatistics = stats.getCacheRegionStatistics(REGION_NAME);
+               assertEquals(0, cacheStatistics.getMissCount());
+               assertEquals(1, cacheStatistics.getHitCount());
+               assertEquals(0, cacheStatistics.getPutCount());
 
-            assertEquals(anotherEntity.valuesSet, anotherEntity1.valuesSet);
-         }
+               assertEquals(anotherEntity.valuesSet, anotherEntity1.valuesSet);
+            }
       );
    }
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/EqualityTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/EqualityTest.java
@@ -1,16 +1,16 @@
 package org.infinispan.test.hibernate.cache.commons.functional;
 
-import org.hibernate.stat.Statistics;
-import org.infinispan.test.hibernate.cache.commons.functional.entities.Name;
-import org.infinispan.test.hibernate.cache.commons.functional.entities.Person;
-import org.junit.Test;
-
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.hibernate.stat.Statistics;
+import org.infinispan.test.hibernate.cache.commons.functional.entities.Name;
+import org.infinispan.test.hibernate.cache.commons.functional.entities.Person;
+import org.junit.Test;
 
 /**
  * Persons should be correctly indexed since we can use Type for comparison
@@ -18,49 +18,49 @@ import static org.junit.Assert.assertTrue;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class EqualityTest extends SingleNodeTest {
-	 @Override
-	 public List<Object[]> getParameters() {
-		  return getParameters(true, true, true, true, true);
-	 }
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, true, true, true);
+   }
 
-	 @Override
-	 protected Class[] getAnnotatedClasses() {
-		  return new Class[] { Person.class };
-	 }
+   @Override
+   protected Class[] getAnnotatedClasses() {
+      return new Class[]{Person.class};
+   }
 
-	 @Test
-	 public void testEqualityFromType() throws Exception {
-		  Person john = new Person("John", "Black", 26);
-		  Person peter = new Person("Peter", "White", 32);
+   @Test
+   public void testEqualityFromType() throws Exception {
+      Person john = new Person("John", "Black", 26);
+      Person peter = new Person("Peter", "White", 32);
 
-		  withTxSession(s -> {
-				s.persist(john);
-				s.persist(peter);
-		  });
+      withTxSession(s -> {
+         s.persist(john);
+         s.persist(peter);
+      });
 
-		  Statistics statistics = sessionFactory().getStatistics();
-		  statistics.clear();
+      Statistics statistics = sessionFactory().getStatistics();
+      statistics.clear();
 
-		  for (int i = 0; i < 5; ++i) {
-				withTxSession(s -> {
-					 Person p1 = s.get(Person.class, john.getName());
-					 assertPersonEquals(john, p1);
-					 Person p2 = s.get(Person.class, peter.getName());
-					 assertPersonEquals(peter, p2);
-					 Person p3 = s.get(Person.class, new Name("Foo", "Bar"));
-					 assertNull(p3);
-				});
-		  }
+      for (int i = 0; i < 5; ++i) {
+         withTxSession(s -> {
+            Person p1 = s.get(Person.class, john.getName());
+            assertPersonEquals(john, p1);
+            Person p2 = s.get(Person.class, peter.getName());
+            assertPersonEquals(peter, p2);
+            Person p3 = s.get(Person.class, new Name("Foo", "Bar"));
+            assertNull(p3);
+         });
+      }
 
-		  assertTrue(statistics.getSecondLevelCacheHitCount() > 0);
-		  assertTrue(statistics.getSecondLevelCacheMissCount() > 0);
-	 }
+      assertTrue(statistics.getSecondLevelCacheHitCount() > 0);
+      assertTrue(statistics.getSecondLevelCacheMissCount() > 0);
+   }
 
-	 private static void assertPersonEquals(Person expected, Person person) {
-		  assertNotNull(person);
-		  assertNotNull(person.getName());
-		  assertEquals(expected.getName().getFirstName(), person.getName().getFirstName());
-		  assertEquals(expected.getName().getLastName(), person.getName().getLastName());
-		  assertEquals(expected.getAge(), person.getAge());
-	 }
+   private static void assertPersonEquals(Person expected, Person person) {
+      assertNotNull(person);
+      assertNotNull(person.getName());
+      assertEquals(expected.getName().getFirstName(), person.getName().getFirstName());
+      assertEquals(expected.getName().getLastName(), person.getName().getLastName());
+      assertEquals(expected.getAge(), person.getAge());
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/InvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/InvalidationTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.hibernate.PessimisticLockException;
 import org.hibernate.testing.orm.junit.JiraKey;
-
 import org.infinispan.AdvancedCache;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.context.InvocationContext;
@@ -54,7 +53,7 @@ public class InvalidationTest extends SingleNodeTest {
    @JiraKey(value = "HHH-9868")
    public void testConcurrentRemoveAndPutFromLoad() throws Exception {
 
-      final Item item = new Item( "chris", "Chris's Item" );
+      final Item item = new Item("chris", "Chris's Item");
       withTxSession(s -> {
          s.persist(item);
       });

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/MultiTenancyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/MultiTenancyTest.java
@@ -28,75 +28,76 @@ import org.junit.Test;
  */
 public class MultiTenancyTest extends SingleNodeTest {
 
-	 private static final String DB1 = "db1";
-	 private static final String DB2 = "db2";
-	 private final XaConnectionProvider db1
-			 = new XaConnectionProvider(TestingUtil.buildConnectionProvider(DB1));
-	 private final XaConnectionProvider db2
-			 = new XaConnectionProvider(TestingUtil.buildConnectionProvider(DB2));
+   private static final String DB1 = "db1";
+   private static final String DB2 = "db2";
+   private final XaConnectionProvider db1
+         = new XaConnectionProvider(TestingUtil.buildConnectionProvider(DB1));
+   private final XaConnectionProvider db2
+         = new XaConnectionProvider(TestingUtil.buildConnectionProvider(DB2));
 
-	 @Override
-	 public List<Object[]> getParameters() {
-		  return Collections.singletonList(READ_ONLY_INVALIDATION);
-	 }
+   @Override
+   public List<Object[]> getParameters() {
+      return Collections.singletonList(READ_ONLY_INVALIDATION);
+   }
 
-	 @Override
-	 protected void addSettings(Map settings) {
-		  super.addSettings( settings );
-		  settings.put( Environment.CACHE_KEYS_FACTORY, DefaultCacheKeysFactory.SHORT_NAME );
-	 }
+   @Override
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
+      settings.put(Environment.CACHE_KEYS_FACTORY, DefaultCacheKeysFactory.SHORT_NAME);
+   }
 
-	 @Override
-	 protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
-		  super.configureStandardServiceRegistryBuilder(ssrb);
-		  ssrb.addService(MultiTenantConnectionProvider.class, new AbstractMultiTenantConnectionProvider() {
+   @Override
+   protected void configureStandardServiceRegistryBuilder(StandardServiceRegistryBuilder ssrb) {
+      super.configureStandardServiceRegistryBuilder(ssrb);
+      ssrb.addService(MultiTenantConnectionProvider.class, new AbstractMultiTenantConnectionProvider() {
 
-				@Override
-				protected ConnectionProvider getAnyConnectionProvider() {
-					 return db1;
-				}
+         @Override
+         protected ConnectionProvider getAnyConnectionProvider() {
+            return db1;
+         }
 
-				ConnectionProvider selectConnectionProvider(String tenantIdentifier) {
-					 if (DB1.equals(tenantIdentifier)) return db1;
-					 if (DB2.equals(tenantIdentifier)) return db2;
-					 throw new IllegalArgumentException();
-				}
-				@Override
-			   protected ConnectionProvider selectConnectionProvider(Object tenantIdentifier) {
-					if (DB1.equals(tenantIdentifier)) return db1;
-					if (DB2.equals(tenantIdentifier)) return db2;
-					throw new IllegalArgumentException();
-			   }
-		  });
-	 }
+         ConnectionProvider selectConnectionProvider(String tenantIdentifier) {
+            if (DB1.equals(tenantIdentifier)) return db1;
+            if (DB2.equals(tenantIdentifier)) return db2;
+            throw new IllegalArgumentException();
+         }
 
-	 @Override
-	 protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
-		 super.configureSessionFactoryBuilder(sfb);
-		 sfb.applyMultiTenancy(true);
-	 }
+         @Override
+         protected ConnectionProvider selectConnectionProvider(Object tenantIdentifier) {
+            if (DB1.equals(tenantIdentifier)) return db1;
+            if (DB2.equals(tenantIdentifier)) return db2;
+            throw new IllegalArgumentException();
+         }
+      });
+   }
 
-	 @Override
-	 protected void cleanupTest() throws Exception {
-		  db1.stop();
-		  db2.stop();
-	 }
+   @Override
+   protected void configureSessionFactoryBuilder(SessionFactoryBuilder sfb) {
+      super.configureSessionFactoryBuilder(sfb);
+      sfb.applyMultiTenancy(true);
+   }
 
-	 @Test
-	 public void testMultiTenancy() throws Exception {
-		  final Item item = new Item("my item", "description" );
+   @Override
+   protected void cleanupTest() throws Exception {
+      db1.stop();
+      db2.stop();
+   }
 
-		  withTxSession(sessionFactory().withOptions().tenantIdentifier(DB1), s -> s.persist(item));
+   @Test
+   public void testMultiTenancy() throws Exception {
+      final Item item = new Item("my item", "description");
 
-		  for (int i = 0; i < 5; ++i) { // make sure we get something cached
-				withTxSession(sessionFactory().withOptions().tenantIdentifier(DB1), s -> {
-						  Item item2 = s.get(Item.class, item.getId());
-						  assertNotNull(item2);
-						  assertEquals(item.getName(), item2.getName());
-				});
+      withTxSession(sessionFactory().withOptions().tenantIdentifier(DB1), s -> s.persist(item));
 
-		  }
-		  // The table ITEMS is not created in DB2 - we would get just an exception
+      for (int i = 0; i < 5; ++i) { // make sure we get something cached
+         withTxSession(sessionFactory().withOptions().tenantIdentifier(DB1), s -> {
+            Item item2 = s.get(Item.class, item.getId());
+            assertNotNull(item2);
+            assertEquals(item.getName(), item2.getName());
+         });
+
+      }
+      // The table ITEMS is not created in DB2 - we would get just an exception
 //        for (int i = 0; i < 5; ++i) { // make sure we get something cached
 //            withTx(tm, new Callable<Void>() {
 //                @Override
@@ -111,11 +112,11 @@ public class MultiTenancyTest extends SingleNodeTest {
 //                }
 //            });
 //        }
-		  InfinispanBaseRegion region = TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName());
-		  AdvancedCache localCache = region.getCache().withFlags(Flag.CACHE_MODE_LOCAL);
-		  assertEquals(1, localCache.size());
-		  try (CloseableIterator iterator = localCache.keySet().iterator()) {
-			  assertEquals("CacheKeyImplementation", iterator.next().getClass().getSimpleName());
-		  }
-	 }
+      InfinispanBaseRegion region = TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName());
+      AdvancedCache localCache = region.getCache().withFlags(Flag.CACHE_MODE_LOCAL);
+      assertEquals(1, localCache.size());
+      try (CloseableIterator iterator = localCache.keySet().iterator()) {
+         assertEquals("CacheKeyImplementation", iterator.next().getClass().getSimpleName());
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/NoTenancyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/NoTenancyTest.java
@@ -16,26 +16,26 @@ import org.junit.Test;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class NoTenancyTest extends SingleNodeTest {
-	 @Override
-	 public List<Object[]> getParameters() {
-		  return Collections.singletonList(READ_ONLY_INVALIDATION);
-	 }
+   @Override
+   public List<Object[]> getParameters() {
+      return Collections.singletonList(READ_ONLY_INVALIDATION);
+   }
 
-	 @Test
-	 public void testNoTenancy() throws Exception {
-		  final Item item = new Item("my item", "description" );
+   @Test
+   public void testNoTenancy() throws Exception {
+      final Item item = new Item("my item", "description");
 
-		  withTxSession(s -> s.persist(item));
-		  for (int i = 0; i < 5; ++i) { // make sure we get something cached
-				withTxSession(s -> {
-					  Item item2 = s.get(Item.class, item.getId());
-					  assertNotNull(item2);
-					  assertEquals(item.getName(), item2.getName());
-				});
+      withTxSession(s -> s.persist(item));
+      for (int i = 0; i < 5; ++i) { // make sure we get something cached
+         withTxSession(s -> {
+            Item item2 = s.get(Item.class, item.getId());
+            assertNotNull(item2);
+            assertEquals(item.getName(), item2.getName());
+         });
 
-		  }
-		  InfinispanBaseRegion region = TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName());
-		  AdvancedCache localCache = region.getCache().withFlags(Flag.CACHE_MODE_LOCAL);
-		  assertEquals(1, localCache.size());
-	 }
+      }
+      InfinispanBaseRegion region = TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName());
+      AdvancedCache localCache = region.getCache().withFlags(Flag.CACHE_MODE_LOCAL);
+      assertEquals(1, localCache.size());
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/NonTxQueryTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/NonTxQueryTest.java
@@ -8,9 +8,9 @@ import java.util.Map;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.hibernate.stat.Statistics;
+import org.infinispan.commons.time.ControlledTimeService;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Person;
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
-import org.infinispan.commons.time.ControlledTimeService;
 import org.junit.Test;
 
 public class NonTxQueryTest extends SingleNodeTest {

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ReadOnlyTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ReadOnlyTest.java
@@ -6,11 +6,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.hibernate.stat.Statistics;
+import org.infinispan.commons.time.ControlledTimeService;
 import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Item;
 import org.infinispan.test.hibernate.cache.commons.util.TestRegionFactory;
-import org.infinispan.commons.time.ControlledTimeService;
 import org.junit.Test;
 
 /**
@@ -21,73 +21,73 @@ import org.junit.Test;
  * @since 4.1
  */
 public class ReadOnlyTest extends SingleNodeTest {
-	protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(ReadOnlyTest.class);
-	protected static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
+   protected static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(ReadOnlyTest.class);
+   protected static final ControlledTimeService TIME_SERVICE = new ControlledTimeService();
 
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(false, false, true, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(false, false, true, true, true);
+   }
 
-	@Test
-	public void testEmptySecondLevelCacheEntry() {
-		sessionFactory().getCache().evictCollectionData(Item.class.getName() + ".items");
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
-		InfinispanBaseRegion region = TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName() + ".items");
-		assertEquals(0, region.getElementCountInMemory());
-	}
+   @Test
+   public void testEmptySecondLevelCacheEntry() {
+      sessionFactory().getCache().evictCollectionData(Item.class.getName() + ".items");
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
+      InfinispanBaseRegion region = TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName() + ".items");
+      assertEquals(0, region.getElementCountInMemory());
+   }
 
-	@Test
-	public void testInsertDeleteEntity() throws Exception {
-		final Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testInsertDeleteEntity() throws Exception {
+      final Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		final Item item = new Item( "chris", "Chris's Item" );
-		withTxSession(s -> s.persist(item));
+      final Item item = new Item("chris", "Chris's Item");
+      withTxSession(s -> s.persist(item));
 
-		log.info("Entry persisted, let's load and delete it.");
+      log.info("Entry persisted, let's load and delete it.");
 
-		withTxSession(s -> {
-			Item found = s.getReference(Item.class, item.getId());
-			log.info(stats.toString());
-			assertEquals(item.getDescription(), found.getDescription());
-			assertEquals(0, stats.getSecondLevelCacheMissCount());
-			assertEquals(1, stats.getSecondLevelCacheHitCount());
-			s.remove(found);
-		});
-	}
+      withTxSession(s -> {
+         Item found = s.getReference(Item.class, item.getId());
+         log.info(stats.toString());
+         assertEquals(item.getDescription(), found.getDescription());
+         assertEquals(0, stats.getSecondLevelCacheMissCount());
+         assertEquals(1, stats.getSecondLevelCacheHitCount());
+         s.remove(found);
+      });
+   }
 
-	@Test
-	public void testInsertClearCacheDeleteEntity() throws Exception {
-		final Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testInsertClearCacheDeleteEntity() throws Exception {
+      final Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		final Item item = new Item( "chris", "Chris's Item" );
-		withTxSession(s -> s.persist(item));
-		assertEquals(0, stats.getSecondLevelCacheMissCount());
-		assertEquals(0, stats.getSecondLevelCacheHitCount());
-		assertEquals(1, stats.getSecondLevelCachePutCount());
+      final Item item = new Item("chris", "Chris's Item");
+      withTxSession(s -> s.persist(item));
+      assertEquals(0, stats.getSecondLevelCacheMissCount());
+      assertEquals(0, stats.getSecondLevelCacheHitCount());
+      assertEquals(1, stats.getSecondLevelCachePutCount());
 
-		log.info("Entry persisted, let's load and delete it.");
+      log.info("Entry persisted, let's load and delete it.");
 
-		cleanupCache();
-		TIME_SERVICE.advance(1);
+      cleanupCache();
+      TIME_SERVICE.advance(1);
 
-		withTxSession(s -> {
-			Item found = s.getReference(Item.class, item.getId());
-			log.info(stats.toString());
-			assertEquals(item.getDescription(), found.getDescription());
-			assertEquals(1, stats.getSecondLevelCacheMissCount());
-			assertEquals(0, stats.getSecondLevelCacheHitCount());
-			assertEquals(2, stats.getSecondLevelCachePutCount());
-			s.remove(found);
-		});
-	}
+      withTxSession(s -> {
+         Item found = s.getReference(Item.class, item.getId());
+         log.info(stats.toString());
+         assertEquals(item.getDescription(), found.getDescription());
+         assertEquals(1, stats.getSecondLevelCacheMissCount());
+         assertEquals(0, stats.getSecondLevelCacheHitCount());
+         assertEquals(2, stats.getSecondLevelCachePutCount());
+         s.remove(found);
+      });
+   }
 
-	@Override
-	protected void addSettings(Map settings) {
-		super.addSettings(settings);
-		settings.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
-	}
+   @Override
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
+      settings.put(TestRegionFactory.TIME_SERVICE, TIME_SERVICE);
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ReadWriteTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/ReadWriteTest.java
@@ -44,662 +44,661 @@ import jakarta.persistence.criteria.Root;
  * @since 3.5
  */
 public class ReadWriteTest extends ReadOnlyTest {
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(true, true, false, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, false, true, true);
+   }
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Citizen.class, State.class,
-				NaturalIdOnManyToOne.class
-		};
-	}
+   @Override
+   protected Class<?>[] getAnnotatedClasses() {
+      return new Class[]{
+            Citizen.class, State.class,
+            NaturalIdOnManyToOne.class
+      };
+   }
 
-	@After
-	public void cleanupData() throws Exception {
-		super.cleanupCache();
-		withTxSession(s -> {
+   @After
+   public void cleanupData() throws Exception {
+      super.cleanupCache();
+      withTxSession(s -> {
          TEST_SESSION_ACCESS.execQueryUpdate(s, "delete NaturalIdOnManyToOne");
          TEST_SESSION_ACCESS.execQueryUpdate(s, "delete Citizen");
-         TEST_SESSION_ACCESS.execQueryUpdate(s, "delete State" );
-		});
-	}
+         TEST_SESSION_ACCESS.execQueryUpdate(s, "delete State");
+      });
+   }
 
-	@Test
-	public void testCollectionCache() throws Exception {
-		final Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testCollectionCache() throws Exception {
+      final Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		final Item item = new Item( "chris", "Chris's Item" );
-		final Item another = new Item( "another", "Owned Item" );
-		item.addItem( another );
+      final Item item = new Item("chris", "Chris's Item");
+      final Item another = new Item("another", "Owned Item");
+      item.addItem(another);
 
-		withTxSession(s -> {
-			s.persist( item );
-			s.persist( another );
-		});
-		// The collection has been removed, but we can't add it again immediately using putFromLoad
-		TIME_SERVICE.advance(1);
+      withTxSession(s -> {
+         s.persist(item);
+         s.persist(another);
+      });
+      // The collection has been removed, but we can't add it again immediately using putFromLoad
+      TIME_SERVICE.advance(1);
 
-		withTxSession(s -> {
-			Item loaded = s.getReference( Item.class, item.getId() );
-			assertEquals( 1, loaded.getItems().size() );
-		});
+      withTxSession(s -> {
+         Item loaded = s.getReference(Item.class, item.getId());
+         assertEquals(1, loaded.getItems().size());
+      });
 
-		String itemsRegionName = Item.class.getName() + ".items";
-		CacheRegionStatistics cStats = stats.getCacheRegionStatistics(itemsRegionName);
-		assertEquals( 1, cStats.getElementCountInMemory() );
+      String itemsRegionName = Item.class.getName() + ".items";
+      CacheRegionStatistics cStats = stats.getCacheRegionStatistics(itemsRegionName);
+      assertEquals(1, cStats.getElementCountInMemory());
 
-		withTxSession(s -> {
-			Item loadedWithCachedCollection = (Item) s.getReference( Item.class, item.getId() );
-			stats.logSummary();
-			assertEquals( item.getName(), loadedWithCachedCollection.getName() );
-			assertEquals( item.getItems().size(), loadedWithCachedCollection.getItems().size() );
-			assertEquals( 1, cStats.getHitCount() );
-			assertEquals( 1, TEST_SESSION_ACCESS.getRegion(sessionFactory(), itemsRegionName).getElementCountInMemory());
-			Item itemElement = loadedWithCachedCollection.getItems().iterator().next();
-			itemElement.setOwner( null );
-			loadedWithCachedCollection.getItems().clear();
-			s.remove( itemElement );
-			s.remove( loadedWithCachedCollection );
-		});
-	}
+      withTxSession(s -> {
+         Item loadedWithCachedCollection = (Item) s.getReference(Item.class, item.getId());
+         stats.logSummary();
+         assertEquals(item.getName(), loadedWithCachedCollection.getName());
+         assertEquals(item.getItems().size(), loadedWithCachedCollection.getItems().size());
+         assertEquals(1, cStats.getHitCount());
+         assertEquals(1, TEST_SESSION_ACCESS.getRegion(sessionFactory(), itemsRegionName).getElementCountInMemory());
+         Item itemElement = loadedWithCachedCollection.getItems().iterator().next();
+         itemElement.setOwner(null);
+         loadedWithCachedCollection.getItems().clear();
+         s.remove(itemElement);
+         s.remove(loadedWithCachedCollection);
+      });
+   }
 
-	@Test
-	@JiraKey( value = "HHH-9231" )
-	public void testAddNewOneToManyElementInitFlushLeaveCacheConsistent() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
-		CacheRegionStatistics cStats = stats.getCacheRegionStatistics(Item.class.getName() + ".items");
+   @Test
+   @JiraKey(value = "HHH-9231")
+   public void testAddNewOneToManyElementInitFlushLeaveCacheConsistent() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
+      CacheRegionStatistics cStats = stats.getCacheRegionStatistics(Item.class.getName() + ".items");
 
-		ByRef<Long> itemId = new ByRef<>(null);
-		saveItem(itemId);
+      ByRef<Long> itemId = new ByRef<>(null);
+      saveItem(itemId);
 
-		// create an element for item.itsms
-		Item itemElement = new Item();
-		itemElement.setName( "element" );
-		itemElement.setDescription( "element item" );
+      // create an element for item.itsms
+      Item itemElement = new Item();
+      itemElement.setName("element");
+      itemElement.setDescription("element item");
 
-		withTxSession(s -> {
-			Item item = s.get( Item.class, itemId.get() );
-			assertFalse( Hibernate.isInitialized( item.getItems() ) );
-			// Add an element to item.items (a Set); it will initialize the Set.
-			item.addItem( itemElement );
-			assertTrue( Hibernate.isInitialized( item.getItems() ) );
-			s.persist( itemElement );
-			s.flush();
-			markRollbackOnly(s);
-		});
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         assertFalse(Hibernate.isInitialized(item.getItems()));
+         // Add an element to item.items (a Set); it will initialize the Set.
+         item.addItem(itemElement);
+         assertTrue(Hibernate.isInitialized(item.getItems()));
+         s.persist(itemElement);
+         s.flush();
+         markRollbackOnly(s);
+      });
 
-		withTxSession(s -> {
-			Item item = s.get( Item.class, itemId.get() );
-			Hibernate.initialize( item.getItems() );
-			assertTrue( item.getItems().isEmpty() );
-			s.remove( item );
-		});
-	}
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         Hibernate.initialize(item.getItems());
+         assertTrue(item.getItems().isEmpty());
+         s.remove(item);
+      });
+   }
 
-	@Test
-	@JiraKey( value = "HHH-9231" )
-	public void testAddNewOneToManyElementNoInitFlushLeaveCacheConsistent() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
-		CacheRegionStatistics cStats = stats.getCacheRegionStatistics(Item.class.getName() + ".items");
+   @Test
+   @JiraKey(value = "HHH-9231")
+   public void testAddNewOneToManyElementNoInitFlushLeaveCacheConsistent() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
+      CacheRegionStatistics cStats = stats.getCacheRegionStatistics(Item.class.getName() + ".items");
 
-		ByRef<Long> itemId = new ByRef<>(null);
+      ByRef<Long> itemId = new ByRef<>(null);
 
-		saveItem(itemId);
+      saveItem(itemId);
 
-		// create an element for item.bagOfItems
-		Item itemElement = new Item();
-		itemElement.setName( "element" );
-		itemElement.setDescription( "element item" );
+      // create an element for item.bagOfItems
+      Item itemElement = new Item();
+      itemElement.setName("element");
+      itemElement.setDescription("element item");
 
-		withTxSession(s -> {
-			Item item = s.get( Item.class, itemId.get() );
-			assertFalse( Hibernate.isInitialized( item.getItems() ) );
-			// Add an element to item.bagOfItems (a bag); it will not initialize the bag.
-			item.addItemToBag( itemElement );
-			assertFalse( Hibernate.isInitialized( item.getBagOfItems() ) );
-			s.persist( itemElement );
-			s.flush();
-			markRollbackOnly(s);
-		});
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         assertFalse(Hibernate.isInitialized(item.getItems()));
+         // Add an element to item.bagOfItems (a bag); it will not initialize the bag.
+         item.addItemToBag(itemElement);
+         assertFalse(Hibernate.isInitialized(item.getBagOfItems()));
+         s.persist(itemElement);
+         s.flush();
+         markRollbackOnly(s);
+      });
 
-		withTxSession(s -> {
-			Item item = s.get( Item.class, itemId.get() );
-			Hibernate.initialize( item.getItems() );
-			assertTrue( item.getItems().isEmpty() );
-			s.remove( item );
-		});
-	}
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         Hibernate.initialize(item.getItems());
+         assertTrue(item.getItems().isEmpty());
+         s.remove(item);
+      });
+   }
 
-	@Test
-	public void testAddNewOneToManyElementNoInitFlushInitLeaveCacheConsistent() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testAddNewOneToManyElementNoInitFlushInitLeaveCacheConsistent() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		ByRef<Long> itemId = new ByRef<>(null);
+      ByRef<Long> itemId = new ByRef<>(null);
 
-		saveItem(itemId);
+      saveItem(itemId);
 
-		// create an element for item.bagOfItems
-		Item itemElement = new Item();
-		itemElement.setName( "element" );
-		itemElement.setDescription( "element item" );
+      // create an element for item.bagOfItems
+      Item itemElement = new Item();
+      itemElement.setName("element");
+      itemElement.setDescription("element item");
 
-		withTxSession(s -> {
-			Item item = s.get(Item.class, itemId.get());
-			assertFalse(Hibernate.isInitialized(item.getBagOfItems()));
-			// Add an element to item.bagOfItems (a bag); it will not initialize the bag.
-			item.addItemToBag(itemElement);
-			assertFalse(Hibernate.isInitialized(item.getBagOfItems()));
-			s.persist(itemElement);
-			s.flush();
-			// Now initialize the collection; it will contain the uncommitted itemElement.
-			Hibernate.initialize(item.getBagOfItems());
-			markRollbackOnly(s);
-		});
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         assertFalse(Hibernate.isInitialized(item.getBagOfItems()));
+         // Add an element to item.bagOfItems (a bag); it will not initialize the bag.
+         item.addItemToBag(itemElement);
+         assertFalse(Hibernate.isInitialized(item.getBagOfItems()));
+         s.persist(itemElement);
+         s.flush();
+         // Now initialize the collection; it will contain the uncommitted itemElement.
+         Hibernate.initialize(item.getBagOfItems());
+         markRollbackOnly(s);
+      });
 
-		withTxSession(s -> {
-			Item item = s.get(Item.class, itemId.get());
-			// Because of HHH-9231, the following will fail due to ObjectNotFoundException because the
-			// collection will be read from the cache and it still contains the uncommitted element,
-			// which cannot be found.
-			Hibernate.initialize(item.getBagOfItems());
-			assertTrue(item.getBagOfItems().isEmpty());
-			s.remove(item);
-		});
-	}
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         // Because of HHH-9231, the following will fail due to ObjectNotFoundException because the
+         // collection will be read from the cache and it still contains the uncommitted element,
+         // which cannot be found.
+         Hibernate.initialize(item.getBagOfItems());
+         assertTrue(item.getBagOfItems().isEmpty());
+         s.remove(item);
+      });
+   }
 
-	protected void saveItem(ByRef<Long> itemId) throws Exception {
-		withTxSession(s -> {
-			Item item = new Item();
-			item.setName( "steve" );
-			item.setDescription( "steve's item" );
-			s.persist( item );
-			itemId.set(item.getId());
-		});
-	}
+   protected void saveItem(ByRef<Long> itemId) throws Exception {
+      withTxSession(s -> {
+         Item item = new Item();
+         item.setName("steve");
+         item.setDescription("steve's item");
+         s.persist(item);
+         itemId.set(item.getId());
+      });
+   }
 
-	@Test
-	public void testAddNewManyToManyPropertyRefNoInitFlushInitLeaveCacheConsistent() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
-		CacheRegionStatistics cStats = stats.getCacheRegionStatistics(Item.class.getName() + ".items");
+   @Test
+   public void testAddNewManyToManyPropertyRefNoInitFlushInitLeaveCacheConsistent() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
+      CacheRegionStatistics cStats = stats.getCacheRegionStatistics(Item.class.getName() + ".items");
 
-		ByRef<Long> otherItemId = new ByRef<>(null);
-		withTxSession(s -> {
-			OtherItem otherItem = new OtherItem();
-			otherItem.setName( "steve" );
-			s.persist( otherItem );
-			otherItemId.set(otherItem.getId());
-		});
+      ByRef<Long> otherItemId = new ByRef<>(null);
+      withTxSession(s -> {
+         OtherItem otherItem = new OtherItem();
+         otherItem.setName("steve");
+         s.persist(otherItem);
+         otherItemId.set(otherItem.getId());
+      });
 
-		// create an element for otherItem.bagOfItems
-		Item item = new Item();
-		item.setName( "element" );
-		item.setDescription( "element Item" );
+      // create an element for otherItem.bagOfItems
+      Item item = new Item();
+      item.setName("element");
+      item.setDescription("element Item");
 
-		withTxSession(s -> {
-			OtherItem otherItem = s.get( OtherItem.class, otherItemId.get() );
-			assertFalse( Hibernate.isInitialized( otherItem.getBagOfItems() ) );
-			// Add an element to otherItem.bagOfItems (a bag); it will not initialize the bag.
-			otherItem.addItemToBag( item );
-			assertFalse( Hibernate.isInitialized( otherItem.getBagOfItems() ) );
-			s.persist( item );
-			s.flush();
-			// Now initialize the collection; it will contain the uncommitted itemElement.
-			// The many-to-many uses a property-ref
-			Hibernate.initialize( otherItem.getBagOfItems() );
-			markRollbackOnly(s);
-		});
+      withTxSession(s -> {
+         OtherItem otherItem = s.get(OtherItem.class, otherItemId.get());
+         assertFalse(Hibernate.isInitialized(otherItem.getBagOfItems()));
+         // Add an element to otherItem.bagOfItems (a bag); it will not initialize the bag.
+         otherItem.addItemToBag(item);
+         assertFalse(Hibernate.isInitialized(otherItem.getBagOfItems()));
+         s.persist(item);
+         s.flush();
+         // Now initialize the collection; it will contain the uncommitted itemElement.
+         // The many-to-many uses a property-ref
+         Hibernate.initialize(otherItem.getBagOfItems());
+         markRollbackOnly(s);
+      });
 
-		withTxSession(s -> {
-			OtherItem otherItem = s.get( OtherItem.class, otherItemId.get() );
-			// Because of HHH-9231, the following will fail due to ObjectNotFoundException because the
-			// collection will be read from the cache and it still contains the uncommitted element,
-			// which cannot be found.
-			Hibernate.initialize( otherItem.getBagOfItems() );
-			assertTrue( otherItem.getBagOfItems().isEmpty() );
-			s.remove( otherItem );
-		});
-	}
+      withTxSession(s -> {
+         OtherItem otherItem = s.get(OtherItem.class, otherItemId.get());
+         // Because of HHH-9231, the following will fail due to ObjectNotFoundException because the
+         // collection will be read from the cache and it still contains the uncommitted element,
+         // which cannot be found.
+         Hibernate.initialize(otherItem.getBagOfItems());
+         assertTrue(otherItem.getBagOfItems().isEmpty());
+         s.remove(otherItem);
+      });
+   }
 
-	@Test
-	public void testStaleWritesLeaveCacheConsistent() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testStaleWritesLeaveCacheConsistent() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		ByRef<VersionedItem> itemRef = new ByRef<>(null);
-		withTxSession(s -> {
-			VersionedItem item = new VersionedItem();
-			item.setName( "steve" );
-			item.setDescription( "steve's item" );
-			s.persist( item );
-			itemRef.set(item);
-		});
+      ByRef<VersionedItem> itemRef = new ByRef<>(null);
+      withTxSession(s -> {
+         VersionedItem item = new VersionedItem();
+         item.setName("steve");
+         item.setDescription("steve's item");
+         s.persist(item);
+         itemRef.set(item);
+      });
 
-		final VersionedItem item = itemRef.get();
-		Long initialVersion = item.getVersion();
+      final VersionedItem item = itemRef.get();
+      Long initialVersion = item.getVersion();
 
-		// manually revert the version property
-		item.setVersion(item.getVersion() - 1 );
+      // manually revert the version property
+      item.setVersion(item.getVersion() - 1);
 
-		try {
-			withTxSession(s -> s.merge(item));
-			fail("expected stale write to fail");
-		}
-		catch (Exception e) {
-			log.debug("Rollback was expected", e);
-		}
+      try {
+         withTxSession(s -> s.merge(item));
+         fail("expected stale write to fail");
+      } catch (Exception e) {
+         log.debug("Rollback was expected", e);
+      }
 
-		// check the version value in the cache...
-		Object entry = getEntry(VersionedItem.class.getName(), item.getId());
-		assertNotNull(entry);
-		Long cachedVersionValue = (Long) ((CacheEntry) entry).getVersion();
-		assertNotNull(cachedVersionValue);
-		assertEquals(initialVersion.longValue(), cachedVersionValue.longValue());
+      // check the version value in the cache...
+      Object entry = getEntry(VersionedItem.class.getName(), item.getId());
+      assertNotNull(entry);
+      Long cachedVersionValue = (Long) ((CacheEntry) entry).getVersion();
+      assertNotNull(cachedVersionValue);
+      assertEquals(initialVersion.longValue(), cachedVersionValue.longValue());
 
-		withTxSession(s -> {
-			VersionedItem item2 = s.getReference( VersionedItem.class, item.getId() );
-			s.remove( item2 );
-		});
-	}
+      withTxSession(s -> {
+         VersionedItem item2 = s.getReference(VersionedItem.class, item.getId());
+         s.remove(item2);
+      });
+   }
 
-	@Test
-	@JiraKey( value = "HHH-5690")
-	public void testPersistEntityFlushRollbackNotInEntityCache() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   @JiraKey(value = "HHH-5690")
+   public void testPersistEntityFlushRollbackNotInEntityCache() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		CacheRegionStatistics slcs = stats.getCacheRegionStatistics(Item.class.getName());
+      CacheRegionStatistics slcs = stats.getCacheRegionStatistics(Item.class.getName());
 
-		ByRef<Long> itemId = new ByRef<>(null);
-		withTxSession(s -> {
-			Item item = new Item();
-			item.setName("steve");
-			item.setDescription("steve's item");
-			s.persist(item);
-			s.flush();
-			itemId.set(item.getId());
+      ByRef<Long> itemId = new ByRef<>(null);
+      withTxSession(s -> {
+         Item item = new Item();
+         item.setName("steve");
+         item.setDescription("steve's item");
+         s.persist(item);
+         s.flush();
+         itemId.set(item.getId());
 //			assertNotNull( slcs.getEntries().get( item.getId() ) );
-			markRollbackOnly(s);
-		});
+         markRollbackOnly(s);
+      });
 
-		// item should not be in entity cache.
-		assertEquals(0, getNumberOfItems());
+      // item should not be in entity cache.
+      assertEquals(0, getNumberOfItems());
 
-		withTxSession(s -> {
-			Item item = s.get( Item.class, itemId.get() );
-			assertNull( item );
-		});
-	}
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         assertNull(item);
+      });
+   }
 
-	@Test
-	@JiraKey( value = "HHH-5690")
-	public void testPersistEntityFlushEvictGetRollbackNotInEntityCache() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
-		CacheRegionStatistics slcs = stats.getCacheRegionStatistics(Item.class.getName());
+   @Test
+   @JiraKey(value = "HHH-5690")
+   public void testPersistEntityFlushEvictGetRollbackNotInEntityCache() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
+      CacheRegionStatistics slcs = stats.getCacheRegionStatistics(Item.class.getName());
 
-		ByRef<Long> itemId = new ByRef<>(null);
-		withTxSession(s -> {
-			Item item = new Item();
-			item.setName("steve");
-			item.setDescription("steve's item");
-			s.persist(item);
-			s.flush();
-			itemId.set(item.getId());
-			// item is cached on insert.
+      ByRef<Long> itemId = new ByRef<>(null);
+      withTxSession(s -> {
+         Item item = new Item();
+         item.setName("steve");
+         item.setDescription("steve's item");
+         s.persist(item);
+         s.flush();
+         itemId.set(item.getId());
+         // item is cached on insert.
 //			assertNotNull( slcs.getEntries().get( item.getId() ) );
-			s.evict(item);
-			assertEquals(slcs.getHitCount(), 0);
-			item = s.get(Item.class, item.getId());
-			assertNotNull(item);
+         s.evict(item);
+         assertEquals(slcs.getHitCount(), 0);
+         item = s.get(Item.class, item.getId());
+         assertNotNull(item);
 //			assertEquals( slcs.getHitCount(), 1 );
 //			assertNotNull( slcs.getEntries().get( item.getId() ) );
-			markRollbackOnly(s);
-		});
+         markRollbackOnly(s);
+      });
 
-		// item should not be in entity cache.
-		//slcs = stats.getSecondLevelCacheStatistics( Item.class.getName() );
-		assertEquals(0, getNumberOfItems());
+      // item should not be in entity cache.
+      //slcs = stats.getSecondLevelCacheStatistics( Item.class.getName() );
+      assertEquals(0, getNumberOfItems());
 
-		withTxSession(s -> {
-			Item item = s.get(Item.class, itemId.get());
-			assertNull(item);
-		});
-	}
+      withTxSession(s -> {
+         Item item = s.get(Item.class, itemId.get());
+         assertNull(item);
+      });
+   }
 
-	@Test
-	public void testQueryCacheInvalidation() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testQueryCacheInvalidation() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		CacheRegionStatistics slcs = stats.getCacheRegionStatistics(Item.class.getName());
-		sessionFactory().getCache().evictEntityData(Item.class);
+      CacheRegionStatistics slcs = stats.getCacheRegionStatistics(Item.class.getName());
+      sessionFactory().getCache().evictEntityData(Item.class);
 
-		TIME_SERVICE.advance(1);
+      TIME_SERVICE.advance(1);
 
-		assertEquals(0, slcs.getPutCount());
-		assertEquals(0, slcs.getElementCountInMemory());
-		assertEquals(0, getNumberOfItems());
+      assertEquals(0, slcs.getPutCount());
+      assertEquals(0, slcs.getElementCountInMemory());
+      assertEquals(0, getNumberOfItems());
 
-		ByRef<Long> idRef = new ByRef<>(null);
-		withTxSession(s -> {
-			Item item = new Item();
-			item.setName( "widget" );
-			item.setDescription( "A really top-quality, full-featured widget." );
-			s.persist( item );
-			idRef.set( item.getId() );
-		});
+      ByRef<Long> idRef = new ByRef<>(null);
+      withTxSession(s -> {
+         Item item = new Item();
+         item.setName("widget");
+         item.setDescription("A really top-quality, full-featured widget.");
+         s.persist(item);
+         idRef.set(item.getId());
+      });
 
-		assertEquals( 1, slcs.getPutCount() );
-		assertEquals( 1, slcs.getElementCountInMemory() );
-		assertEquals( 1, getNumberOfItems());
+      assertEquals(1, slcs.getPutCount());
+      assertEquals(1, slcs.getElementCountInMemory());
+      assertEquals(1, getNumberOfItems());
 
-		withTxSession(s -> {
-			Item item = s.get(Item.class, idRef.get());
-			assertEquals(slcs.getHitCount(), 1);
-			assertEquals(slcs.getMissCount(), 0);
-			item.setDescription("A bog standard item");
-		});
+      withTxSession(s -> {
+         Item item = s.get(Item.class, idRef.get());
+         assertEquals(slcs.getHitCount(), 1);
+         assertEquals(slcs.getMissCount(), 0);
+         item.setDescription("A bog standard item");
+      });
 
-		assertEquals(slcs.getPutCount(), 2);
+      assertEquals(slcs.getPutCount(), 2);
 
-		CacheEntry entry = getEntry(Item.class.getName(), idRef.get());
-		Serializable[] ser = entry.getDisassembledState();
-		assertEquals("widget", ser[4]);
-		assertEquals("A bog standard item", ser[2]);
+      CacheEntry entry = getEntry(Item.class.getName(), idRef.get());
+      Serializable[] ser = entry.getDisassembledState();
+      assertEquals("widget", ser[4]);
+      assertEquals("A bog standard item", ser[2]);
 
-		withTxSession(s -> {
-			Item item = s.getReference(Item.class, idRef.get());
-			s.remove(item);
-		});
-	}
+      withTxSession(s -> {
+         Item item = s.getReference(Item.class, idRef.get());
+         s.remove(item);
+      });
+   }
 
-	@Test
-	public void testQueryCache() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testQueryCache() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		Item item = new Item( "chris", "Chris's Item" );
+      Item item = new Item("chris", "Chris's Item");
 
-		withTxSession(s -> s.persist( item ));
+      withTxSession(s -> s.persist(item));
 
-		// Delay added to guarantee that query cache results won't be considered
-		// as not up to date due to persist session and query results from first
-		// query happening simultaneously.
-		TIME_SERVICE.advance(60001);
+      // Delay added to guarantee that query cache results won't be considered
+      // as not up to date due to persist session and query results from first
+      // query happening simultaneously.
+      TIME_SERVICE.advance(60001);
 
-		withTxSession(s -> TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item"));
+      withTxSession(s -> TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item"));
 
-		withTxSession(s -> {
-         TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item" );
-			assertEquals( 1, stats.getQueryCacheHitCount() );
+      withTxSession(s -> {
+         TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item");
+         assertEquals(1, stats.getQueryCacheHitCount());
          TEST_SESSION_ACCESS.execQueryUpdate(s, "delete from Item");
-		});
-	}
+      });
+   }
 
-	@Test
-	public void testQueryCacheHitInSameTransaction() throws Exception {
-		Statistics stats = sessionFactory().getStatistics();
-		stats.clear();
+   @Test
+   public void testQueryCacheHitInSameTransaction() throws Exception {
+      Statistics stats = sessionFactory().getStatistics();
+      stats.clear();
 
-		Item item = new Item( "galder", "Galder's Item" );
+      Item item = new Item("galder", "Galder's Item");
 
-		withTxSession(s -> s.persist( item ));
+      withTxSession(s -> s.persist(item));
 
-		// Delay added to guarantee that query cache results won't be considered
-		// as not up to date due to persist session and query results from first
-		// query happening simultaneously.
-		TIME_SERVICE.advance(60001);
+      // Delay added to guarantee that query cache results won't be considered
+      // as not up to date due to persist session and query results from first
+      // query happening simultaneously.
+      TIME_SERVICE.advance(60001);
 
-		withTxSession(s -> {
-         TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item" );
-         TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item" );
-			assertEquals(1, stats.getQueryCacheHitCount());
-		});
+      withTxSession(s -> {
+         TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item");
+         TEST_SESSION_ACCESS.execQueryListCacheable(s, "from Item");
+         assertEquals(1, stats.getQueryCacheHitCount());
+      });
 
-		withTxSession(s -> TEST_SESSION_ACCESS.execQueryUpdate(s, "delete from Item"));
-	}
+      withTxSession(s -> TEST_SESSION_ACCESS.execQueryUpdate(s, "delete from Item"));
+   }
 
-	@Test
-	public void testNaturalIdCached() throws Exception {
-		saveSomeCitizens();
+   @Test
+   public void testNaturalIdCached() throws Exception {
+      saveSomeCitizens();
 
-		// Clear the cache before the transaction begins
-		cleanupCache();
-		TIME_SERVICE.advance(1);
+      // Clear the cache before the transaction begins
+      cleanupCache();
+      TIME_SERVICE.advance(1);
 
-		withTxSession(s -> {
-			State france = ReadWriteTest.this.getState(s, "Ile de France");
+      withTxSession(s -> {
+         State france = ReadWriteTest.this.getState(s, "Ile de France");
 
-			HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
-			CriteriaQuery<Citizen> criteria = cb.createQuery(Citizen.class);
-			Root<Citizen> root = criteria.from(Citizen.class);
-			criteria.where(cb.equal(root.get(Citizen_.ssn), "1234"), cb.equal(root.get(Citizen_.state), france));
+         HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
+         CriteriaQuery<Citizen> criteria = cb.createQuery(Citizen.class);
+         Root<Citizen> root = criteria.from(Citizen.class);
+         criteria.where(cb.equal(root.get(Citizen_.ssn), "1234"), cb.equal(root.get(Citizen_.state), france));
 
-			Statistics stats = sessionFactory().getStatistics();
-			stats.setStatisticsEnabled(true);
-			stats.clear();
-			assertEquals(
-					"Cache hits should be empty", 0, stats
-							.getNaturalIdCacheHitCount()
-			);
-			TypedQuery<Citizen> typedQuery = s.createQuery(criteria)
-					.setHint(QueryHints.HINT_CACHEABLE, "true");
+         Statistics stats = sessionFactory().getStatistics();
+         stats.setStatisticsEnabled(true);
+         stats.clear();
+         assertEquals(
+               "Cache hits should be empty", 0, stats
+                     .getNaturalIdCacheHitCount()
+         );
+         TypedQuery<Citizen> typedQuery = s.createQuery(criteria)
+               .setHint(QueryHints.HINT_CACHEABLE, "true");
 
-			// first query
-			List results = typedQuery
-					.getResultList();
-			assertEquals(1, results.size());
-			assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
-			assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
-			assertEquals("NaturalId Cache Puts", 1, stats.getNaturalIdCachePutCount());
-			assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
+         // first query
+         List results = typedQuery
+               .getResultList();
+         assertEquals(1, results.size());
+         assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
+         assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+         assertEquals("NaturalId Cache Puts", 1, stats.getNaturalIdCachePutCount());
+         assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-			// query a second time - result should be cached in session
-			typedQuery.getResultList();
-			assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
-			assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
-			assertEquals("NaturalId Cache Puts", 1, stats.getNaturalIdCachePutCount());
-			assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
+         // query a second time - result should be cached in session
+         typedQuery.getResultList();
+         assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
+         assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+         assertEquals("NaturalId Cache Puts", 1, stats.getNaturalIdCachePutCount());
+         assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-			// cleanup
-			markRollbackOnly(s);
-		});
-	}
+         // cleanup
+         markRollbackOnly(s);
+      });
+   }
 
-	@Test
-	public void testNaturalIdLoaderCached() throws Exception {
-		final Statistics stats = sessionFactory().getStatistics();
-		stats.setStatisticsEnabled( true );
-		stats.clear();
+   @Test
+   public void testNaturalIdLoaderCached() throws Exception {
+      final Statistics stats = sessionFactory().getStatistics();
+      stats.setStatisticsEnabled(true);
+      stats.clear();
 
-		assertEquals( "NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount() );
-		assertEquals( "NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount() );
-		assertEquals( "NaturalId Cache Puts", 0, stats.getNaturalIdCachePutCount() );
-		assertEquals( "NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount() );
+      assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
+      assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+      assertEquals("NaturalId Cache Puts", 0, stats.getNaturalIdCachePutCount());
+      assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-		saveSomeCitizens();
+      saveSomeCitizens();
 
-		assertEquals( "NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount() );
-		assertEquals( "NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount() );
-		assertEquals( "NaturalId Cache Puts", 2, stats.getNaturalIdCachePutCount() );
-		assertEquals( "NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount() );
+      assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
+      assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+      assertEquals("NaturalId Cache Puts", 2, stats.getNaturalIdCachePutCount());
+      assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-		//Try NaturalIdLoadAccess after insert
-		final Citizen citizen = withTxSessionApply(s -> {
-			State france = ReadWriteTest.this.getState(s, "Ile de France");
-			NaturalIdLoadAccess<Citizen> naturalIdLoader = s.byNaturalId(Citizen.class);
-			naturalIdLoader.using("ssn", "1234").using("state", france);
+      //Try NaturalIdLoadAccess after insert
+      final Citizen citizen = withTxSessionApply(s -> {
+         State france = ReadWriteTest.this.getState(s, "Ile de France");
+         NaturalIdLoadAccess<Citizen> naturalIdLoader = s.byNaturalId(Citizen.class);
+         naturalIdLoader.using("ssn", "1234").using("state", france);
 
-			//Not clearing naturalId caches, should be warm from entity loading
-			stats.clear();
+         //Not clearing naturalId caches, should be warm from entity loading
+         stats.clear();
 
-			// first query
-			Citizen c = naturalIdLoader.load();
-			assertNotNull(c);
-			assertEquals("NaturalId Cache Hits", 1, stats.getNaturalIdCacheHitCount());
-			assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
-			assertEquals("NaturalId Cache Puts", 0, stats.getNaturalIdCachePutCount());
-			assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
+         // first query
+         Citizen c = naturalIdLoader.load();
+         assertNotNull(c);
+         assertEquals("NaturalId Cache Hits", 1, stats.getNaturalIdCacheHitCount());
+         assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+         assertEquals("NaturalId Cache Puts", 0, stats.getNaturalIdCachePutCount());
+         assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-			// cleanup
-			markRollbackOnly(s);
-			return c;
-		});
+         // cleanup
+         markRollbackOnly(s);
+         return c;
+      });
 
-		// TODO: Clear caches manually via cache manager (it's faster!!)
-		cleanupCache();
-		TIME_SERVICE.advance(1);
-		stats.setStatisticsEnabled( true );
-		stats.clear();
+      // TODO: Clear caches manually via cache manager (it's faster!!)
+      cleanupCache();
+      TIME_SERVICE.advance(1);
+      stats.setStatisticsEnabled(true);
+      stats.clear();
 
-		//Try NaturalIdLoadAccess
-		withTxSession(s -> {
-			// first query
-			Citizen loadedCitizen = (Citizen) s.get( Citizen.class, citizen.getId() );
-			assertNotNull( loadedCitizen );
-			assertEquals( "NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount() );
-			assertEquals( "NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount() );
-			assertEquals( "NaturalId Cache Puts", 1, stats.getNaturalIdCachePutCount() );
-			assertEquals( "NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount() );
+      //Try NaturalIdLoadAccess
+      withTxSession(s -> {
+         // first query
+         Citizen loadedCitizen = (Citizen) s.get(Citizen.class, citizen.getId());
+         assertNotNull(loadedCitizen);
+         assertEquals("NaturalId Cache Hits", 0, stats.getNaturalIdCacheHitCount());
+         assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+         assertEquals("NaturalId Cache Puts", 1, stats.getNaturalIdCachePutCount());
+         assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-			// cleanup
-			markRollbackOnly(s);
-		});
+         // cleanup
+         markRollbackOnly(s);
+      });
 
-		// Try NaturalIdLoadAccess after load
-		withTxSession(s -> {
-			State france = ReadWriteTest.this.getState(s, "Ile de France");
-			NaturalIdLoadAccess naturalIdLoader = s.byNaturalId(Citizen.class);
-			naturalIdLoader.using( "ssn", "1234" ).using( "state", france );
+      // Try NaturalIdLoadAccess after load
+      withTxSession(s -> {
+         State france = ReadWriteTest.this.getState(s, "Ile de France");
+         NaturalIdLoadAccess naturalIdLoader = s.byNaturalId(Citizen.class);
+         naturalIdLoader.using("ssn", "1234").using("state", france);
 
-			//Not clearing naturalId caches, should be warm from entity loading
-			stats.setStatisticsEnabled( true );
-			stats.clear();
+         //Not clearing naturalId caches, should be warm from entity loading
+         stats.setStatisticsEnabled(true);
+         stats.clear();
 
-			// first query
-			Citizen loadedCitizen = (Citizen) naturalIdLoader.load();
-			assertNotNull( loadedCitizen );
-			assertEquals( "NaturalId Cache Hits", 1, stats.getNaturalIdCacheHitCount() );
-			assertEquals( "NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount() );
-			assertEquals( "NaturalId Cache Puts", 0, stats.getNaturalIdCachePutCount() );
-			assertEquals( "NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount() );
+         // first query
+         Citizen loadedCitizen = (Citizen) naturalIdLoader.load();
+         assertNotNull(loadedCitizen);
+         assertEquals("NaturalId Cache Hits", 1, stats.getNaturalIdCacheHitCount());
+         assertEquals("NaturalId Cache Misses", 0, stats.getNaturalIdCacheMissCount());
+         assertEquals("NaturalId Cache Puts", 0, stats.getNaturalIdCachePutCount());
+         assertEquals("NaturalId Cache Queries", 0, stats.getNaturalIdQueryExecutionCount());
 
-			// cleanup
-			markRollbackOnly(s);
-		});
+         // cleanup
+         markRollbackOnly(s);
+      });
 
-	}
+   }
 
-	@Test
-	public void testEntityCacheContentsAfterEvictAll() throws Exception {
-		final List<Citizen> citizens = saveSomeCitizens();
+   @Test
+   public void testEntityCacheContentsAfterEvictAll() throws Exception {
+      final List<Citizen> citizens = saveSomeCitizens();
 
-		withTxSession(s -> {
-			Cache cache = s.getSessionFactory().getCache();
+      withTxSession(s -> {
+         Cache cache = s.getSessionFactory().getCache();
 
-			Statistics stats = sessionFactory().getStatistics();
-			CacheRegionStatistics slcStats = stats.getCacheRegionStatistics(Citizen.class.getName());
+         Statistics stats = sessionFactory().getStatistics();
+         CacheRegionStatistics slcStats = stats.getCacheRegionStatistics(Citizen.class.getName());
 
-			assertTrue("2lc entity cache is expected to contain Citizen id = " + citizens.get(0).getId(),
-					cache.containsEntity(Citizen.class, citizens.get(0).getId()));
-			assertTrue("2lc entity cache is expected to contain Citizen id = " + citizens.get(1).getId(),
-					cache.containsEntity(Citizen.class, citizens.get(1).getId()));
-			assertEquals(2, slcStats.getPutCount());
+         assertTrue("2lc entity cache is expected to contain Citizen id = " + citizens.get(0).getId(),
+               cache.containsEntity(Citizen.class, citizens.get(0).getId()));
+         assertTrue("2lc entity cache is expected to contain Citizen id = " + citizens.get(1).getId(),
+               cache.containsEntity(Citizen.class, citizens.get(1).getId()));
+         assertEquals(2, slcStats.getPutCount());
 
-			cache.evictAll();
-			TIME_SERVICE.advance(1);
+         cache.evictAll();
+         TIME_SERVICE.advance(1);
 
-			assertEquals(0, slcStats.getElementCountInMemory());
-			assertFalse("2lc entity cache is expected to not contain Citizen id = " + citizens.get(0).getId(),
-					cache.containsEntity(Citizen.class, citizens.get(0).getId()));
-			assertFalse("2lc entity cache is expected to not contain Citizen id = " + citizens.get(1).getId(),
-					cache.containsEntity(Citizen.class, citizens.get(1).getId()));
+         assertEquals(0, slcStats.getElementCountInMemory());
+         assertFalse("2lc entity cache is expected to not contain Citizen id = " + citizens.get(0).getId(),
+               cache.containsEntity(Citizen.class, citizens.get(0).getId()));
+         assertFalse("2lc entity cache is expected to not contain Citizen id = " + citizens.get(1).getId(),
+               cache.containsEntity(Citizen.class, citizens.get(1).getId()));
 
-			Citizen citizen = s.getReference(Citizen.class, citizens.get(0).getId());
-			assertNotNull(citizen);
-			assertNotNull(citizen.getFirstname()); // proxy gets resolved
-			assertEquals(1, slcStats.getMissCount());
+         Citizen citizen = s.getReference(Citizen.class, citizens.get(0).getId());
+         assertNotNull(citizen);
+         assertNotNull(citizen.getFirstname()); // proxy gets resolved
+         assertEquals(1, slcStats.getMissCount());
 
-			// cleanup
-			markRollbackOnly(s);
-		});
-	}
+         // cleanup
+         markRollbackOnly(s);
+      });
+   }
 
-	@Test
-	public void testMultipleEvictAll() throws Exception {
-		final List<Citizen> citizens = saveSomeCitizens();
+   @Test
+   public void testMultipleEvictAll() throws Exception {
+      final List<Citizen> citizens = saveSomeCitizens();
 
-		withTxSession(s -> {
-			Cache cache = s.getSessionFactory().getCache();
+      withTxSession(s -> {
+         Cache cache = s.getSessionFactory().getCache();
 
-			cache.evictAll();
-			cache.evictAll();
-		});
-		withTxSession(s -> {
-			Cache cache = s.getSessionFactory().getCache();
+         cache.evictAll();
+         cache.evictAll();
+      });
+      withTxSession(s -> {
+         Cache cache = s.getSessionFactory().getCache();
 
-			cache.evictAll();
+         cache.evictAll();
 
-			s.remove(s.getReference(Citizen.class, citizens.get(0).getId()));
-			s.remove(s.getReference(Citizen.class, citizens.get(1).getId()));
-		});
-	}
+         s.remove(s.getReference(Citizen.class, citizens.get(0).getId()));
+         s.remove(s.getReference(Citizen.class, citizens.get(1).getId()));
+      });
+   }
 
-	private List<Citizen> saveSomeCitizens() throws Exception {
-		final Citizen c1 = new Citizen();
-		c1.setFirstname( "Emmanuel" );
-		c1.setLastname( "Bernard" );
-		c1.setSsn( "1234" );
+   private List<Citizen> saveSomeCitizens() throws Exception {
+      final Citizen c1 = new Citizen();
+      c1.setFirstname("Emmanuel");
+      c1.setLastname("Bernard");
+      c1.setSsn("1234");
 
-		final State france = new State();
-		france.setName( "Ile de France" );
-		c1.setState( france );
+      final State france = new State();
+      france.setName("Ile de France");
+      c1.setState(france);
 
-		final Citizen c2 = new Citizen();
-		c2.setFirstname( "Gavin" );
-		c2.setLastname( "King" );
-		c2.setSsn( "000" );
-		final State australia = new State();
-		australia.setName( "Australia" );
-		c2.setState( australia );
+      final Citizen c2 = new Citizen();
+      c2.setFirstname("Gavin");
+      c2.setLastname("King");
+      c2.setSsn("000");
+      final State australia = new State();
+      australia.setName("Australia");
+      c2.setState(australia);
 
-		withTxSession(s -> {
-			s.persist( australia );
-			s.persist( france );
-			s.persist( c1 );
-			s.persist( c2 );
-		});
+      withTxSession(s -> {
+         s.persist(australia);
+         s.persist(france);
+         s.persist(c1);
+         s.persist(c2);
+      });
 
-		List<Citizen> citizens = new ArrayList<>(2);
-		citizens.add(c1);
-		citizens.add(c2);
-		return citizens;
-	}
+      List<Citizen> citizens = new ArrayList<>(2);
+      citizens.add(c1);
+      citizens.add(c2);
+      return citizens;
+   }
 
-	private State getState(Session s, String name) {
-		HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
-		CriteriaQuery<State> criteria = cb.createQuery(State.class);
-		Root<State> root = criteria.from(State.class);
-		criteria.where(cb.equal(root.get(State_.name), name));
+   private State getState(Session s, String name) {
+      HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
+      CriteriaQuery<State> criteria = cb.createQuery(State.class);
+      Root<State> root = criteria.from(State.class);
+      criteria.where(cb.equal(root.get(State_.name), name));
 
-		return s.createQuery(criteria)
-				.setHint(QueryHints.HINT_CACHEABLE, "true")
-				.getResultList().get(0);
-	}
+      return s.createQuery(criteria)
+            .setHint(QueryHints.HINT_CACHEABLE, "true")
+            .getResultList().get(0);
+   }
 
-	private int getNumberOfItems() {
-		return (int) TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName()).getElementCountInMemory();
-	}
+   private int getNumberOfItems() {
+      return (int) TEST_SESSION_ACCESS.getRegion(sessionFactory(), Item.class.getName()).getElementCountInMemory();
+   }
 
-	private CacheEntry getEntry(String regionName, Long key) {
-		return (CacheEntry) TEST_SESSION_ACCESS.getRegion(sessionFactory(), regionName).getCache().get(key);
-	}
+   private CacheEntry getEntry(String regionName, Long key) {
+      return (CacheEntry) TEST_SESSION_ACCESS.getRegion(sessionFactory(), regionName).getCache().get(key);
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/SingleNodeTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/SingleNodeTest.java
@@ -19,46 +19,46 @@ import jakarta.transaction.TransactionManager;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class SingleNodeTest extends AbstractFunctionalTest {
-	protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
+   protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
 
-	@Override
-	protected void afterSessionFactoryBuilt(SessionFactoryImplementor sessionFactory) {
-		super.afterSessionFactoryBuilt(sessionFactory);
-		JtaPlatform jtaPlatform = sessionFactory().getServiceRegistry().getService(JtaPlatform.class);
-		assertNotNull(jtaPlatform);
-		assertEquals(jtaPlatformClass, jtaPlatform.getClass());
-	}
+   @Override
+   protected void afterSessionFactoryBuilt(SessionFactoryImplementor sessionFactory) {
+      super.afterSessionFactoryBuilt(sessionFactory);
+      JtaPlatform jtaPlatform = sessionFactory().getServiceRegistry().getService(JtaPlatform.class);
+      assertNotNull(jtaPlatform);
+      assertEquals(jtaPlatformClass, jtaPlatform.getClass());
+   }
 
-	protected void withTxSession(TxUtil.ThrowingConsumer<Session, Exception> consumer) throws Exception {
-		withTxSession(sessionFactory().withOptions(), consumer);
-	}
+   protected void withTxSession(TxUtil.ThrowingConsumer<Session, Exception> consumer) throws Exception {
+      withTxSession(sessionFactory().withOptions(), consumer);
+   }
 
-	protected void withTxSession(SessionBuilder sessionBuilder, TxUtil.ThrowingConsumer<Session, Exception> consumer) throws Exception {
-		JtaPlatform jtaPlatform = useJta ? sessionFactory().getServiceRegistry().getService(JtaPlatform.class) : null;
-		TxUtil.withTxSession(jtaPlatform, sessionBuilder, consumer);
-	}
+   protected void withTxSession(SessionBuilder sessionBuilder, TxUtil.ThrowingConsumer<Session, Exception> consumer) throws Exception {
+      JtaPlatform jtaPlatform = useJta ? sessionFactory().getServiceRegistry().getService(JtaPlatform.class) : null;
+      TxUtil.withTxSession(jtaPlatform, sessionBuilder, consumer);
+   }
 
-	protected <T> T withTxSessionApply(TxUtil.ThrowingFunction<Session, T, Exception> function) throws Exception {
-		JtaPlatform jtaPlatform = useJta ? sessionFactory().getServiceRegistry().getService(JtaPlatform.class) : null;
-		return TxUtil.withTxSessionApply(jtaPlatform, sessionFactory().withOptions(), function);
-	}
+   protected <T> T withTxSessionApply(TxUtil.ThrowingFunction<Session, T, Exception> function) throws Exception {
+      JtaPlatform jtaPlatform = useJta ? sessionFactory().getServiceRegistry().getService(JtaPlatform.class) : null;
+      return TxUtil.withTxSessionApply(jtaPlatform, sessionFactory().withOptions(), function);
+   }
 
-	protected <T> T withTx(Callable<T> callable) throws Exception {
-		if (useJta) {
-			TransactionManager tm = sessionFactory().getServiceRegistry().getService(JtaPlatform.class).retrieveTransactionManager();
-			return Caches.withinTx(tm, () -> callable.call());
-		} else {
-			return callable.call();
-		}
-	}
+   protected <T> T withTx(Callable<T> callable) throws Exception {
+      if (useJta) {
+         TransactionManager tm = sessionFactory().getServiceRegistry().getService(JtaPlatform.class).retrieveTransactionManager();
+         return Caches.withinTx(tm, () -> callable.call());
+      } else {
+         return callable.call();
+      }
+   }
 
-	public <E extends Throwable> void withSession(TxUtil.ThrowingConsumer<Session, E> consumer) throws E {
-		TxUtil.withSession(sessionFactory().withOptions(), consumer);
-	}
+   public <E extends Throwable> void withSession(TxUtil.ThrowingConsumer<Session, E> consumer) throws E {
+      TxUtil.withSession(sessionFactory().withOptions(), consumer);
+   }
 
 
-	public <R, E extends Throwable> R withSessionApply(TxUtil.ThrowingFunction<Session, R, E> function) throws E {
-		return TxUtil.withSessionApply(sessionFactory().withOptions(), function);
-	}
+   public <R, E extends Throwable> R withSessionApply(TxUtil.ThrowingFunction<Session, R, E> function) throws E {
+      return TxUtil.withSessionApply(sessionFactory().withOptions(), function);
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/TombstoneTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/TombstoneTest.java
@@ -14,9 +14,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-
-import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.hibernate.testing.orm.junit.JiraKey;
+import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.distribution.BlockingInterceptor;
 import org.infinispan.hibernate.cache.commons.util.Tombstone;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Item;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/VersionedTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/VersionedTest.java
@@ -291,7 +291,7 @@ public class VersionedTest extends AbstractNonInvalidationTest {
       CollectionUpdateTestInterceptor collectionUpdateTestInterceptor = new CollectionUpdateTestInterceptor(putFromLoadLatch);
       AnotherCollectionUpdateTestInterceptor anotherInterceptor = new AnotherCollectionUpdateTestInterceptor(putFromLoadLatch, committing);
       AsyncInterceptorChain interceptorChain = extractInterceptorChain(collectionCache);
-      interceptorChain.addInterceptorBefore( collectionUpdateTestInterceptor, CallInterceptor.class );
+      interceptorChain.addInterceptorBefore(collectionUpdateTestInterceptor, CallInterceptor.class);
       interceptorChain.addInterceptor(anotherInterceptor, 0);
 
       TIME_SERVICE.advance(1);

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/AbstractPartialUpdateTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/AbstractPartialUpdateTest.java
@@ -39,8 +39,8 @@ public abstract class AbstractPartialUpdateTest extends DualNodeTest {
       localFactory = sessionFactory();
       remoteFactory = secondNodeEnvironment().getSessionFactory();
       remoteCustomerCache = ClusterAware
-         .getCacheManager(DualNodeTest.REMOTE)
-         .getCache(Customer.class.getName()).getAdvancedCache();
+            .getCacheManager(DualNodeTest.REMOTE)
+            .getCache(Customer.class.getName()).getAdvancedCache();
    }
 
    public String getDbName() {
@@ -50,14 +50,14 @@ public abstract class AbstractPartialUpdateTest extends DualNodeTest {
    @Test
    public void testPartialUpdate() throws Exception {
       final AsyncInterceptor failureInterceptor =
-         addFailureInducingInterceptor(remoteCustomerCache);
+            addFailureInducingInterceptor(remoteCustomerCache);
 
       try {
          // Remote update latch
          CountDownLatch remoteLatch = new CountDownLatch(2);
          ExpectingInterceptor.get(remoteCustomerCache)
-            .when((ctx, cmd) -> cmd instanceof ReadWriteKeyCommand)
-            .countDown(remoteLatch);
+               .when((ctx, cmd) -> cmd instanceof ReadWriteKeyCommand)
+               .countDown(remoteLatch);
 
          try {
             Statistics statsNode0 = getStatistics(localFactory);
@@ -100,7 +100,7 @@ public abstract class AbstractPartialUpdateTest extends DualNodeTest {
          }
       } finally {
          extractInterceptorChain(remoteCustomerCache)
-            .removeInterceptor(failureInterceptor.getClass());
+               .removeInterceptor(failureInterceptor.getClass());
       }
    }
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/AccountDAO.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/AccountDAO.java
@@ -16,156 +16,156 @@ import org.infinispan.test.hibernate.cache.commons.functional.entities.AccountHo
  * @author Brian Stansberry
  */
 public class AccountDAO {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(AccountDAO.class);
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(AccountDAO.class);
 
-	private final boolean useJta;
-	private final SessionFactory sessionFactory;
+   private final boolean useJta;
+   private final SessionFactory sessionFactory;
 
-	private final AccountHolder smith = new AccountHolder("Smith", "1000");
-	private final AccountHolder jones = new AccountHolder("Jones", "2000");
-	private final AccountHolder barney = new AccountHolder("Barney", "3000");
+   private final AccountHolder smith = new AccountHolder("Smith", "1000");
+   private final AccountHolder jones = new AccountHolder("Jones", "2000");
+   private final AccountHolder barney = new AccountHolder("Barney", "3000");
 
-	public AccountDAO(boolean useJta, SessionFactory sessionFactory) throws Exception {
-		this.useJta = useJta;
-		this.sessionFactory = sessionFactory;
-	}
+   public AccountDAO(boolean useJta, SessionFactory sessionFactory) throws Exception {
+      this.useJta = useJta;
+      this.sessionFactory = sessionFactory;
+   }
 
-	public AccountHolder getSmith() {
-		return smith;
-	}
+   public AccountHolder getSmith() {
+      return smith;
+   }
 
-	public AccountHolder getJones() {
-		return jones;
-	}
+   public AccountHolder getJones() {
+      return jones;
+   }
 
-	public AccountHolder getBarney() {
-		return barney;
-	}
+   public AccountHolder getBarney() {
+      return barney;
+   }
 
-	public void updateAccountBranch(Integer id, String branch) throws Exception {
-		withTxSession(useJta, sessionFactory, session -> {
-			log.debug("Updating account " + id + " to branch " + branch);
-			Account account = session.get(Account.class, id);
-			log.debug("Set branch " + branch);
-			account.setBranch(branch);
-			session.merge(account);
-			log.debug("Updated account " + id + " to branch " + branch);
-		});
-	}
+   public void updateAccountBranch(Integer id, String branch) throws Exception {
+      withTxSession(useJta, sessionFactory, session -> {
+         log.debug("Updating account " + id + " to branch " + branch);
+         Account account = session.get(Account.class, id);
+         log.debug("Set branch " + branch);
+         account.setBranch(branch);
+         session.merge(account);
+         log.debug("Updated account " + id + " to branch " + branch);
+      });
+   }
 
-	public int getCountForBranch(String branch, boolean useRegion) throws Exception {
-		return withTxSessionApply(useJta, sessionFactory, session -> {
-			Query query = session.createQuery(
-					"select account from Account as account where account.branch = :branch");
-			query.setParameter("branch", branch);
-			if (useRegion) {
-				query.setCacheRegion("AccountRegion");
-			}
-			query.setCacheable(true);
-			return query.list().size();
-		});
-	}
+   public int getCountForBranch(String branch, boolean useRegion) throws Exception {
+      return withTxSessionApply(useJta, sessionFactory, session -> {
+         Query query = session.createQuery(
+               "select account from Account as account where account.branch = :branch");
+         query.setParameter("branch", branch);
+         if (useRegion) {
+            query.setCacheRegion("AccountRegion");
+         }
+         query.setCacheable(true);
+         return query.list().size();
+      });
+   }
 
-	public void createAccount(AccountHolder holder, Integer id, Integer openingBalance, String branch) throws Exception {
-		withTxSession(useJta, sessionFactory, session -> {
-			log.debug("Creating account " + id);
-			Account account = new Account();
-			account.setId(id);
-			account.setAccountHolder(holder);
-			account.setBalance(openingBalance);
-			log.debug("Set branch " + branch);
-			account.setBranch(branch);
-			session.persist(account);
-			log.debug("Created account " + id);
-		});
-	}
+   public void createAccount(AccountHolder holder, Integer id, Integer openingBalance, String branch) throws Exception {
+      withTxSession(useJta, sessionFactory, session -> {
+         log.debug("Creating account " + id);
+         Account account = new Account();
+         account.setId(id);
+         account.setAccountHolder(holder);
+         account.setBalance(openingBalance);
+         log.debug("Set branch " + branch);
+         account.setBranch(branch);
+         session.persist(account);
+         log.debug("Created account " + id);
+      });
+   }
 
-	public Account getAccount(Integer id) throws Exception {
-		return withTxSessionApply(useJta, sessionFactory, session -> {
-			log.debug("Getting account " + id);
-			return session.get(Account.class, id);
-		});
-	}
+   public Account getAccount(Integer id) throws Exception {
+      return withTxSessionApply(useJta, sessionFactory, session -> {
+         log.debug("Getting account " + id);
+         return session.get(Account.class, id);
+      });
+   }
 
-	public Account getAccountWithRefresh(Integer id) throws Exception {
-		return withTxSessionApply(useJta, sessionFactory, session -> {
-			log.debug("Getting account " + id + " with refresh");
-			Account acct = session.get(Account.class, id);
-			session.refresh(acct);
-			return session.get(Account.class, id);
-		});
-	}
+   public Account getAccountWithRefresh(Integer id) throws Exception {
+      return withTxSessionApply(useJta, sessionFactory, session -> {
+         log.debug("Getting account " + id + " with refresh");
+         Account acct = session.get(Account.class, id);
+         session.refresh(acct);
+         return session.get(Account.class, id);
+      });
+   }
 
-	public void updateAccountBalance(Integer id, Integer newBalance) throws Exception {
-		withTxSession(useJta, sessionFactory, session -> {
-			log.debug("Updating account " + id + " to balance " + newBalance);
-			Account account = session.get(Account.class, id);
-			account.setBalance(newBalance);
-			session.merge(account);
-			log.debug("Updated account " + id + " to balance " + newBalance);
-		});
-	}
+   public void updateAccountBalance(Integer id, Integer newBalance) throws Exception {
+      withTxSession(useJta, sessionFactory, session -> {
+         log.debug("Updating account " + id + " to balance " + newBalance);
+         Account account = session.get(Account.class, id);
+         account.setBalance(newBalance);
+         session.merge(account);
+         log.debug("Updated account " + id + " to balance " + newBalance);
+      });
+   }
 
-	public String getBranch(Object holder, boolean useRegion) throws Exception {
-		return withTxSessionApply(useJta, sessionFactory, session -> {
-			Query query = session.createQuery(
-					"select account.branch from Account as account where account.accountHolder = ?");
-			query.setParameter(0, holder);
-			if (useRegion) {
-				query.setCacheRegion("AccountRegion");
-			}
-			query.setCacheable(true);
-			return (String) query.list().get(0);
-		});
-	}
+   public String getBranch(Object holder, boolean useRegion) throws Exception {
+      return withTxSessionApply(useJta, sessionFactory, session -> {
+         Query query = session.createQuery(
+               "select account.branch from Account as account where account.accountHolder = ?");
+         query.setParameter(0, holder);
+         if (useRegion) {
+            query.setCacheRegion("AccountRegion");
+         }
+         query.setCacheable(true);
+         return (String) query.list().get(0);
+      });
+   }
 
-	public int getTotalBalance(AccountHolder holder, boolean useRegion) throws Exception {
-		List results = (List) withTxSessionApply(useJta, sessionFactory, session -> {
-			Query query = session.createQuery(
-					"select account.balance from Account as account where account.accountHolder = ?");
-			query.setParameter(0, holder);
-			if (useRegion) {
-				query.setCacheRegion("AccountRegion");
-			}
-			query.setCacheable(true);
-			return query.list();
-		});
-		int total = 0;
-		if (results != null) {
-			for (Iterator it = results.iterator(); it.hasNext();) {
-				total += ((Integer) it.next()).intValue();
-				System.out.println("Total = " + total);
-			}
-		}
-		return total;
-	}
+   public int getTotalBalance(AccountHolder holder, boolean useRegion) throws Exception {
+      List results = (List) withTxSessionApply(useJta, sessionFactory, session -> {
+         Query query = session.createQuery(
+               "select account.balance from Account as account where account.accountHolder = ?");
+         query.setParameter(0, holder);
+         if (useRegion) {
+            query.setCacheRegion("AccountRegion");
+         }
+         query.setCacheable(true);
+         return query.list();
+      });
+      int total = 0;
+      if (results != null) {
+         for (Iterator it = results.iterator(); it.hasNext(); ) {
+            total += ((Integer) it.next()).intValue();
+            System.out.println("Total = " + total);
+         }
+      }
+      return total;
+   }
 
-	public void cleanup() throws Exception {
-		internalCleanup();
-	}
+   public void cleanup() throws Exception {
+      internalCleanup();
+   }
 
-	private void internalCleanup() throws Exception {
-		withTxSession(useJta, sessionFactory, session -> {
-			Query query = session.createQuery("select account from Account as account");
-			List accts = query.list();
-			if (accts != null) {
-				for (Iterator it = accts.iterator(); it.hasNext(); ) {
-					try {
-						Object acct = it.next();
-						log.info("Removing " + acct);
-						session.remove(acct);
-					} catch (Exception ignored) {
-					}
-				}
-			}
-		});
-	}
+   private void internalCleanup() throws Exception {
+      withTxSession(useJta, sessionFactory, session -> {
+         Query query = session.createQuery("select account from Account as account");
+         List accts = query.list();
+         if (accts != null) {
+            for (Iterator it = accts.iterator(); it.hasNext(); ) {
+               try {
+                  Object acct = it.next();
+                  log.info("Removing " + acct);
+                  session.remove(acct);
+               } catch (Exception ignored) {
+               }
+            }
+         }
+      });
+   }
 
-	public void remove() {
-		try {
-			internalCleanup();
-		} catch (Exception e) {
-			log.error("Caught exception in remove", e);
-		}
-	}
+   public void remove() {
+      try {
+         internalCleanup();
+      } catch (Exception e) {
+         log.error("Caught exception in remove", e);
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeConnectionProviderImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeConnectionProviderImpl.java
@@ -5,8 +5,8 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import org.hibernate.HibernateException;
-import org.hibernate.service.UnknownUnwrapTypeException;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.service.UnknownUnwrapTypeException;
 import org.hibernate.service.spi.Configurable;
 import org.hibernate.service.spi.Stoppable;
 import org.hibernate.testing.env.ConnectionProviderBuilder;
@@ -22,25 +22,23 @@ public class DualNodeConnectionProviderImpl implements ConnectionProvider, Confi
    private String nodeId;
    private boolean isTransactional;
 
-	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
-		return DualNodeConnectionProviderImpl.class.isAssignableFrom( unwrapType ) ||
-				ConnectionProvider.class.isAssignableFrom( unwrapType );
-	}
+   @Override
+   public boolean isUnwrappableAs(Class unwrapType) {
+      return DualNodeConnectionProviderImpl.class.isAssignableFrom(unwrapType) ||
+            ConnectionProvider.class.isAssignableFrom(unwrapType);
+   }
 
-	@Override
-	@SuppressWarnings( {"unchecked"})
-	public <T> T unwrap(Class<T> unwrapType) {
-		if ( DualNodeConnectionProviderImpl.class.isAssignableFrom( unwrapType ) ) {
-			return (T) this;
-		}
-		else if ( ConnectionProvider.class.isAssignableFrom( unwrapType ) ) {
-			return (T) actualConnectionProvider;
-		}
-		else {
-			throw new UnknownUnwrapTypeException( unwrapType );
-		}
-	}
+   @Override
+   @SuppressWarnings({"unchecked"})
+   public <T> T unwrap(Class<T> unwrapType) {
+      if (DualNodeConnectionProviderImpl.class.isAssignableFrom(unwrapType)) {
+         return (T) this;
+      } else if (ConnectionProvider.class.isAssignableFrom(unwrapType)) {
+         return (T) actualConnectionProvider;
+      } else {
+         throw new UnknownUnwrapTypeException(unwrapType);
+      }
+   }
 
    public static ConnectionProvider getActualConnectionProvider() {
       return actualConnectionProvider;
@@ -48,14 +46,14 @@ public class DualNodeConnectionProviderImpl implements ConnectionProvider, Confi
 
    public void setNodeId(String nodeId) throws HibernateException {
       if (nodeId == null) {
-         throw new HibernateException( "nodeId not configured" );
-	  }
-	  this.nodeId = nodeId;
+         throw new HibernateException("nodeId not configured");
+      }
+      this.nodeId = nodeId;
    }
 
    public Connection getConnection() throws SQLException {
       DualNodeJtaTransactionImpl currentTransaction = DualNodeJtaTransactionManagerImpl
-               .getInstance(nodeId).getCurrentTransaction();
+            .getInstance(nodeId).getCurrentTransaction();
       if (currentTransaction == null) {
          isTransactional = false;
          return actualConnectionProvider.getConnection();
@@ -77,17 +75,17 @@ public class DualNodeConnectionProviderImpl implements ConnectionProvider, Confi
    }
 
    public void close() throws HibernateException {
-	   if ( actualConnectionProvider instanceof Stoppable ) {
-		   ( ( Stoppable ) actualConnectionProvider ).stop();
-	   }
+      if (actualConnectionProvider instanceof Stoppable) {
+         ((Stoppable) actualConnectionProvider).stop();
+      }
    }
 
    public boolean supportsAggressiveRelease() {
       return true;
    }
 
-	@Override
-	public void configure(Map configurationValues) {
-		nodeId = (String) configurationValues.get( "nodeId" );
-	}
+   @Override
+   public void configure(Map configurationValues) {
+      nodeId = (String) configurationValues.get("nodeId");
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeJtaPlatformImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeJtaPlatformImpl.java
@@ -18,51 +18,50 @@ import jakarta.transaction.UserTransaction;
  * @author Steve Ebersole
  */
 public class DualNodeJtaPlatformImpl implements JtaPlatform, Configurable {
-	private String nodeId;
+   private String nodeId;
 
-	public DualNodeJtaPlatformImpl() {
-	}
+   public DualNodeJtaPlatformImpl() {
+   }
 
-	@Override
-	public void configure(Map configurationValues) {
-		nodeId = (String) configurationValues.get( DualNodeTest.NODE_ID_PROP );
-		if ( nodeId == null ) {
-		  throw new HibernateException(DualNodeTest.NODE_ID_PROP + " not configured");
-	  }
-	}
+   @Override
+   public void configure(Map configurationValues) {
+      nodeId = (String) configurationValues.get(DualNodeTest.NODE_ID_PROP);
+      if (nodeId == null) {
+         throw new HibernateException(DualNodeTest.NODE_ID_PROP + " not configured");
+      }
+   }
 
-	@Override
-	public TransactionManager retrieveTransactionManager() {
-		return DualNodeJtaTransactionManagerImpl.getInstance( nodeId );
-	}
+   @Override
+   public TransactionManager retrieveTransactionManager() {
+      return DualNodeJtaTransactionManagerImpl.getInstance(nodeId);
+   }
 
-	@Override
-	public UserTransaction retrieveUserTransaction() {
-		throw new TransactionException( "UserTransaction not used in these tests" );
-	}
+   @Override
+   public UserTransaction retrieveUserTransaction() {
+      throw new TransactionException("UserTransaction not used in these tests");
+   }
 
-	@Override
-	public Object getTransactionIdentifier(Transaction transaction) {
-		return transaction;
-	}
+   @Override
+   public Object getTransactionIdentifier(Transaction transaction) {
+      return transaction;
+   }
 
-	@Override
-	public boolean canRegisterSynchronization() {
-		return JtaStatusHelper.isActive( retrieveTransactionManager() );
-	}
+   @Override
+   public boolean canRegisterSynchronization() {
+      return JtaStatusHelper.isActive(retrieveTransactionManager());
+   }
 
-	@Override
-	public void registerSynchronization(Synchronization synchronization) {
-		try {
-			retrieveTransactionManager().getTransaction().registerSynchronization( synchronization );
-		}
-		catch (Exception e) {
-			throw new TransactionException( "Could not obtain transaction from TM" );
-		}
-	}
+   @Override
+   public void registerSynchronization(Synchronization synchronization) {
+      try {
+         retrieveTransactionManager().getTransaction().registerSynchronization(synchronization);
+      } catch (Exception e) {
+         throw new TransactionException("Could not obtain transaction from TM");
+      }
+   }
 
-	@Override
-	public int getCurrentStatus() throws SystemException {
-		return JtaStatusHelper.getStatus( retrieveTransactionManager() );
-	}
+   @Override
+   public int getCurrentStatus() throws SystemException {
+      return JtaStatusHelper.getStatus(retrieveTransactionManager());
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeJtaTransactionImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeJtaTransactionImpl.java
@@ -24,7 +24,7 @@ import jakarta.transaction.Transaction;
 
 /**
  * SimpleJtaTransactionImpl variant that works with DualNodeTransactionManagerImpl.
- *
+ * <p>
  * TODO: Merge with single node transaction manager
  *
  * @author Brian Stansberry
@@ -49,7 +49,7 @@ public class DualNodeJtaTransactionImpl implements Transaction {
    }
 
    public void commit() throws RollbackException, HeuristicMixedException,
-            HeuristicRollbackException, IllegalStateException, SystemException {
+         HeuristicRollbackException, IllegalStateException, SystemException {
 
       if (status == Status.STATUS_MARKED_ROLLBACK) {
          log.trace("on commit, status was marked for rollback-only");
@@ -129,7 +129,7 @@ public class DualNodeJtaTransactionImpl implements Transaction {
    }
 
    public void registerSynchronization(Synchronization synchronization) throws RollbackException,
-            IllegalStateException, SystemException {
+         IllegalStateException, SystemException {
       // todo : find the spec-allowable statuses during which synch can be registered...
       if (synchronizations == null) {
          synchronizations = new LinkedList();
@@ -149,7 +149,7 @@ public class DualNodeJtaTransactionImpl implements Transaction {
    }
 
    public boolean enlistResource(XAResource xaResource) throws RollbackException,
-            IllegalStateException, SystemException {
+         IllegalStateException, SystemException {
       enlistedResources.add(new WrappedXaResource(xaResource));
       try {
          xaResource.start(xid, 0);
@@ -161,7 +161,7 @@ public class DualNodeJtaTransactionImpl implements Transaction {
    }
 
    public boolean delistResource(XAResource xaResource, int i) throws IllegalStateException,
-            SystemException {
+         SystemException {
       throw new SystemException("not supported");
    }
 
@@ -191,7 +191,7 @@ public class DualNodeJtaTransactionImpl implements Transaction {
          try {
             res.rollback(xid);
          } catch (XAException e) {
-            log.warn("Error while rolling back",e);
+            log.warn("Error while rolling back", e);
          }
       }
    }
@@ -202,7 +202,7 @@ public class DualNodeJtaTransactionImpl implements Transaction {
          try {
             res.commit(xid, false);//todo we only support one phase commit for now, change this!!!
          } catch (XAException e) {
-            log.warn("exception while committing",e);
+            log.warn("exception while committing", e);
             throw new HeuristicMixedException(e.getMessage());
          }
       }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeJtaTransactionManagerImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeJtaTransactionManagerImpl.java
@@ -17,7 +17,7 @@ import jakarta.transaction.TransactionManager;
 /**
  * Variant of SimpleJtaTransactionManagerImpl that doesn't use a VM-singleton, but rather a set of
  * impls keyed by a node id.
- *
+ * <p>
  * TODO: Merge with single node transaction manager as much as possible
  *
  * @author Brian Stansberry
@@ -33,7 +33,7 @@ public class DualNodeJtaTransactionManagerImpl implements TransactionManager {
 
    public synchronized static DualNodeJtaTransactionManagerImpl getInstance(String nodeId) {
       DualNodeJtaTransactionManagerImpl tm = (DualNodeJtaTransactionManagerImpl) INSTANCES
-               .get(nodeId);
+            .get(nodeId);
       if (tm == null) {
          tm = new DualNodeJtaTransactionManagerImpl(nodeId);
          INSTANCES.put(nodeId, tm);
@@ -42,7 +42,7 @@ public class DualNodeJtaTransactionManagerImpl implements TransactionManager {
    }
 
    public synchronized static void cleanupTransactions() {
-      for (java.util.Iterator it = INSTANCES.values().iterator(); it.hasNext();) {
+      for (java.util.Iterator it = INSTANCES.values().iterator(); it.hasNext(); ) {
          TransactionManager tm = (TransactionManager) it.next();
          try {
             tm.suspend();
@@ -80,20 +80,20 @@ public class DualNodeJtaTransactionManagerImpl implements TransactionManager {
    public Transaction suspend() throws SystemException {
       DualNodeJtaTransactionImpl suspended = getCurrentTransaction();
       log.trace(nodeId + ": Suspending " + suspended + " for thread "
-               + Thread.currentThread().getName());
+            + Thread.currentThread().getName());
       currentTransaction.set(null);
       return suspended;
    }
 
    public void resume(Transaction transaction) throws InvalidTransactionException,
-            IllegalStateException, SystemException {
+         IllegalStateException, SystemException {
       currentTransaction.set(transaction);
       log.trace(nodeId + ": Resumed " + transaction + " for thread "
-               + Thread.currentThread().getName());
+            + Thread.currentThread().getName());
    }
 
    public void commit() throws RollbackException, HeuristicMixedException,
-            HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
+         HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
       Transaction tx = getCurrentTransaction();
       if (tx == null) {
          throw new IllegalStateException("no current transaction to commit");

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/DualNodeTest.java
@@ -23,24 +23,24 @@ import org.junit.ClassRule;
  */
 public abstract class DualNodeTest extends AbstractFunctionalTest {
 
-	@ClassRule
-	public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
+   @ClassRule
+   public static final InfinispanTestingSetup infinispanTestIdentifier = new InfinispanTestingSetup();
 
-	public static final String REGION_FACTORY_DELEGATE = "hibernate.cache.region.factory_delegate";
-	public static final String NODE_ID_PROP = "hibernate.test.cluster.node.id";
-	public static final String NODE_ID_FIELD = "nodeId";
-	public static final String LOCAL = "local";
-	public static final String REMOTE = "remote";
+   public static final String REGION_FACTORY_DELEGATE = "hibernate.cache.region.factory_delegate";
+   public static final String NODE_ID_PROP = "hibernate.test.cluster.node.id";
+   public static final String NODE_ID_FIELD = "nodeId";
+   public static final String LOCAL = "local";
+   public static final String REMOTE = "remote";
 
-	private SecondNodeEnvironment secondNodeEnvironment;
+   private SecondNodeEnvironment secondNodeEnvironment;
 
-	protected void withTxSession(SessionFactory sessionFactory, TxUtil.ThrowingConsumer<Session, Exception> consumer) throws Exception {
-		TxUtil.withTxSession(useJta, sessionFactory, consumer);
-	}
+   protected void withTxSession(SessionFactory sessionFactory, TxUtil.ThrowingConsumer<Session, Exception> consumer) throws Exception {
+      TxUtil.withTxSession(useJta, sessionFactory, consumer);
+   }
 
-	protected <T> T withTxSessionApply(SessionFactory sessionFactory, TxUtil.ThrowingFunction<Session, T, Exception> consumer) throws Exception {
-		return TxUtil.withTxSessionApply(useJta, sessionFactory, consumer);
-	}
+   protected <T> T withTxSessionApply(SessionFactory sessionFactory, TxUtil.ThrowingFunction<Session, T, Exception> consumer) throws Exception {
+      return TxUtil.withTxSessionApply(useJta, sessionFactory, consumer);
+   }
 
    @Override
    protected String getBaseForMappings() {
@@ -48,109 +48,107 @@ public abstract class DualNodeTest extends AbstractFunctionalTest {
    }
 
    @Override
-	public String[] getMappings() {
-		return new String[] {
-				"hibernate/cache/commons/functional/entities/Contact.hbm.xml",
-				"hibernate/cache/commons/functional/entities/Customer.hbm.xml"
-		};
-	}
+   public String[] getMappings() {
+      return new String[]{
+            "hibernate/cache/commons/functional/entities/Contact.hbm.xml",
+            "hibernate/cache/commons/functional/entities/Customer.hbm.xml"
+      };
+   }
 
-	@Override
-	@SuppressWarnings("unchecked")
-	protected void addSettings(Map settings) {
-		super.addSettings( settings );
+   @Override
+   @SuppressWarnings("unchecked")
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
 
-		applyStandardSettings( settings );
+      applyStandardSettings(settings);
 
-		settings.put( NODE_ID_PROP, LOCAL );
-		settings.put( NODE_ID_FIELD, LOCAL );
-      settings.put( REGION_FACTORY_DELEGATE, TestRegionFactoryProvider.load().getRegionFactoryClass());
-	}
+      settings.put(NODE_ID_PROP, LOCAL);
+      settings.put(NODE_ID_FIELD, LOCAL);
+      settings.put(REGION_FACTORY_DELEGATE, TestRegionFactoryProvider.load().getRegionFactoryClass());
+   }
 
-	@Override
-	protected void cleanupTest() throws Exception {
-		cleanupTransactionManagement();
-	}
+   @Override
+   protected void cleanupTest() throws Exception {
+      cleanupTransactionManagement();
+   }
 
-	protected void cleanupTransactionManagement() {
-		DualNodeJtaTransactionManagerImpl.cleanupTransactions();
-		DualNodeJtaTransactionManagerImpl.cleanupTransactionManagers();
-	}
+   protected void cleanupTransactionManagement() {
+      DualNodeJtaTransactionManagerImpl.cleanupTransactions();
+      DualNodeJtaTransactionManagerImpl.cleanupTransactionManagers();
+   }
 
-	@Override
-	public void startUp() {
-		super.startUp();
-		// In some cases tests are multi-threaded, so they have to join the group
-		infinispanTestIdentifier.joinContext();
-		secondNodeEnvironment = new SecondNodeEnvironment();
-	}
+   @Override
+   public void startUp() {
+      super.startUp();
+      // In some cases tests are multi-threaded, so they have to join the group
+      infinispanTestIdentifier.joinContext();
+      secondNodeEnvironment = new SecondNodeEnvironment();
+   }
 
-	@Override
-	public void shutDown() {
-		if ( secondNodeEnvironment != null ) {
-			secondNodeEnvironment.shutDown();
-		}
-		super.shutDown();
-	}
+   @Override
+   public void shutDown() {
+      if (secondNodeEnvironment != null) {
+         secondNodeEnvironment.shutDown();
+      }
+      super.shutDown();
+   }
 
-	protected SecondNodeEnvironment secondNodeEnvironment() {
-		return secondNodeEnvironment;
-	}
+   protected SecondNodeEnvironment secondNodeEnvironment() {
+      return secondNodeEnvironment;
+   }
 
-	protected void configureSecondNode(StandardServiceRegistryBuilder ssrb) {
-	}
+   protected void configureSecondNode(StandardServiceRegistryBuilder ssrb) {
+   }
 
-	@SuppressWarnings("unchecked")
-	protected void applyStandardSettings(Map settings) {
-		settings.put( Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getClusterAwareClass().getName() );
-	}
+   @SuppressWarnings("unchecked")
+   protected void applyStandardSettings(Map settings) {
+      settings.put(Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getClusterAwareClass().getName());
+   }
 
-	public class SecondNodeEnvironment {
-		private final StandardServiceRegistry serviceRegistry;
-		private final SessionFactoryImplementor sessionFactory;
+   public class SecondNodeEnvironment {
+      private final StandardServiceRegistry serviceRegistry;
+      private final SessionFactoryImplementor sessionFactory;
 
-		public SecondNodeEnvironment() {
-			StandardServiceRegistryBuilder ssrb = constructStandardServiceRegistryBuilder();
-			applyStandardSettings( ssrb.getSettings() );
-			ssrb.applySetting( NODE_ID_PROP, REMOTE );
-			ssrb.applySetting( NODE_ID_FIELD, REMOTE );
-			configureSecondNode( ssrb );
+      public SecondNodeEnvironment() {
+         StandardServiceRegistryBuilder ssrb = constructStandardServiceRegistryBuilder();
+         applyStandardSettings(ssrb.getSettings());
+         ssrb.applySetting(NODE_ID_PROP, REMOTE);
+         ssrb.applySetting(NODE_ID_FIELD, REMOTE);
+         configureSecondNode(ssrb);
 
-			serviceRegistry = ssrb.build();
+         serviceRegistry = ssrb.build();
 
-			MetadataSources metadataSources = new MetadataSources( serviceRegistry );
-			applyMetadataSources( metadataSources );
+         MetadataSources metadataSources = new MetadataSources(serviceRegistry);
+         applyMetadataSources(metadataSources);
 
-			Metadata metadata = metadataSources.buildMetadata();
-			applyCacheSettings( metadata );
-			afterMetadataBuilt( metadata );
+         Metadata metadata = metadataSources.buildMetadata();
+         applyCacheSettings(metadata);
+         afterMetadataBuilt(metadata);
 
-			sessionFactory = (SessionFactoryImplementor) metadata.buildSessionFactory();
-		}
+         sessionFactory = (SessionFactoryImplementor) metadata.buildSessionFactory();
+      }
 
-		public StandardServiceRegistry getServiceRegistry() {
-			return serviceRegistry;
-		}
+      public StandardServiceRegistry getServiceRegistry() {
+         return serviceRegistry;
+      }
 
-		public SessionFactoryImplementor getSessionFactory() {
-			return sessionFactory;
-		}
+      public SessionFactoryImplementor getSessionFactory() {
+         return sessionFactory;
+      }
 
-		public void shutDown() {
-			if ( sessionFactory != null ) {
-				try {
-					sessionFactory.close();
-				}
-				catch (Exception ignore) {
-				}
-			}
-			if ( serviceRegistry != null ) {
-				try {
-					StandardServiceRegistryBuilder.destroy( serviceRegistry );
-				}
-				catch (Exception ignore) {
-				}
-			}
-		}
-	}
+      public void shutDown() {
+         if (sessionFactory != null) {
+            try {
+               sessionFactory.close();
+            } catch (Exception ignore) {
+            }
+         }
+         if (serviceRegistry != null) {
+            try {
+               StandardServiceRegistryBuilder.destroy(serviceRegistry);
+            } catch (Exception ignore) {
+            }
+         }
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/EntityCollectionInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/EntityCollectionInvalidationTest.java
@@ -60,495 +60,495 @@ import org.junit.rules.TestName;
  * @since 3.5
  */
 public class EntityCollectionInvalidationTest extends DualNodeTest {
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( EntityCollectionInvalidationTest.class );
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(EntityCollectionInvalidationTest.class);
 
-	private static final Integer CUSTOMER_ID = 1;
-	private static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
+   private static final Integer CUSTOMER_ID = 1;
+   private static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
 
-	private EmbeddedCacheManager localManager, remoteManager;
-	private AdvancedCache localCustomerCache, remoteCustomerCache;
-	private AdvancedCache localContactCache, remoteContactCache;
-	private AdvancedCache localCollectionCache, remoteCollectionCache;
-	private MyListener localListener, remoteListener;
-	private SessionFactoryImplementor localFactory, remoteFactory;
-	private final ControlledTimeService timeService = new ControlledTimeService();
-	private InfinispanBaseRegion localCustomerRegion, remoteCustomerRegion;
-	private InfinispanBaseRegion localCollectionRegion, remoteCollectionRegion;
-	private InfinispanBaseRegion localContactRegion, remoteContactRegion;
+   private EmbeddedCacheManager localManager, remoteManager;
+   private AdvancedCache localCustomerCache, remoteCustomerCache;
+   private AdvancedCache localContactCache, remoteContactCache;
+   private AdvancedCache localCollectionCache, remoteCollectionCache;
+   private MyListener localListener, remoteListener;
+   private SessionFactoryImplementor localFactory, remoteFactory;
+   private final ControlledTimeService timeService = new ControlledTimeService();
+   private InfinispanBaseRegion localCustomerRegion, remoteCustomerRegion;
+   private InfinispanBaseRegion localCollectionRegion, remoteCollectionRegion;
+   private InfinispanBaseRegion localContactRegion, remoteContactRegion;
 
    @Rule
    public TestName name = new TestName();
 
 
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(true, true, false, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, false, true, true);
+   }
 
-	@Override
-	public void startUp()  {
-		super.startUp();
-		// Bind a listener to the "local" cache
-		// Our region factory makes its CacheManager available to us
-		localManager = ClusterAware.getCacheManager( DualNodeTest.LOCAL );
-		// Cache localCache = localManager.getCache("entity");
-		localCustomerCache = localManager.getCache( Customer.class.getName() ).getAdvancedCache();
-		localContactCache = localManager.getCache( Contact.class.getName() ).getAdvancedCache();
-		localCollectionCache = localManager.getCache( Customer.class.getName() + ".contacts" ).getAdvancedCache();
-		localListener = new MyListener( "local" );
-		localCustomerCache.addListener( localListener );
-		localContactCache.addListener( localListener );
-		localCollectionCache.addListener( localListener );
+   @Override
+   public void startUp() {
+      super.startUp();
+      // Bind a listener to the "local" cache
+      // Our region factory makes its CacheManager available to us
+      localManager = ClusterAware.getCacheManager(DualNodeTest.LOCAL);
+      // Cache localCache = localManager.getCache("entity");
+      localCustomerCache = localManager.getCache(Customer.class.getName()).getAdvancedCache();
+      localContactCache = localManager.getCache(Contact.class.getName()).getAdvancedCache();
+      localCollectionCache = localManager.getCache(Customer.class.getName() + ".contacts").getAdvancedCache();
+      localListener = new MyListener("local");
+      localCustomerCache.addListener(localListener);
+      localContactCache.addListener(localListener);
+      localCollectionCache.addListener(localListener);
 
-		// Bind a listener to the "remote" cache
-		remoteManager = ClusterAware.getCacheManager( DualNodeTest.REMOTE );
-		remoteCustomerCache = remoteManager.getCache( Customer.class.getName() ).getAdvancedCache();
-		remoteContactCache = remoteManager.getCache( Contact.class.getName() ).getAdvancedCache();
-		remoteCollectionCache = remoteManager.getCache( Customer.class.getName() + ".contacts" ).getAdvancedCache();
-		remoteListener = new MyListener( "remote" );
-		remoteCustomerCache.addListener( remoteListener );
-		remoteContactCache.addListener( remoteListener );
-		remoteCollectionCache.addListener( remoteListener );
+      // Bind a listener to the "remote" cache
+      remoteManager = ClusterAware.getCacheManager(DualNodeTest.REMOTE);
+      remoteCustomerCache = remoteManager.getCache(Customer.class.getName()).getAdvancedCache();
+      remoteContactCache = remoteManager.getCache(Contact.class.getName()).getAdvancedCache();
+      remoteCollectionCache = remoteManager.getCache(Customer.class.getName() + ".contacts").getAdvancedCache();
+      remoteListener = new MyListener("remote");
+      remoteCustomerCache.addListener(remoteListener);
+      remoteContactCache.addListener(remoteListener);
+      remoteCollectionCache.addListener(remoteListener);
 
-		localFactory = sessionFactory();
-		localCustomerRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Customer.class.getName());
-		localContactRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Contact.class.getName());
-		localCollectionRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Customer.class.getName() + ".contacts");
-		remoteFactory = secondNodeEnvironment().getSessionFactory();
-		remoteCustomerRegion = TEST_SESSION_ACCESS.getRegion(remoteFactory, Customer.class.getName());
-		remoteContactRegion = TEST_SESSION_ACCESS.getRegion(remoteFactory, Contact.class.getName());
-		remoteCollectionRegion = TEST_SESSION_ACCESS.getRegion(remoteFactory, Customer.class.getName() + ".contacts");
+      localFactory = sessionFactory();
+      localCustomerRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Customer.class.getName());
+      localContactRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Contact.class.getName());
+      localCollectionRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Customer.class.getName() + ".contacts");
+      remoteFactory = secondNodeEnvironment().getSessionFactory();
+      remoteCustomerRegion = TEST_SESSION_ACCESS.getRegion(remoteFactory, Customer.class.getName());
+      remoteContactRegion = TEST_SESSION_ACCESS.getRegion(remoteFactory, Contact.class.getName());
+      remoteCollectionRegion = TEST_SESSION_ACCESS.getRegion(remoteFactory, Customer.class.getName() + ".contacts");
 
-	}
+   }
 
-	@Override
-	public void shutDown() {
-		cleanupTransactionManagement();
-	}
+   @Override
+   public void shutDown() {
+      cleanupTransactionManagement();
+   }
 
-	@Override
-	protected void cleanupTest() throws Exception {
-		cleanup(localFactory);
-		localListener.clear();
-		remoteListener.clear();
-		// do not call super.cleanupTest becasue we would clean transaction managers
-	}
+   @Override
+   protected void cleanupTest() throws Exception {
+      cleanup(localFactory);
+      localListener.clear();
+      remoteListener.clear();
+      // do not call super.cleanupTest becasue we would clean transaction managers
+   }
 
-	@Override
-	protected void addSettings(Map settings) {
-		super.addSettings(settings);
-		settings.put(TestRegionFactory.PENDING_PUTS_SIMPLE, false);
-		settings.put(TestRegionFactory.TIME_SERVICE, timeService);
-	}
+   @Override
+   protected void addSettings(Map settings) {
+      super.addSettings(settings);
+      settings.put(TestRegionFactory.PENDING_PUTS_SIMPLE, false);
+      settings.put(TestRegionFactory.TIME_SERVICE, timeService);
+   }
 
-	@Test
-	public void testAll() throws Exception {
+   @Test
+   public void testAll() throws Exception {
       log.infof(name.getMethodName());
 
-		assertEmptyCaches();
-		assertTrue( remoteListener.isEmpty() );
-		assertTrue( localListener.isEmpty() );
+      assertEmptyCaches();
+      assertTrue(remoteListener.isEmpty());
+      assertTrue(localListener.isEmpty());
 
-		log.debug( "Create node 0" );
-		IdContainer ids = createCustomer( localFactory );
+      log.debug("Create node 0");
+      IdContainer ids = createCustomer(localFactory);
 
-		assertTrue( remoteListener.isEmpty() );
-		assertTrue( localListener.isEmpty() );
+      assertTrue(remoteListener.isEmpty());
+      assertTrue(localListener.isEmpty());
 
-		// The create customer above removes the collection from the cache (see CollectionRecreateAction)
-		// and therefore the putFromLoad in getCustomer could be considered stale if executed too soon.
-		timeService.advance(1);
+      // The create customer above removes the collection from the cache (see CollectionRecreateAction)
+      // and therefore the putFromLoad in getCustomer could be considered stale if executed too soon.
+      timeService.advance(1);
 
       CountDownLatch remoteCollectionLoadLatch = null;
       if (!cacheMode.isInvalidation()) {
          remoteCollectionLoadLatch = new CountDownLatch(1);
          ExpectingInterceptor.get(remoteCollectionCache)
-            .when((ctx, cmd) -> cmd instanceof ReadWriteKeyCommand)
-            .countDown(remoteCollectionLoadLatch);
+               .when((ctx, cmd) -> cmd instanceof ReadWriteKeyCommand)
+               .countDown(remoteCollectionLoadLatch);
       }
 
-		log.debug( "Find node 0" );
-		// This actually brings the collection into the cache
-		getCustomer( ids.customerId, localFactory );
+      log.debug("Find node 0");
+      // This actually brings the collection into the cache
+      getCustomer(ids.customerId, localFactory);
 
-		// Now the collection is in the cache so, the 2nd "get"
-		// should read everything from the cache
-		log.debug( "Find(2) node 0" );
-		localListener.clear();
-		getCustomer( ids.customerId, localFactory );
+      // Now the collection is in the cache so, the 2nd "get"
+      // should read everything from the cache
+      log.debug("Find(2) node 0");
+      localListener.clear();
+      getCustomer(ids.customerId, localFactory);
 
-		// Check the read came from the cache
-		log.debug( "Check cache 0" );
-		assertLoadedFromCache( localListener, ids.customerId, ids.contactIds );
+      // Check the read came from the cache
+      log.debug("Check cache 0");
+      assertLoadedFromCache(localListener, ids.customerId, ids.contactIds);
 
       if (remoteCollectionLoadLatch != null) {
-         log.debug( "Wait for remote collection put from load to complete" );
+         log.debug("Wait for remote collection put from load to complete");
          assertTrue(remoteCollectionLoadLatch.await(2, TimeUnit.SECONDS));
          ExpectingInterceptor.cleanup(remoteCollectionCache);
       }
 
-		log.debug( "Find node 1" );
-		// This actually brings the collection into the cache since invalidation is in use
-		getCustomer( ids.customerId, remoteFactory );
+      log.debug("Find node 1");
+      // This actually brings the collection into the cache since invalidation is in use
+      getCustomer(ids.customerId, remoteFactory);
 
-		// Now the collection is in the cache so, the 2nd "get"
-		// should read everything from the cache
-		log.debug( "Find(2) node 1" );
-		remoteListener.clear();
-		getCustomer( ids.customerId, remoteFactory );
+      // Now the collection is in the cache so, the 2nd "get"
+      // should read everything from the cache
+      log.debug("Find(2) node 1");
+      remoteListener.clear();
+      getCustomer(ids.customerId, remoteFactory);
 
-		// Check the read came from the cache
-		log.debug( "Check cache 1" );
-		assertLoadedFromCache( remoteListener, ids.customerId, ids.contactIds );
+      // Check the read came from the cache
+      log.debug("Check cache 1");
+      assertLoadedFromCache(remoteListener, ids.customerId, ids.contactIds);
 
-		// Modify customer in remote
-		remoteListener.clear();
+      // Modify customer in remote
+      remoteListener.clear();
 
-		CountDownLatch modifyLatch = null;
-		if (!cacheMode.isInvalidation() && accessType != AccessType.NONSTRICT_READ_WRITE) {
-			modifyLatch = new CountDownLatch(1);
-			ExpectingInterceptor.get(localCustomerCache).when(this::isFutureUpdate).countDown(modifyLatch);
-		}
+      CountDownLatch modifyLatch = null;
+      if (!cacheMode.isInvalidation() && accessType != AccessType.NONSTRICT_READ_WRITE) {
+         modifyLatch = new CountDownLatch(1);
+         ExpectingInterceptor.get(localCustomerCache).when(this::isFutureUpdate).countDown(modifyLatch);
+      }
 
-		ids = modifyCustomer( ids.customerId, remoteFactory );
-		assertLoadedFromCache( remoteListener, ids.customerId, ids.contactIds );
+      ids = modifyCustomer(ids.customerId, remoteFactory);
+      assertLoadedFromCache(remoteListener, ids.customerId, ids.contactIds);
 
-		if (modifyLatch != null) {
-			assertTrue(modifyLatch.await(2, TimeUnit.SECONDS));
-			ExpectingInterceptor.cleanup(localCustomerCache);
-		}
+      if (modifyLatch != null) {
+         assertTrue(modifyLatch.await(2, TimeUnit.SECONDS));
+         ExpectingInterceptor.cleanup(localCustomerCache);
+      }
 
-		assertEquals( 0, localCollectionRegion.getElementCountInMemory());
-		if (cacheMode.isInvalidation()) {
-			// After modification, local cache should have been invalidated and hence should be empty
-			assertEquals(0, localCustomerRegion.getElementCountInMemory());
-		} else {
-			// Replicated cache is updated, not invalidated
-			assertEquals(1, localCustomerRegion.getElementCountInMemory());
-		}
-	}
+      assertEquals(0, localCollectionRegion.getElementCountInMemory());
+      if (cacheMode.isInvalidation()) {
+         // After modification, local cache should have been invalidated and hence should be empty
+         assertEquals(0, localCustomerRegion.getElementCountInMemory());
+      } else {
+         // Replicated cache is updated, not invalidated
+         assertEquals(1, localCustomerRegion.getElementCountInMemory());
+      }
+   }
 
-	@JiraKey(value = "HHH-9881")
-	@Test
-	public void testConcurrentLoadAndRemoval() throws Exception {
-		if (!remoteCustomerCache.getCacheConfiguration().clustering().cacheMode().isInvalidation()) {
-			// This test is tailored for invalidation-based strategies, using pending puts cache
-			return;
-		}
-		AtomicReference<Exception> getException = new AtomicReference<>();
-		AtomicReference<Exception> deleteException = new AtomicReference<>();
+   @JiraKey(value = "HHH-9881")
+   @Test
+   public void testConcurrentLoadAndRemoval() throws Exception {
+      if (!remoteCustomerCache.getCacheConfiguration().clustering().cacheMode().isInvalidation()) {
+         // This test is tailored for invalidation-based strategies, using pending puts cache
+         return;
+      }
+      AtomicReference<Exception> getException = new AtomicReference<>();
+      AtomicReference<Exception> deleteException = new AtomicReference<>();
 
-		Phaser getPhaser = new Phaser(2);
-		HookInterceptor hookInterceptor = new HookInterceptor(getException);
-		AdvancedCache remotePPCache = remoteCustomerCache.getCacheManager().getCache(
-				remoteCustomerCache.getName() + "-" + InfinispanProperties.DEF_PENDING_PUTS_RESOURCE).getAdvancedCache();
+      Phaser getPhaser = new Phaser(2);
+      HookInterceptor hookInterceptor = new HookInterceptor(getException);
+      AdvancedCache remotePPCache = remoteCustomerCache.getCacheManager().getCache(
+            remoteCustomerCache.getName() + "-" + InfinispanProperties.DEF_PENDING_PUTS_RESOURCE).getAdvancedCache();
       extractInterceptorChain(remotePPCache).addInterceptor(hookInterceptor, 0);
 
-		IdContainer idContainer = new IdContainer();
-		withTxSession(localFactory, s -> {
-			Customer customer = new Customer();
-			customer.setName( "JBoss" );
-			s.persist(customer);
-			idContainer.customerId = customer.getId();
-		});
-		// start loading
+      IdContainer idContainer = new IdContainer();
+      withTxSession(localFactory, s -> {
+         Customer customer = new Customer();
+         customer.setName("JBoss");
+         s.persist(customer);
+         idContainer.customerId = customer.getId();
+      });
+      // start loading
 
-		Thread getThread = new Thread(() -> {
-			try {
-				withTxSession(remoteFactory, s -> {
-					s.get(Customer.class, idContainer.customerId);
-				});
-			} catch (Exception e) {
-				log.error("Failure to get customer", e);
-				getException.set(e);
-			}
-		}, "get-thread");
-		Thread deleteThread = new Thread(() -> {
-			try {
-				withTxSession(localFactory, s -> {
-					Customer customer = s.get(Customer.class, idContainer.customerId);
-					s.remove(customer);
-				});
-			} catch (Exception e) {
-				log.error("Failure to delete customer", e);
-				deleteException.set(e);
-			}
-		}, "delete-thread");
-		// get thread should block on the beginning of PutFromLoadValidator#acquirePutFromLoadLock
-		hookInterceptor.block(getPhaser, getThread);
-		getThread.start();
+      Thread getThread = new Thread(() -> {
+         try {
+            withTxSession(remoteFactory, s -> {
+               s.get(Customer.class, idContainer.customerId);
+            });
+         } catch (Exception e) {
+            log.error("Failure to get customer", e);
+            getException.set(e);
+         }
+      }, "get-thread");
+      Thread deleteThread = new Thread(() -> {
+         try {
+            withTxSession(localFactory, s -> {
+               Customer customer = s.get(Customer.class, idContainer.customerId);
+               s.remove(customer);
+            });
+         } catch (Exception e) {
+            log.error("Failure to delete customer", e);
+            deleteException.set(e);
+         }
+      }, "delete-thread");
+      // get thread should block on the beginning of PutFromLoadValidator#acquirePutFromLoadLock
+      hookInterceptor.block(getPhaser, getThread);
+      getThread.start();
 
-		arriveAndAwait(getPhaser);
-		deleteThread.start();
-		deleteThread.join();
-		hookInterceptor.unblock();
-		arriveAndAwait(getPhaser);
-		getThread.join();
+      arriveAndAwait(getPhaser);
+      deleteThread.start();
+      deleteThread.join();
+      hookInterceptor.unblock();
+      arriveAndAwait(getPhaser);
+      getThread.join();
 
-		if (getException.get() != null) {
-			throw new IllegalStateException("get-thread failed", getException.get());
-		}
-		if (deleteException.get() != null) {
-			throw new IllegalStateException("delete-thread failed", deleteException.get());
-		}
+      if (getException.get() != null) {
+         throw new IllegalStateException("get-thread failed", getException.get());
+      }
+      if (deleteException.get() != null) {
+         throw new IllegalStateException("delete-thread failed", deleteException.get());
+      }
 
-		Customer localCustomer = getCustomer(idContainer.customerId, localFactory);
-		assertNull(localCustomer);
-		Customer remoteCustomer = getCustomer(idContainer.customerId, remoteFactory);
-		assertNull(remoteCustomer);
-		assertTrue(remoteCustomerCache.isEmpty());
-	}
+      Customer localCustomer = getCustomer(idContainer.customerId, localFactory);
+      assertNull(localCustomer);
+      Customer remoteCustomer = getCustomer(idContainer.customerId, remoteFactory);
+      assertNull(remoteCustomer);
+      assertTrue(remoteCustomerCache.isEmpty());
+   }
 
-	protected void assertEmptyCaches() {
-		assertEquals(0, localCustomerRegion.getElementCountInMemory());
-		assertEquals(0, localContactRegion.getElementCountInMemory());
-		assertEquals(0, localCollectionRegion.getElementCountInMemory());
-		assertEquals(0, remoteCustomerRegion.getElementCountInMemory());
-		assertEquals(0, remoteContactRegion.getElementCountInMemory());
-		assertEquals(0, remoteCollectionRegion.getElementCountInMemory());
-	}
+   protected void assertEmptyCaches() {
+      assertEquals(0, localCustomerRegion.getElementCountInMemory());
+      assertEquals(0, localContactRegion.getElementCountInMemory());
+      assertEquals(0, localCollectionRegion.getElementCountInMemory());
+      assertEquals(0, remoteCustomerRegion.getElementCountInMemory());
+      assertEquals(0, remoteContactRegion.getElementCountInMemory());
+      assertEquals(0, remoteCollectionRegion.getElementCountInMemory());
+   }
 
-	private IdContainer createCustomer(SessionFactory sessionFactory)
-			throws Exception {
-		log.debug( "CREATE CUSTOMER" );
+   private IdContainer createCustomer(SessionFactory sessionFactory)
+         throws Exception {
+      log.debug("CREATE CUSTOMER");
 
-		Customer customer = new Customer();
-		customer.setName("JBoss");
-		Set<Contact> contacts = new HashSet<Contact>();
+      Customer customer = new Customer();
+      customer.setName("JBoss");
+      Set<Contact> contacts = new HashSet<Contact>();
 
-		Contact kabir = new Contact();
-		kabir.setCustomer(customer);
-		kabir.setName("Kabir");
-		kabir.setTlf("1111");
-		contacts.add(kabir);
+      Contact kabir = new Contact();
+      kabir.setCustomer(customer);
+      kabir.setName("Kabir");
+      kabir.setTlf("1111");
+      contacts.add(kabir);
 
-		Contact bill = new Contact();
-		bill.setCustomer(customer);
-		bill.setName("Bill");
-		bill.setTlf("2222");
-		contacts.add(bill);
+      Contact bill = new Contact();
+      bill.setCustomer(customer);
+      bill.setName("Bill");
+      bill.setTlf("2222");
+      contacts.add(bill);
 
-		customer.setContacts(contacts);
+      customer.setContacts(contacts);
 
-		ArrayList<Runnable> cleanup = new ArrayList<>();
-		CountDownLatch customerLatch = new CountDownLatch(1);
-		CountDownLatch collectionLatch = new CountDownLatch(1);
-		CountDownLatch contactsLatch = new CountDownLatch(2);
+      ArrayList<Runnable> cleanup = new ArrayList<>();
+      CountDownLatch customerLatch = new CountDownLatch(1);
+      CountDownLatch collectionLatch = new CountDownLatch(1);
+      CountDownLatch contactsLatch = new CountDownLatch(2);
 
-		if (cacheMode.isInvalidation()) {
-			cleanup.add(mockValidator(remoteCustomerCache, customerLatch));
-			cleanup.add(mockValidator(remoteCollectionCache, collectionLatch));
-			cleanup.add(mockValidator(remoteContactCache, contactsLatch));
-		} else if (accessType == AccessType.NONSTRICT_READ_WRITE) {
-			// ATM nonstrict mode has sync after-invalidation update
-			Stream.of(customerLatch, collectionLatch, contactsLatch, contactsLatch).forEach(l -> l.countDown());
-		} else {
-			ExpectingInterceptor.get(remoteCustomerCache).when(this::isFutureUpdate).countDown(collectionLatch);
-			ExpectingInterceptor.get(remoteCollectionCache).when(this::isFutureUpdate).countDown(customerLatch);
-			ExpectingInterceptor.get(remoteContactCache).when(this::isFutureUpdate).countDown(contactsLatch);
-			cleanup.add(() -> ExpectingInterceptor.cleanup(remoteCustomerCache, remoteCollectionCache, remoteContactCache));
-		}
+      if (cacheMode.isInvalidation()) {
+         cleanup.add(mockValidator(remoteCustomerCache, customerLatch));
+         cleanup.add(mockValidator(remoteCollectionCache, collectionLatch));
+         cleanup.add(mockValidator(remoteContactCache, contactsLatch));
+      } else if (accessType == AccessType.NONSTRICT_READ_WRITE) {
+         // ATM nonstrict mode has sync after-invalidation update
+         Stream.of(customerLatch, collectionLatch, contactsLatch, contactsLatch).forEach(l -> l.countDown());
+      } else {
+         ExpectingInterceptor.get(remoteCustomerCache).when(this::isFutureUpdate).countDown(collectionLatch);
+         ExpectingInterceptor.get(remoteCollectionCache).when(this::isFutureUpdate).countDown(customerLatch);
+         ExpectingInterceptor.get(remoteContactCache).when(this::isFutureUpdate).countDown(contactsLatch);
+         cleanup.add(() -> ExpectingInterceptor.cleanup(remoteCustomerCache, remoteCollectionCache, remoteContactCache));
+      }
 
-		withTxSession(sessionFactory, session -> session.persist(customer));
+      withTxSession(sessionFactory, session -> session.persist(customer));
 
-		assertTrue(customerLatch.await(2, TimeUnit.SECONDS));
-		assertTrue(collectionLatch.await(2, TimeUnit.SECONDS));
-		assertTrue(contactsLatch.await(2, TimeUnit.SECONDS));
-		cleanup.forEach(Runnable::run);
+      assertTrue(customerLatch.await(2, TimeUnit.SECONDS));
+      assertTrue(collectionLatch.await(2, TimeUnit.SECONDS));
+      assertTrue(contactsLatch.await(2, TimeUnit.SECONDS));
+      cleanup.forEach(Runnable::run);
 
-		IdContainer ids = new IdContainer();
-		ids.customerId = customer.getId();
-		Set contactIds = new HashSet();
-		contactIds.add( kabir.getId() );
-		contactIds.add( bill.getId() );
-		ids.contactIds = contactIds;
+      IdContainer ids = new IdContainer();
+      ids.customerId = customer.getId();
+      Set contactIds = new HashSet();
+      contactIds.add(kabir.getId());
+      contactIds.add(bill.getId());
+      ids.contactIds = contactIds;
 
-		log.debug( "CREATE CUSTOMER -  END" );
-		return ids;
-	}
+      log.debug("CREATE CUSTOMER -  END");
+      return ids;
+   }
 
-	private boolean isFutureUpdate(InvocationContext ctx, VisitableCommand cmd) {
-		return cmd instanceof ReadWriteKeyCommand && ((ReadWriteKeyCommand) cmd).getFunction() instanceof FutureUpdate;
-	}
+   private boolean isFutureUpdate(InvocationContext ctx, VisitableCommand cmd) {
+      return cmd instanceof ReadWriteKeyCommand && ((ReadWriteKeyCommand) cmd).getFunction() instanceof FutureUpdate;
+   }
 
-	private Runnable mockValidator(AdvancedCache cache, CountDownLatch latch) {
-		PutFromLoadValidator originalValidator = PutFromLoadValidator.removeFromCache(cache);
-		PutFromLoadValidator mockValidator = spy(originalValidator);
-		doAnswer(invocation -> {
-			try {
-				return invocation.callRealMethod();
-			} finally {
-				latch.countDown();
-			}
-		}).when(mockValidator).endInvalidatingKey(any(), any());
-		PutFromLoadValidator.addToCache(cache, mockValidator);
-		return () -> {
-			PutFromLoadValidator.removeFromCache(cache);
-			PutFromLoadValidator.addToCache(cache, originalValidator);
-		};
-	}
+   private Runnable mockValidator(AdvancedCache cache, CountDownLatch latch) {
+      PutFromLoadValidator originalValidator = PutFromLoadValidator.removeFromCache(cache);
+      PutFromLoadValidator mockValidator = spy(originalValidator);
+      doAnswer(invocation -> {
+         try {
+            return invocation.callRealMethod();
+         } finally {
+            latch.countDown();
+         }
+      }).when(mockValidator).endInvalidatingKey(any(), any());
+      PutFromLoadValidator.addToCache(cache, mockValidator);
+      return () -> {
+         PutFromLoadValidator.removeFromCache(cache);
+         PutFromLoadValidator.addToCache(cache, originalValidator);
+      };
+   }
 
-	private Customer getCustomer(Integer id, SessionFactory sessionFactory) throws Exception {
-		log.debug( "Find customer with id=" + id );
-		return withTxSessionApply(sessionFactory, session -> doGetCustomer(id, session));
-	}
+   private Customer getCustomer(Integer id, SessionFactory sessionFactory) throws Exception {
+      log.debug("Find customer with id=" + id);
+      return withTxSessionApply(sessionFactory, session -> doGetCustomer(id, session));
+   }
 
-	private Customer doGetCustomer(Integer id, Session session) throws Exception {
-		Customer customer = session.get( Customer.class, id );
-		if (customer == null) {
-			return null;
-		}
-		// Access all the contacts
-		Set<Contact> contacts = customer.getContacts();
-		if (contacts != null) {
-			for (Iterator it = contacts.iterator(); it.hasNext(); ) {
-				((Contact) it.next()).getName();
-			}
-		}
-		return customer;
-	}
+   private Customer doGetCustomer(Integer id, Session session) throws Exception {
+      Customer customer = session.get(Customer.class, id);
+      if (customer == null) {
+         return null;
+      }
+      // Access all the contacts
+      Set<Contact> contacts = customer.getContacts();
+      if (contacts != null) {
+         for (Iterator it = contacts.iterator(); it.hasNext(); ) {
+            ((Contact) it.next()).getName();
+         }
+      }
+      return customer;
+   }
 
-	private IdContainer modifyCustomer(Integer id, SessionFactory sessionFactory)
-			throws Exception {
-		log.debug( "Modify customer with id=" + id );
-		return withTxSessionApply(sessionFactory, session -> {
-			IdContainer ids = new IdContainer();
-			Set contactIds = new HashSet();
-			Customer customer = doGetCustomer( id, session );
-			customer.setName( "NewJBoss" );
-			ids.customerId = customer.getId();
-			Set<Contact> contacts = customer.getContacts();
-			for ( Contact c : contacts ) {
-				contactIds.add( c.getId() );
-			}
-			Contact contact = contacts.iterator().next();
-			contacts.remove( contact );
-			contactIds.remove( contact.getId() );
-			ids.contactIds = contactIds;
-			contact.setCustomer( null );
+   private IdContainer modifyCustomer(Integer id, SessionFactory sessionFactory)
+         throws Exception {
+      log.debug("Modify customer with id=" + id);
+      return withTxSessionApply(sessionFactory, session -> {
+         IdContainer ids = new IdContainer();
+         Set contactIds = new HashSet();
+         Customer customer = doGetCustomer(id, session);
+         customer.setName("NewJBoss");
+         ids.customerId = customer.getId();
+         Set<Contact> contacts = customer.getContacts();
+         for (Contact c : contacts) {
+            contactIds.add(c.getId());
+         }
+         Contact contact = contacts.iterator().next();
+         contacts.remove(contact);
+         contactIds.remove(contact.getId());
+         ids.contactIds = contactIds;
+         contact.setCustomer(null);
 
-			session.persist( customer );
-			return ids;
-		});
-	}
+         session.persist(customer);
+         return ids;
+      });
+   }
 
-	private void cleanup(SessionFactory sessionFactory) throws Exception {
-		withTxSession(sessionFactory, session -> {
-			Customer c = (Customer) session.get(Customer.class, CUSTOMER_ID);
-			if (c != null) {
-				Set contacts = c.getContacts();
-				for (Iterator it = contacts.iterator(); it.hasNext(); ) {
-					session.remove(it.next());
-				}
-				c.setContacts(null);
-				session.remove(c);
-			}
-			// since we don't use orphan removal, some contacts may persist
-			for (Contact contact : session.createQuery("from Contact", Contact.class).getResultList()) {
-				session.remove(contact);
-			}
-		});
-	}
+   private void cleanup(SessionFactory sessionFactory) throws Exception {
+      withTxSession(sessionFactory, session -> {
+         Customer c = (Customer) session.get(Customer.class, CUSTOMER_ID);
+         if (c != null) {
+            Set contacts = c.getContacts();
+            for (Iterator it = contacts.iterator(); it.hasNext(); ) {
+               session.remove(it.next());
+            }
+            c.setContacts(null);
+            session.remove(c);
+         }
+         // since we don't use orphan removal, some contacts may persist
+         for (Contact contact : session.createQuery("from Contact", Contact.class).getResultList()) {
+            session.remove(contact);
+         }
+      });
+   }
 
-	private void assertLoadedFromCache(MyListener listener, Integer custId, Set contactIds) {
-		assertTrue("Customer#" + custId + " was in cache", listener.visited.contains("Customer#" + custId));
-		for ( Iterator it = contactIds.iterator(); it.hasNext(); ) {
-			Integer contactId = (Integer) it.next();
-			assertTrue("Contact#" + contactId + " was in cache", listener.visited.contains("Contact#"	+ contactId));
-		}
-		assertTrue("Customer.contacts" + custId + " was in cache", listener.visited.contains( "Customer.contacts#" + custId ));
-	}
+   private void assertLoadedFromCache(MyListener listener, Integer custId, Set contactIds) {
+      assertTrue("Customer#" + custId + " was in cache", listener.visited.contains("Customer#" + custId));
+      for (Iterator it = contactIds.iterator(); it.hasNext(); ) {
+         Integer contactId = (Integer) it.next();
+         assertTrue("Contact#" + contactId + " was in cache", listener.visited.contains("Contact#" + contactId));
+      }
+      assertTrue("Customer.contacts" + custId + " was in cache", listener.visited.contains("Customer.contacts#" + custId));
+   }
 
-	protected static void arriveAndAwait(Phaser phaser) throws TimeoutException, InterruptedException {
-		try {
-			phaser.awaitAdvanceInterruptibly(phaser.arrive(), 10, TimeUnit.SECONDS);
-		} catch (TimeoutException e) {
-			log.error("Failed to progress: " + Util.threadDump());
-			throw e;
-		}
-	}
+   protected static void arriveAndAwait(Phaser phaser) throws TimeoutException, InterruptedException {
+      try {
+         phaser.awaitAdvanceInterruptibly(phaser.arrive(), 10, TimeUnit.SECONDS);
+      } catch (TimeoutException e) {
+         log.error("Failed to progress: " + Util.threadDump());
+         throw e;
+      }
+   }
 
-	@Listener
-	public static class MyListener {
-		private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( MyListener.class );
-		private final Set<String> visited = ConcurrentHashMap.newKeySet();
-		private final String name;
+   @Listener
+   public static class MyListener {
+      private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(MyListener.class);
+      private final Set<String> visited = ConcurrentHashMap.newKeySet();
+      private final String name;
 
-		public MyListener(String name) {
-			this.name = name;
-		}
+      public MyListener(String name) {
+         this.name = name;
+      }
 
-		public void clear() {
-			visited.clear();
-		}
+      public void clear() {
+         visited.clear();
+      }
 
-		public boolean isEmpty() {
-			return visited.isEmpty();
-		}
+      public boolean isEmpty() {
+         return visited.isEmpty();
+      }
 
-		@CacheEntryVisited
-		public void nodeVisited(CacheEntryVisitedEvent event) {
-			log.debug( event.toString() );
-			if ( !event.isPre() ) {
-				String key = event.getCache().getName() + "#" + event.getKey();
-				log.debug( "MyListener[" + name + "] - Visiting key " + key );
-				// String name = fqn.toString();
-				String token = ".entities.";
-				int index = key.indexOf( token );
-				if ( index > -1 ) {
-					index += token.length();
-					key = key.substring( index );
-					log.debug( "MyListener[" + this.name + "] - recording visit to " + key );
-					visited.add( key );
-				}
-			}
-		}
-	}
+      @CacheEntryVisited
+      public void nodeVisited(CacheEntryVisitedEvent event) {
+         log.debug(event.toString());
+         if (!event.isPre()) {
+            String key = event.getCache().getName() + "#" + event.getKey();
+            log.debug("MyListener[" + name + "] - Visiting key " + key);
+            // String name = fqn.toString();
+            String token = ".entities.";
+            int index = key.indexOf(token);
+            if (index > -1) {
+               index += token.length();
+               key = key.substring(index);
+               log.debug("MyListener[" + this.name + "] - recording visit to " + key);
+               visited.add(key);
+            }
+         }
+      }
+   }
 
-	private static class IdContainer {
-		Integer customerId;
-		Set<Integer> contactIds;
-	}
+   private static class IdContainer {
+      Integer customerId;
+      Set<Integer> contactIds;
+   }
 
-	static class HookInterceptor extends DDAsyncInterceptor {
-		final AtomicReference<Exception> failure;
-		Phaser phaser;
-		Thread thread;
+   static class HookInterceptor extends DDAsyncInterceptor {
+      final AtomicReference<Exception> failure;
+      Phaser phaser;
+      Thread thread;
 
-		private HookInterceptor(AtomicReference<Exception> failure) {
-			this.failure = failure;
-		}
+      private HookInterceptor(AtomicReference<Exception> failure) {
+         this.failure = failure;
+      }
 
-		public synchronized void block(Phaser phaser, Thread thread) {
-			this.phaser = phaser;
-			this.thread = thread;
-		}
+      public synchronized void block(Phaser phaser, Thread thread) {
+         this.phaser = phaser;
+         this.thread = thread;
+      }
 
-		public synchronized void unblock() {
-			phaser = null;
-			thread = null;
-		}
+      public synchronized void unblock() {
+         phaser = null;
+         thread = null;
+      }
 
-		@Override
-		public Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
-			try {
-				Phaser phaser;
-				Thread thread;
-				synchronized (this) {
-					phaser = this.phaser;
-					thread = this.thread;
-				}
-				if (phaser != null && Thread.currentThread() == thread) {
-					arriveAndAwait(phaser);
-					arriveAndAwait(phaser);
-				}
-			} catch (Exception e) {
-				failure.set(e);
-				throw e;
-			} finally {
-				return super.visitGetKeyValueCommand(ctx, command);
-			}
-		}
-	}
+      @Override
+      public Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
+         try {
+            Phaser phaser;
+            Thread thread;
+            synchronized (this) {
+               phaser = this.phaser;
+               thread = this.thread;
+            }
+            if (phaser != null && Thread.currentThread() == thread) {
+               arriveAndAwait(phaser);
+               arriveAndAwait(phaser);
+            }
+         } catch (Exception e) {
+            failure.set(e);
+            throw e;
+         } finally {
+            return super.visitGetKeyValueCommand(ctx, command);
+         }
+      }
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/NaturalIdInvalidationTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/NaturalIdInvalidationTest.java
@@ -51,109 +51,108 @@ import jakarta.persistence.criteria.Root;
 @Category(Smoke.class)
 public class NaturalIdInvalidationTest extends DualNodeTest {
 
-	private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(NaturalIdInvalidationTest.class);
+   private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(NaturalIdInvalidationTest.class);
 
    protected static final TestSessionAccess TEST_SESSION_ACCESS = TestSessionAccess.findTestSessionAccess();
 
-	@Rule
+   @Rule
    public TestName name = new TestName();
 
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(true, true, true, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, true, true, true);
+   }
 
-	@Override
-	protected Class<?>[] getAnnotatedClasses() {
-		return new Class[] {
-				Citizen.class, State.class,
-				NaturalIdOnManyToOne.class
-		};
-	}
+   @Override
+   protected Class<?>[] getAnnotatedClasses() {
+      return new Class[]{
+            Citizen.class, State.class,
+            NaturalIdOnManyToOne.class
+      };
+   }
 
-	@Test
-	public void testAll() throws Exception {
+   @Test
+   public void testAll() throws Exception {
       log.infof("*** %s", name.getMethodName());
 
-		// Bind a listener to the "local" cache
-		// Our region factory makes its CacheManager available to us
-		CacheContainer localManager = ClusterAware.getCacheManager(DualNodeTest.LOCAL);
-		Cache localNaturalIdCache = localManager.getCache(Citizen.class.getName() + "##NaturalId");
-		MyListener localListener = new MyListener( "local" );
-		localNaturalIdCache.addListener(localListener);
+      // Bind a listener to the "local" cache
+      // Our region factory makes its CacheManager available to us
+      CacheContainer localManager = ClusterAware.getCacheManager(DualNodeTest.LOCAL);
+      Cache localNaturalIdCache = localManager.getCache(Citizen.class.getName() + "##NaturalId");
+      MyListener localListener = new MyListener("local");
+      localNaturalIdCache.addListener(localListener);
 
-		// Bind a listener to the "remote" cache
-		CacheContainer remoteManager = ClusterAware.getCacheManager(DualNodeTest.REMOTE);
-		Cache remoteNaturalIdCache = remoteManager.getCache(Citizen.class.getName() + "##NaturalId");
-		MyListener remoteListener = new MyListener( "remote" );
-		remoteNaturalIdCache.addListener(remoteListener);
+      // Bind a listener to the "remote" cache
+      CacheContainer remoteManager = ClusterAware.getCacheManager(DualNodeTest.REMOTE);
+      Cache remoteNaturalIdCache = remoteManager.getCache(Citizen.class.getName() + "##NaturalId");
+      MyListener remoteListener = new MyListener("remote");
+      remoteNaturalIdCache.addListener(remoteListener);
 
-		SessionFactoryImplementor localFactory = sessionFactory();
-		InfinispanBaseRegion localNaturalIdRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Citizen.class.getName() + "##NaturalId");
-		SessionFactory remoteFactory = secondNodeEnvironment().getSessionFactory();
+      SessionFactoryImplementor localFactory = sessionFactory();
+      InfinispanBaseRegion localNaturalIdRegion = TEST_SESSION_ACCESS.getRegion(localFactory, Citizen.class.getName() + "##NaturalId");
+      SessionFactory remoteFactory = secondNodeEnvironment().getSessionFactory();
 
-		try {
-			assertTrue(remoteListener.isEmpty());
-			assertTrue(localListener.isEmpty());
+      try {
+         assertTrue(remoteListener.isEmpty());
+         assertTrue(localListener.isEmpty());
 
-			CountDownLatch remoteUpdateLatch = getRemoteUpdateLatch(remoteNaturalIdCache);
-			saveSomeCitizens(localFactory);
+         CountDownLatch remoteUpdateLatch = getRemoteUpdateLatch(remoteNaturalIdCache);
+         saveSomeCitizens(localFactory);
 
-			assertTrue(await(remoteUpdateLatch));
+         assertTrue(await(remoteUpdateLatch));
 
-			assertTrue(remoteListener.isEmpty());
-			assertTrue(localListener.isEmpty());
+         assertTrue(remoteListener.isEmpty());
+         assertTrue(localListener.isEmpty());
 
-			log.debug("Find node 0");
-			// This actually brings the collection into the cache
-			getCitizenWithCriteria(localFactory);
+         log.debug("Find node 0");
+         // This actually brings the collection into the cache
+         getCitizenWithCriteria(localFactory);
 
-			// Now the collection is in the cache so, the 2nd "get"
-			// should read everything from the cache
-			log.debug( "Find(2) node 0" );
-			localListener.clear();
-			getCitizenWithCriteria(localFactory);
+         // Now the collection is in the cache so, the 2nd "get"
+         // should read everything from the cache
+         log.debug("Find(2) node 0");
+         localListener.clear();
+         getCitizenWithCriteria(localFactory);
 
-			// Check the read came from the cache
-			log.debug( "Check cache 0" );
-			assertLoadedFromCache(localListener, "1234");
+         // Check the read came from the cache
+         log.debug("Check cache 0");
+         assertLoadedFromCache(localListener, "1234");
 
-			log.debug( "Find node 1" );
-			// This actually brings the collection into the cache since invalidation is in use
-			getCitizenWithCriteria(remoteFactory);
+         log.debug("Find node 1");
+         // This actually brings the collection into the cache since invalidation is in use
+         getCitizenWithCriteria(remoteFactory);
 
-			// Now the collection is in the cache so, the 2nd "get"
-			// should read everything from the cache
-			log.debug( "Find(2) node 1" );
-			remoteListener.clear();
-			getCitizenWithCriteria(remoteFactory);
+         // Now the collection is in the cache so, the 2nd "get"
+         // should read everything from the cache
+         log.debug("Find(2) node 1");
+         remoteListener.clear();
+         getCitizenWithCriteria(remoteFactory);
 
-			// Check the read came from the cache
-			log.debug( "Check cache 1" );
-			assertLoadedFromCache(remoteListener, "1234");
+         // Check the read came from the cache
+         log.debug("Check cache 1");
+         assertLoadedFromCache(remoteListener, "1234");
 
-			// Modify customer in remote
-			remoteListener.clear();
-			CountDownLatch localUpdate = expectEvict(localNaturalIdCache.getAdvancedCache(), 1);
-			deleteCitizenWithCriteria(remoteFactory);
-			assertTrue(localUpdate.await(2, TimeUnit.SECONDS));
+         // Modify customer in remote
+         remoteListener.clear();
+         CountDownLatch localUpdate = expectEvict(localNaturalIdCache.getAdvancedCache(), 1);
+         deleteCitizenWithCriteria(remoteFactory);
+         assertTrue(localUpdate.await(2, TimeUnit.SECONDS));
 
-			assertEquals(1, localNaturalIdRegion.getElementCountInMemory());
-		}
-		catch (Exception e) {
-			log.error("Error", e);
-			throw e;
-		} finally {
-		   if (cacheMode.isInvalidation())
+         assertEquals(1, localNaturalIdRegion.getElementCountInMemory());
+      } catch (Exception e) {
+         log.error("Error", e);
+         throw e;
+      } finally {
+         if (cacheMode.isInvalidation())
             removeAfterEndInvalidationHandler(remoteNaturalIdCache.getAdvancedCache());
 
-			withTxSession(localFactory, s -> {
+         withTxSession(localFactory, s -> {
             TEST_SESSION_ACCESS.execQueryUpdate(s, "delete NaturalIdOnManyToOne");
             TEST_SESSION_ACCESS.execQueryUpdate(s, "delete Citizen");
             TEST_SESSION_ACCESS.execQueryUpdate(s, "delete State");
-			});
-		}
-	}
+         });
+      }
+   }
 
    private boolean await(CountDownLatch latch) {
       assertNotNull(latch);
@@ -172,8 +171,8 @@ public class NaturalIdInvalidationTest extends DualNodeTest {
       CountDownLatch latch;
       if (cacheMode.isInvalidation()) {
          latch = useTransactionalCache()
-            ? expectAfterEndInvalidation(remoteNaturalIdCache.getAdvancedCache(), 1)
-            : expectAfterEndInvalidation(remoteNaturalIdCache.getAdvancedCache(), 2);
+               ? expectAfterEndInvalidation(remoteNaturalIdCache.getAdvancedCache(), 1)
+               : expectAfterEndInvalidation(remoteNaturalIdCache.getAdvancedCache(), 2);
       } else {
          latch = expectAfterUpdate(remoteNaturalIdCache.getAdvancedCache(), 2);
       }
@@ -182,108 +181,108 @@ public class NaturalIdInvalidationTest extends DualNodeTest {
       return latch;
    }
 
-	private void assertLoadedFromCache(MyListener localListener, String id) {
-		for (String visited : localListener.visited){
-			if (visited.contains(id))
-				return;
-		}
-		fail("Citizen (" + id + ") should have present in the cache");
-	}
+   private void assertLoadedFromCache(MyListener localListener, String id) {
+      for (String visited : localListener.visited) {
+         if (visited.contains(id))
+            return;
+      }
+      fail("Citizen (" + id + ") should have present in the cache");
+   }
 
-	private void saveSomeCitizens(SessionFactory sf) throws Exception {
-		final Citizen c1 = new Citizen();
-		c1.setFirstname( "Emmanuel" );
-		c1.setLastname( "Bernard" );
-		c1.setSsn( "1234" );
+   private void saveSomeCitizens(SessionFactory sf) throws Exception {
+      final Citizen c1 = new Citizen();
+      c1.setFirstname("Emmanuel");
+      c1.setLastname("Bernard");
+      c1.setSsn("1234");
 
-		final State france = new State();
-		france.setName( "Ile de France" );
-		c1.setState( france );
+      final State france = new State();
+      france.setName("Ile de France");
+      c1.setState(france);
 
-		final Citizen c2 = new Citizen();
-		c2.setFirstname( "Gavin" );
-		c2.setLastname( "King" );
-		c2.setSsn( "000" );
-		final State australia = new State();
-		australia.setName( "Australia" );
-		c2.setState( australia );
+      final Citizen c2 = new Citizen();
+      c2.setFirstname("Gavin");
+      c2.setLastname("King");
+      c2.setSsn("000");
+      final State australia = new State();
+      australia.setName("Australia");
+      c2.setState(australia);
 
-		withTxSession(sf, s -> {
-			s.persist( australia );
-			s.persist( france );
-			s.persist( c1 );
-			s.persist( c2 );
-		});
-	}
+      withTxSession(sf, s -> {
+         s.persist(australia);
+         s.persist(france);
+         s.persist(c1);
+         s.persist(c2);
+      });
+   }
 
-	private void getCitizenWithCriteria(SessionFactory sf) throws Exception {
-		withTxSession(sf, s -> {
-			State france = getState(s, "Ile de France");
-			HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
-			CriteriaQuery<Citizen> criteria = cb.createQuery(Citizen.class);
-			Root<Citizen> root = criteria.from(Citizen.class);
-			criteria.where(cb.equal(root.get(Citizen_.state), france));
+   private void getCitizenWithCriteria(SessionFactory sf) throws Exception {
+      withTxSession(sf, s -> {
+         State france = getState(s, "Ile de France");
+         HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
+         CriteriaQuery<Citizen> criteria = cb.createQuery(Citizen.class);
+         Root<Citizen> root = criteria.from(Citizen.class);
+         criteria.where(cb.equal(root.get(Citizen_.state), france));
 
-			s.createQuery(criteria)
-					.getResultList();
-		});
-	}
+         s.createQuery(criteria)
+               .getResultList();
+      });
+   }
 
-	private void deleteCitizenWithCriteria(SessionFactory sf) throws Exception {
-		withTxSession(sf, s -> {
-			State france = getState(s, "Ile de France");
+   private void deleteCitizenWithCriteria(SessionFactory sf) throws Exception {
+      withTxSession(sf, s -> {
+         State france = getState(s, "Ile de France");
 
-			HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
-			JpaCriteriaQuery<Citizen> criteria = cb.createQuery(Citizen.class);
-			Root<Citizen> root = criteria.from(Citizen.class);
-			criteria.where(cb.equal(root.get(Citizen_.ssn), "1234"), cb.equal(root.get(Citizen_.state), france));
+         HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
+         JpaCriteriaQuery<Citizen> criteria = cb.createQuery(Citizen.class);
+         Root<Citizen> root = criteria.from(Citizen.class);
+         criteria.where(cb.equal(root.get(Citizen_.ssn), "1234"), cb.equal(root.get(Citizen_.state), france));
 
-			Citizen c = s.createQuery(criteria).uniqueResult();
-			s.remove(c);
-		});
-	}
+         Citizen c = s.createQuery(criteria).uniqueResult();
+         s.remove(c);
+      });
+   }
 
-	private State getState(Session s, String name) {
-		HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
-		CriteriaQuery<State> criteria = cb.createQuery(State.class);
-		Root<State> root = criteria.from(State.class);
-		criteria.where(cb.equal(root.get(State_.name), name));
+   private State getState(Session s, String name) {
+      HibernateCriteriaBuilder cb = s.getCriteriaBuilder();
+      CriteriaQuery<State> criteria = cb.createQuery(State.class);
+      Root<State> root = criteria.from(State.class);
+      criteria.where(cb.equal(root.get(State_.name), name));
 
-		return s.createQuery(criteria)
-				.setHint(QueryHints.HINT_CACHEABLE, "true")
-				.getResultList().get(0);
-	}
+      return s.createQuery(criteria)
+            .setHint(QueryHints.HINT_CACHEABLE, "true")
+            .getResultList().get(0);
+   }
 
-	@Listener
-	public static class MyListener {
-		private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog( MyListener.class );
-		private final Set<String> visited = ConcurrentHashMap.newKeySet();
+   @Listener
+   public static class MyListener {
+      private static final InfinispanMessageLogger log = InfinispanMessageLogger.Provider.getLog(MyListener.class);
+      private final Set<String> visited = ConcurrentHashMap.newKeySet();
 
       public MyListener(String name) {
       }
 
-		public void clear() {
-			visited.clear();
-		}
+      public void clear() {
+         visited.clear();
+      }
 
-		public boolean isEmpty() {
-			return visited.isEmpty();
-		}
+      public boolean isEmpty() {
+         return visited.isEmpty();
+      }
 
-		@CacheEntryVisited
-		public void nodeVisited(CacheEntryVisitedEvent event) {
-			log.debug( event.toString() );
-			if ( !event.isPre() ) {
-				visited.add(event.getKey().toString());
-			}
-		}
+      @CacheEntryVisited
+      public void nodeVisited(CacheEntryVisitedEvent event) {
+         log.debug(event.toString());
+         if (!event.isPre()) {
+            visited.add(event.getKey().toString());
+         }
+      }
 
-		@CacheEntryCreated
+      @CacheEntryCreated
       @CacheEntryModified
       @CacheEntryRemoved
-		public void nodeWritten(CacheEntryEvent event) {
-		   log.debug( event.toString() );
+      public void nodeWritten(CacheEntryEvent event) {
+         log.debug(event.toString());
       }
-	}
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/PartialFutureUpdateTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/PartialFutureUpdateTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.test.hibernate.cache.commons.functional.cluster;
 
+import static org.junit.Assert.assertEquals;
+
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.hibernate.cache.commons.util.FutureUpdate;
@@ -7,8 +9,6 @@ import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Customer;
-
-import static org.junit.Assert.assertEquals;
 
 public class PartialFutureUpdateTest extends AbstractPartialUpdateTest {
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/PartialTombstoneTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/PartialTombstoneTest.java
@@ -1,5 +1,11 @@
 package org.infinispan.test.hibernate.cache.commons.functional.cluster;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CompletionException;
+
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.hibernate.cache.commons.util.InfinispanMessageLogger;
@@ -7,12 +13,6 @@ import org.infinispan.hibernate.cache.commons.util.Tombstone;
 import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.test.hibernate.cache.commons.functional.entities.Customer;
-
-import java.util.concurrent.CompletionException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class PartialTombstoneTest extends AbstractPartialUpdateTest {
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/SessionRefreshTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/cluster/SessionRefreshTest.java
@@ -24,30 +24,30 @@ import org.junit.Test;
  * @since 3.5
  */
 public class SessionRefreshTest extends DualNodeTest {
-	private static final Logger log = Logger.getLogger(SessionRefreshTest.class);
+   private static final Logger log = Logger.getLogger(SessionRefreshTest.class);
 
-	private Cache localCache;
+   private Cache localCache;
 
-	@Override
-	protected void configureSecondNode(StandardServiceRegistryBuilder ssrb) {
-		super.configureSecondNode(ssrb);
-		ssrb.applySetting(Environment.USE_SECOND_LEVEL_CACHE, "false");
-	}
+   @Override
+   protected void configureSecondNode(StandardServiceRegistryBuilder ssrb) {
+      super.configureSecondNode(ssrb);
+      ssrb.applySetting(Environment.USE_SECOND_LEVEL_CACHE, "false");
+   }
 
-	@Override
-	public List<Object[]> getParameters() {
-		return getParameters(true, true, false, true, true);
-	}
+   @Override
+   public List<Object[]> getParameters() {
+      return getParameters(true, true, false, true, true);
+   }
 
-	@Override
-	protected void applyStandardSettings(Map settings) {
-		super.applyStandardSettings(settings);
-		settings.put(InfinispanProperties.ENTITY_CACHE_RESOURCE_PROP, getEntityCacheConfigName());
-	}
+   @Override
+   protected void applyStandardSettings(Map settings) {
+      super.applyStandardSettings(settings);
+      settings.put(InfinispanProperties.ENTITY_CACHE_RESOURCE_PROP, getEntityCacheConfigName());
+   }
 
-	protected String getEntityCacheConfigName() {
-		return "entity";
-	}
+   protected String getEntityCacheConfigName() {
+      return "entity";
+   }
 
    @Override
    protected String getBaseForMappings() {
@@ -55,61 +55,61 @@ public class SessionRefreshTest extends DualNodeTest {
    }
 
    @Override
-	public String[] getMappings() {
-		return new String[] {"hibernate/cache/commons/functional/entities/Account.hbm.xml"};
-	}
+   public String[] getMappings() {
+      return new String[]{"hibernate/cache/commons/functional/entities/Account.hbm.xml"};
+   }
 
-	@Override
-	protected void cleanupTransactionManagement() {
-		// Don't clean up the managers, just the transactions
-		// Managers are still needed by the long-lived caches
-		DualNodeJtaTransactionManagerImpl.cleanupTransactions();
-	}
+   @Override
+   protected void cleanupTransactionManagement() {
+      // Don't clean up the managers, just the transactions
+      // Managers are still needed by the long-lived caches
+      DualNodeJtaTransactionManagerImpl.cleanupTransactions();
+   }
 
-	@Test
-	public void testRefreshAfterExternalChange() throws Exception {
-		// First session factory uses a cache
-		CacheContainer localManager = ClusterAware.getCacheManager(DualNodeTest.LOCAL);
-		localCache = localManager.getCache(Account.class.getName());
-		SessionFactory localFactory = sessionFactory();
+   @Test
+   public void testRefreshAfterExternalChange() throws Exception {
+      // First session factory uses a cache
+      CacheContainer localManager = ClusterAware.getCacheManager(DualNodeTest.LOCAL);
+      localCache = localManager.getCache(Account.class.getName());
+      SessionFactory localFactory = sessionFactory();
 
-		// Second session factory doesn't; just needs a transaction manager
-		SessionFactory remoteFactory = secondNodeEnvironment().getSessionFactory();
+      // Second session factory doesn't; just needs a transaction manager
+      SessionFactory remoteFactory = secondNodeEnvironment().getSessionFactory();
 
-		AccountDAO dao0 = new AccountDAO(useJta, localFactory);
-		AccountDAO dao1 = new AccountDAO(useJta, remoteFactory);
+      AccountDAO dao0 = new AccountDAO(useJta, localFactory);
+      AccountDAO dao1 = new AccountDAO(useJta, remoteFactory);
 
-		Integer id = 1;
-		dao0.createAccount(dao0.getSmith(), id, 5, DualNodeTest.LOCAL);
+      Integer id = 1;
+      dao0.createAccount(dao0.getSmith(), id, 5, DualNodeTest.LOCAL);
 
-		// Basic sanity check
-		Account acct1 = dao1.getAccount(id);
-		assertNotNull(acct1);
-		assertEquals(DualNodeTest.LOCAL, acct1.getBranch());
+      // Basic sanity check
+      Account acct1 = dao1.getAccount(id);
+      assertNotNull(acct1);
+      assertEquals(DualNodeTest.LOCAL, acct1.getBranch());
 
-		// This dao's session factory isn't caching, so cache won't see this change
-		dao1.updateAccountBranch(id, DualNodeTest.REMOTE);
+      // This dao's session factory isn't caching, so cache won't see this change
+      dao1.updateAccountBranch(id, DualNodeTest.REMOTE);
 
-		// dao1's session doesn't touch the cache,
-		// so reading from dao0 should show a stale value from the cache
-		// (we check to confirm the cache is used)
-		Account acct0 = dao0.getAccount(id);
-		assertNotNull(acct0);
-		assertEquals(DualNodeTest.LOCAL, acct0.getBranch());
-		log.debug("Contents when re-reading from local: " + TestingUtil.printCache(localCache));
+      // dao1's session doesn't touch the cache,
+      // so reading from dao0 should show a stale value from the cache
+      // (we check to confirm the cache is used)
+      Account acct0 = dao0.getAccount(id);
+      assertNotNull(acct0);
+      assertEquals(DualNodeTest.LOCAL, acct0.getBranch());
+      log.debug("Contents when re-reading from local: " + TestingUtil.printCache(localCache));
 
-		// Now call session.refresh and confirm we get the correct value
-		acct0 = dao0.getAccountWithRefresh(id);
-		assertNotNull(acct0);
-		assertEquals(DualNodeTest.REMOTE, acct0.getBranch());
-		log.debug("Contents after refreshing in remote: " + TestingUtil.printCache(localCache));
+      // Now call session.refresh and confirm we get the correct value
+      acct0 = dao0.getAccountWithRefresh(id);
+      assertNotNull(acct0);
+      assertEquals(DualNodeTest.REMOTE, acct0.getBranch());
+      log.debug("Contents after refreshing in remote: " + TestingUtil.printCache(localCache));
 
-		// Double check with a brand new session, in case the other session
-		// for some reason bypassed the 2nd level cache
-		AccountDAO dao0A = new AccountDAO(useJta, localFactory);
-		Account acct0A = dao0A.getAccount(id);
-		assertNotNull(acct0A);
-		assertEquals(DualNodeTest.REMOTE, acct0A.getBranch());
-		log.debug("Contents after creating a new session: " + TestingUtil.printCache(localCache));
-	}
+      // Double check with a brand new session, in case the other session
+      // for some reason bypassed the 2nd level cache
+      AccountDAO dao0A = new AccountDAO(useJta, localFactory);
+      Account acct0A = dao0A.getAccount(id);
+      assertNotNull(acct0A);
+      assertEquals(DualNodeTest.REMOTE, acct0A.getBranch());
+      log.debug("Contents after creating a new session: " + TestingUtil.printCache(localCache));
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Account.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Account.java
@@ -9,102 +9,102 @@ import java.io.Serializable;
  */
 public class Account implements Serializable {
 
-	private static final long serialVersionUID = 1L;
+   private static final long serialVersionUID = 1L;
 
-	private Integer id;
-	private long version;
-	private AccountHolder accountHolder;
-	private Integer balance;
-	private String branch;
+   private Integer id;
+   private long version;
+   private AccountHolder accountHolder;
+   private Integer balance;
+   private String branch;
 
-	public Integer getId() {
-		return id;
-	}
+   public Integer getId() {
+      return id;
+   }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+   public void setId(Integer id) {
+      this.id = id;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	public AccountHolder getAccountHolder() {
-		return accountHolder;
-	}
+   public AccountHolder getAccountHolder() {
+      return accountHolder;
+   }
 
-	public void setAccountHolder(AccountHolder accountHolder) {
-		this.accountHolder = accountHolder;
-	}
+   public void setAccountHolder(AccountHolder accountHolder) {
+      this.accountHolder = accountHolder;
+   }
 
-	public Integer getBalance() {
-		return balance;
-	}
+   public Integer getBalance() {
+      return balance;
+   }
 
-	public void setBalance(Integer balance) {
-		this.balance = balance;
-	}
+   public void setBalance(Integer balance) {
+      this.balance = balance;
+   }
 
-	public String getBranch() {
-		return branch;
-	}
+   public String getBranch() {
+      return branch;
+   }
 
-	public void setBranch(String branch) {
-		this.branch = branch;
-	}
+   public void setBranch(String branch) {
+      this.branch = branch;
+   }
 
-	public boolean equals(Object obj) {
-		if (obj == this)
-			return true;
-		if (!(obj instanceof Account))
-			return false;
-		Account acct = (Account) obj;
-		if (!safeEquals(id, acct.id))
-			return false;
-		if (!safeEquals(branch, acct.branch))
-			return false;
-		if (!safeEquals(balance, acct.balance))
-			return false;
-		if (!safeEquals(accountHolder, acct.accountHolder))
-			return false;
-		return true;
-	}
+   public boolean equals(Object obj) {
+      if (obj == this)
+         return true;
+      if (!(obj instanceof Account))
+         return false;
+      Account acct = (Account) obj;
+      if (!safeEquals(id, acct.id))
+         return false;
+      if (!safeEquals(branch, acct.branch))
+         return false;
+      if (!safeEquals(balance, acct.balance))
+         return false;
+      if (!safeEquals(accountHolder, acct.accountHolder))
+         return false;
+      return true;
+   }
 
-	@Override
-	public int hashCode() {
-		int result = 17;
-		result = result * 31 + safeHashCode(id);
-		result = result * 31 + safeHashCode(branch);
-		result = result * 31 + safeHashCode(balance);
-		result = result * 31 + safeHashCode(accountHolder);
-		return result;
-	}
+   @Override
+   public int hashCode() {
+      int result = 17;
+      result = result * 31 + safeHashCode(id);
+      result = result * 31 + safeHashCode(branch);
+      result = result * 31 + safeHashCode(balance);
+      result = result * 31 + safeHashCode(accountHolder);
+      return result;
+   }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder(getClass().getName());
-		sb.append("[id=");
-		sb.append(id);
-		sb.append(",branch=");
-		sb.append(branch);
-		sb.append(",balance=");
-		sb.append(balance);
-		sb.append(",accountHolder=");
-		sb.append(accountHolder);
-		sb.append("]");
-		return sb.toString();
-	}
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder(getClass().getName());
+      sb.append("[id=");
+      sb.append(id);
+      sb.append(",branch=");
+      sb.append(branch);
+      sb.append(",balance=");
+      sb.append(balance);
+      sb.append(",accountHolder=");
+      sb.append(accountHolder);
+      sb.append("]");
+      return sb.toString();
+   }
 
-	private static int safeHashCode(Object obj) {
-		return obj == null ? 0 : obj.hashCode();
-	}
+   private static int safeHashCode(Object obj) {
+      return obj == null ? 0 : obj.hashCode();
+   }
 
-	private static boolean safeEquals(Object a, Object b) {
-		return (a == b || (a != null && a.equals(b)));
-	}
+   private static boolean safeEquals(Object a, Object b) {
+      return (a == b || (a != null && a.equals(b)));
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/AccountHolder.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/AccountHolder.java
@@ -1,4 +1,5 @@
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -9,75 +10,75 @@ import java.io.Serializable;
  * @author Brian Stansberry
  */
 public class AccountHolder implements Serializable {
-	private static final long serialVersionUID = 1L;
+   private static final long serialVersionUID = 1L;
 
-	private String lastName;
-	private String ssn;
-	private transient boolean deserialized;
+   private String lastName;
+   private String ssn;
+   private transient boolean deserialized;
 
-	public AccountHolder() {
-		this("Stansberry", "123-456-7890");
-	}
+   public AccountHolder() {
+      this("Stansberry", "123-456-7890");
+   }
 
-	public AccountHolder(String lastName, String ssn) {
-		this.lastName = lastName;
-		this.ssn = ssn;
-	}
+   public AccountHolder(String lastName, String ssn) {
+      this.lastName = lastName;
+      this.ssn = ssn;
+   }
 
-	public String getLastName() {
-		return this.lastName;
-	}
+   public String getLastName() {
+      return this.lastName;
+   }
 
-	public void setLastName(String lastName) {
-		this.lastName = lastName;
-	}
+   public void setLastName(String lastName) {
+      this.lastName = lastName;
+   }
 
-	public String getSsn() {
-		return ssn;
-	}
+   public String getSsn() {
+      return ssn;
+   }
 
-	public void setSsn(String ssn) {
-		this.ssn = ssn;
-	}
+   public void setSsn(String ssn) {
+      this.ssn = ssn;
+   }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == this)
-			return true;
-		if (!(obj instanceof AccountHolder))
-			return false;
-		AccountHolder pk = (AccountHolder) obj;
-		if (!lastName.equals(pk.lastName))
-			return false;
-		if (!ssn.equals(pk.ssn))
-			return false;
-		return true;
-	}
+   @Override
+   public boolean equals(Object obj) {
+      if (obj == this)
+         return true;
+      if (!(obj instanceof AccountHolder))
+         return false;
+      AccountHolder pk = (AccountHolder) obj;
+      if (!lastName.equals(pk.lastName))
+         return false;
+      if (!ssn.equals(pk.ssn))
+         return false;
+      return true;
+   }
 
-	@Override
-	public int hashCode() {
-		int result = 17;
-		result = result * 31 + lastName.hashCode();
-		result = result * 31 + ssn.hashCode();
-		return result;
-	}
+   @Override
+   public int hashCode() {
+      int result = 17;
+      result = result * 31 + lastName.hashCode();
+      result = result * 31 + ssn.hashCode();
+      return result;
+   }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder(getClass().getName());
-		sb.append("[lastName=");
-		sb.append(lastName);
-		sb.append(",ssn=");
-		sb.append(ssn);
-		sb.append(",deserialized=");
-		sb.append(deserialized);
-		sb.append("]");
-		return sb.toString();
-	}
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder(getClass().getName());
+      sb.append("[lastName=");
+      sb.append(lastName);
+      sb.append(",ssn=");
+      sb.append(ssn);
+      sb.append(",deserialized=");
+      sb.append(deserialized);
+      sb.append("]");
+      return sb.toString();
+   }
 
-	private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
-		ois.defaultReadObject();
-		deserialized = true;
-	}
+   private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
+      ois.defaultReadObject();
+      deserialized = true;
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Age.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Age.java
@@ -1,5 +1,5 @@
-
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -9,24 +9,24 @@ import jakarta.persistence.NamedQuery;
 /**
  * @author Galder Zamarreño
  */
-@NamedQueries({@NamedQuery(name=Age.QUERY, query = "SELECT a FROM Age a")})
+@NamedQueries({@NamedQuery(name = Age.QUERY, query = "SELECT a FROM Age a")})
 @Entity
 public class Age {
 
    public static final String QUERY = "Age.findAll";
 
-	@Id
-	@GeneratedValue
-	private Integer id;
-	private Integer age;
+   @Id
+   @GeneratedValue
+   private Integer id;
+   private Integer age;
 
-	public Integer getId() {
-		return id;
-	}
+   public Integer getId() {
+      return id;
+   }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+   public void setId(Integer id) {
+      this.id = id;
+   }
 
    public Integer getAge() {
       return age;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Citizen.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Citizen.java
@@ -1,4 +1,3 @@
-
 //$Id$
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
 
@@ -17,65 +16,65 @@ import jakarta.persistence.Transient;
 @Entity
 @NaturalIdCache
 public class Citizen {
-	@Id
-	@GeneratedValue
-	private Integer id;
-	@Transient
-	private long version;
-	private String firstname;
-	private String lastname;
-	@NaturalId
-	@ManyToOne
-	private State state;
-	@NaturalId
-	private String ssn;
+   @Id
+   @GeneratedValue
+   private Integer id;
+   @Transient
+   private long version;
+   private String firstname;
+   private String lastname;
+   @NaturalId
+   @ManyToOne
+   private State state;
+   @NaturalId
+   private String ssn;
 
 
-	public Integer getId() {
-		return id;
-	}
+   public Integer getId() {
+      return id;
+   }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+   public void setId(Integer id) {
+      this.id = id;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	public String getFirstname() {
-		return firstname;
-	}
+   public String getFirstname() {
+      return firstname;
+   }
 
-	public void setFirstname(String firstname) {
-		this.firstname = firstname;
-	}
+   public void setFirstname(String firstname) {
+      this.firstname = firstname;
+   }
 
-	public String getLastname() {
-		return lastname;
-	}
+   public String getLastname() {
+      return lastname;
+   }
 
-	public void setLastname(String lastname) {
-		this.lastname = lastname;
-	}
+   public void setLastname(String lastname) {
+      this.lastname = lastname;
+   }
 
-	public State getState() {
-		return state;
-	}
+   public State getState() {
+      return state;
+   }
 
-	public void setState(State state) {
-		this.state = state;
-	}
+   public void setState(State state) {
+      this.state = state;
+   }
 
-	public String getSsn() {
-		return ssn;
-	}
+   public String getSsn() {
+      return ssn;
+   }
 
-	public void setSsn(String ssn) {
-		this.ssn = ssn;
-	}
+   public void setSsn(String ssn) {
+      this.ssn = ssn;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Contact.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Contact.java
@@ -1,4 +1,5 @@
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
+
 import java.io.Serializable;
 
 /**
@@ -8,70 +9,70 @@ import java.io.Serializable;
  * @since 3.5
  */
 public class Contact implements Serializable {
-	Integer id;
-	String name;
-	String tlf;
-	Customer customer;
-	// mapping added programmatically
-	long version;
+   Integer id;
+   String name;
+   String tlf;
+   Customer customer;
+   // mapping added programmatically
+   long version;
 
-	public Integer getId() {
-		return id;
-	}
+   public Integer getId() {
+      return id;
+   }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+   public void setId(Integer id) {
+      this.id = id;
+   }
 
-	public String getName() {
-		return name;
-	}
+   public String getName() {
+      return name;
+   }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+   public void setName(String name) {
+      this.name = name;
+   }
 
-	public String getTlf() {
-		return tlf;
-	}
+   public String getTlf() {
+      return tlf;
+   }
 
-	public void setTlf(String tlf) {
-		this.tlf = tlf;
-	}
+   public void setTlf(String tlf) {
+      this.tlf = tlf;
+   }
 
-	public Customer getCustomer() {
-		return customer;
-	}
+   public Customer getCustomer() {
+      return customer;
+   }
 
-	public void setCustomer(Customer customer) {
-		this.customer = customer;
-	}
+   public void setCustomer(Customer customer) {
+      this.customer = customer;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	@Override
-	public boolean equals(Object o) {
-		if (o == this)
-			return true;
-		if (!(o instanceof Contact))
-			return false;
-		Contact c = (Contact) o;
-		return c.id.equals(id) && c.name.equals(name) && c.tlf.equals(tlf);
-	}
+   @Override
+   public boolean equals(Object o) {
+      if (o == this)
+         return true;
+      if (!(o instanceof Contact))
+         return false;
+      Contact c = (Contact) o;
+      return c.id.equals(id) && c.name.equals(name) && c.tlf.equals(tlf);
+   }
 
-	@Override
-	public int hashCode() {
-		int result = 17;
-		result = 31 * result + (id == null ? 0 : id.hashCode());
-		result = 31 * result + name.hashCode();
-		result = 31 * result + tlf.hashCode();
-		return result;
-	}
+   @Override
+   public int hashCode() {
+      int result = 17;
+      result = 31 * result + (id == null ? 0 : id.hashCode());
+      result = 31 * result + name.hashCode();
+      result = 31 * result + tlf.hashCode();
+      return result;
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Customer.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Customer.java
@@ -1,4 +1,5 @@
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
+
 import java.io.Serializable;
 import java.util.Set;
 
@@ -9,45 +10,45 @@ import java.util.Set;
  * @author Kabir Khan
  */
 public class Customer implements Serializable {
-	Integer id;
-	String name;
-	// mapping added programmatically
-	long version;
+   Integer id;
+   String name;
+   // mapping added programmatically
+   long version;
 
-	private transient Set<Contact> contacts;
+   private transient Set<Contact> contacts;
 
-	public Customer() {
-	}
+   public Customer() {
+   }
 
-	public Integer getId() {
-		return id;
-	}
+   public Integer getId() {
+      return id;
+   }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+   public void setId(Integer id) {
+      this.id = id;
+   }
 
-	public String getName() {
-		return name;
-	}
+   public String getName() {
+      return name;
+   }
 
-	public void setName(String string) {
-		name = string;
-	}
+   public void setName(String string) {
+      name = string;
+   }
 
-	public Set<Contact> getContacts() {
-		return contacts;
-	}
+   public Set<Contact> getContacts() {
+      return contacts;
+   }
 
-	public void setContacts(Set<Contact> contacts) {
-		this.contacts = contacts;
-	}
+   public void setContacts(Set<Contact> contacts) {
+      this.contacts = contacts;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Item.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Item.java
@@ -1,4 +1,5 @@
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -8,109 +9,110 @@ import java.util.Set;
  * @author Gavin King
  */
 public class Item {
-	private Long id;
-	// mapping for version is added programmatically
-	private long version;
-	private String name;
-	private String description;
-	private Item owner;
-	private Set<Item> items = new HashSet<Item>(  );
-	private Item bagOwner;
-	private List<Item> bagOfItems = new ArrayList<Item>(  );
-	private Set<OtherItem> otherItems = new HashSet<OtherItem>(  );
+   private Long id;
+   // mapping for version is added programmatically
+   private long version;
+   private String name;
+   private String description;
+   private Item owner;
+   private Set<Item> items = new HashSet<Item>();
+   private Item bagOwner;
+   private List<Item> bagOfItems = new ArrayList<Item>();
+   private Set<OtherItem> otherItems = new HashSet<OtherItem>();
 
-	public Item() {}
+   public Item() {
+   }
 
-	public Item( String name, String description ) {
-		this.name = name;
-		this.description = description;
-	}
+   public Item(String name, String description) {
+      this.name = name;
+      this.description = description;
+   }
 
-	public String getDescription() {
-		  return description;
-	 }
+   public String getDescription() {
+      return description;
+   }
 
-	public void setDescription(String description) {
-		  this.description = description;
-	 }
+   public void setDescription(String description) {
+      this.description = description;
+   }
 
-	public Long getId() {
-		  return id;
-	 }
+   public Long getId() {
+      return id;
+   }
 
-	public void setId(Long id) {
-		  this.id = id;
-	 }
+   public void setId(Long id) {
+      this.id = id;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	public String getName() {
-		  return name;
-	 }
+   public String getName() {
+      return name;
+   }
 
-	public void setName(String name) {
-		  this.name = name;
-	 }
+   public void setName(String name) {
+      this.name = name;
+   }
 
-	public Item getOwner() {
-		return owner;
-	}
+   public Item getOwner() {
+      return owner;
+   }
 
-	public void setOwner( Item owner ) {
-		this.owner = owner;
-	}
+   public void setOwner(Item owner) {
+      this.owner = owner;
+   }
 
-	public Set<Item> getItems() {
-		return items;
-	}
+   public Set<Item> getItems() {
+      return items;
+   }
 
-	public void setItems( Set<Item> items ) {
-		this.items = items;
-	}
+   public void setItems(Set<Item> items) {
+      this.items = items;
+   }
 
-	public void addItem( Item item ) {
-		item.setOwner( this );
-		getItems().add( item );
-	}
+   public void addItem(Item item) {
+      item.setOwner(this);
+      getItems().add(item);
+   }
 
-	public Item getBagOwner() {
-		return bagOwner;
-	}
+   public Item getBagOwner() {
+      return bagOwner;
+   }
 
-	public void setBagOwner( Item bagOwner ) {
-		this.bagOwner = bagOwner;
-	}
+   public void setBagOwner(Item bagOwner) {
+      this.bagOwner = bagOwner;
+   }
 
-	public List<Item> getBagOfItems() {
-		return bagOfItems;
-	}
+   public List<Item> getBagOfItems() {
+      return bagOfItems;
+   }
 
-	public void setBagOfItems( List<Item> bagOfItems ) {
-		this.bagOfItems = bagOfItems;
-	}
+   public void setBagOfItems(List<Item> bagOfItems) {
+      this.bagOfItems = bagOfItems;
+   }
 
-	public void addItemToBag( Item item ) {
-		item.setBagOwner( this );
-		getBagOfItems().add( item );
-	}
+   public void addItemToBag(Item item) {
+      item.setBagOwner(this);
+      getBagOfItems().add(item);
+   }
 
-	public Set<OtherItem> getOtherItems() {
-		return otherItems;
-	}
+   public Set<OtherItem> getOtherItems() {
+      return otherItems;
+   }
 
-	public void setOtherItems(Set<OtherItem> otherItems) {
-		this.otherItems = otherItems;
-	}
+   public void setOtherItems(Set<OtherItem> otherItems) {
+      this.otherItems = otherItems;
+   }
 
-	public void addOtherItem(OtherItem otherItem) {
-		getOtherItems().add( otherItem );
-		otherItem.getBagOfItems().add( this );
-	}
+   public void addOtherItem(OtherItem otherItem) {
+      getOtherItems().add(otherItem);
+      otherItem.getBagOfItems().add(this);
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Name.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Name.java
@@ -11,39 +11,40 @@ import jakarta.persistence.Embeddable;
  */
 @Embeddable
 public class Name implements Serializable {
-    String firstName;
-    String lastName;
+   String firstName;
+   String lastName;
 
-    public Name() {}
+   public Name() {
+   }
 
-    public Name(String firstName, String lastName) {
-        this.firstName = firstName;
-        this.lastName = lastName;
-    }
+   public Name(String firstName, String lastName) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+   }
 
-    public String getFirstName() {
-        return firstName;
-    }
+   public String getFirstName() {
+      return firstName;
+   }
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
+   public void setFirstName(String firstName) {
+      this.firstName = firstName;
+   }
 
-    public String getLastName() {
-        return lastName;
-    }
+   public String getLastName() {
+      return lastName;
+   }
 
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
+   public void setLastName(String lastName) {
+      this.lastName = lastName;
+   }
 
-    @Override
-    public int hashCode() {
-        return 0;
-    }
+   @Override
+   public int hashCode() {
+      return 0;
+   }
 
-    @Override
-    public boolean equals(Object obj) {
-        return false;
-    }
+   @Override
+   public boolean equals(Object obj) {
+      return false;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/NaturalIdOnManyToOne.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/NaturalIdOnManyToOne.java
@@ -18,38 +18,38 @@ import jakarta.persistence.Transient;
  * @author Hardy Ferentschik
  */
 public class NaturalIdOnManyToOne {
-	@Id
-	@GeneratedValue
-	int id;
+   @Id
+   @GeneratedValue
+   int id;
 
-	@Transient
-	long version;
+   @Transient
+   long version;
 
-	@NaturalId
-	@ManyToOne
-	Citizen citizen;
+   @NaturalId
+   @ManyToOne
+   Citizen citizen;
 
-	public int getId() {
-		return id;
-	}
+   public int getId() {
+      return id;
+   }
 
-	public void setId(int id) {
-		this.id = id;
-	}
+   public void setId(int id) {
+      this.id = id;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	public Citizen getCitizen() {
-		return citizen;
-	}
+   public Citizen getCitizen() {
+      return citizen;
+   }
 
-	public void setCitizen(Citizen citizen) {
-		this.citizen = citizen;
-	}
+   public void setCitizen(Citizen citizen) {
+      this.citizen = citizen;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/OtherItem.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/OtherItem.java
@@ -7,58 +7,58 @@ import java.util.List;
  * @author Gail Badner
  */
 public class OtherItem {
-	private Long id;
-	// mapping added programmatically
-	private long version;
-	private String name;
-	private Item favoriteItem;
-	private List<Item> bagOfItems = new ArrayList<Item>();
+   private Long id;
+   // mapping added programmatically
+   private long version;
+   private String name;
+   private Item favoriteItem;
+   private List<Item> bagOfItems = new ArrayList<Item>();
 
-	public OtherItem() {
-	}
+   public OtherItem() {
+   }
 
-	public Long getId() {
-		return id;
-	}
+   public Long getId() {
+      return id;
+   }
 
-	public void setId(Long id) {
-		this.id = id;
-	}
+   public void setId(Long id) {
+      this.id = id;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	public String getName() {
-		return name;
-	}
+   public String getName() {
+      return name;
+   }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+   public void setName(String name) {
+      this.name = name;
+   }
 
-	public Item getFavoriteItem() {
-		return favoriteItem;
-	}
+   public Item getFavoriteItem() {
+      return favoriteItem;
+   }
 
-	public void setFavoriteItem(Item favoriteItem) {
-		this.favoriteItem = favoriteItem;
-	}
+   public void setFavoriteItem(Item favoriteItem) {
+      this.favoriteItem = favoriteItem;
+   }
 
-	public List<Item> getBagOfItems() {
-		return bagOfItems;
-	}
+   public List<Item> getBagOfItems() {
+      return bagOfItems;
+   }
 
-	public void setBagOfItems(List<Item> bagOfItems) {
-		this.bagOfItems = bagOfItems;
-	}
+   public void setBagOfItems(List<Item> bagOfItems) {
+      this.bagOfItems = bagOfItems;
+   }
 
-	public void addItemToBag(Item item) {
-		bagOfItems.add( item );
-		item.getOtherItems().add( this );
-	}
+   public void addItemToBag(Item item) {
+      bagOfItems.add(item);
+      item.getOtherItems().add(this);
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/PK.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/PK.java
@@ -10,32 +10,32 @@ import java.io.Serializable;
  * @author Gail Badner
  */
 public class PK implements Serializable {
-	private Long id;
+   private Long id;
 
-	public PK() {
-	}
+   public PK() {
+   }
 
-	public PK(Long id) {
-		this.id = id;
-	}
+   public PK(Long id) {
+      this.id = id;
+   }
 
-	@Override
-	public boolean equals(Object o) {
-		if ( this == o ) {
-			return true;
-		}
-		if ( o == null || getClass() != o.getClass() ) {
-			return false;
-		}
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
 
-		PK pk = (PK) o;
+      PK pk = (PK) o;
 
-		return !( id != null ? !id.equals( pk.id ) : pk.id != null );
+      return !(id != null ? !id.equals(pk.id) : pk.id != null);
 
-	}
+   }
 
-	@Override
-	public int hashCode() {
-		return id != null ? id.hashCode() : 0;
-	}
+   @Override
+   public int hashCode() {
+      return id != null ? id.hashCode() : 0;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Person.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/Person.java
@@ -15,42 +15,43 @@ import jakarta.persistence.Transient;
 @Entity
 @Cacheable
 public class Person implements Serializable {
-    @EmbeddedId
-    Name name;
+   @EmbeddedId
+   Name name;
 
-    int age;
+   int age;
 
-    @Transient
-    long version;
+   @Transient
+   long version;
 
-    public Person() {}
+   public Person() {
+   }
 
-    public Person(String firstName, String lastName, int age) {
-        name = new Name(firstName, lastName);
-        this.age = age;
-    }
+   public Person(String firstName, String lastName, int age) {
+      name = new Name(firstName, lastName);
+      this.age = age;
+   }
 
-    public Name getName() {
-        return name;
-    }
+   public Name getName() {
+      return name;
+   }
 
-    public void setName(Name name) {
-        this.name = name;
-    }
+   public void setName(Name name) {
+      this.name = name;
+   }
 
-    public int getAge() {
-        return age;
-    }
+   public int getAge() {
+      return age;
+   }
 
-    public void setAge(int age) {
-        this.age = age;
-    }
+   public void setAge(int age) {
+      this.age = age;
+   }
 
-    public long getVersion() {
-        return version;
-    }
+   public long getVersion() {
+      return version;
+   }
 
-    public void setVersion(long version) {
-        this.version = version;
-    }
+   public void setVersion(long version) {
+      this.version = version;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/State.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/State.java
@@ -1,6 +1,6 @@
-
 //$Id$
 package org.infinispan.test.hibernate.cache.commons.functional.entities;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -11,34 +11,34 @@ import jakarta.persistence.Transient;
  */
 @Entity
 public class State {
-	@Id
-	@GeneratedValue
-	private Integer id;
-	@Transient
-	private long version;
-	private String name;
+   @Id
+   @GeneratedValue
+   private Integer id;
+   @Transient
+   private long version;
+   private String name;
 
-	public Integer getId() {
-		return id;
-	}
+   public Integer getId() {
+      return id;
+   }
 
-	public void setId(Integer id) {
-		this.id = id;
-	}
+   public void setId(Integer id) {
+      this.id = id;
+   }
 
-	public long getVersion() {
-		return version;
-	}
+   public long getVersion() {
+      return version;
+   }
 
-	public void setVersion(long version) {
-		this.version = version;
-	}
+   public void setVersion(long version) {
+      this.version = version;
+   }
 
-	public String getName() {
-		return name;
-	}
+   public String getName() {
+      return name;
+   }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+   public void setName(String name) {
+      this.name = name;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/WithEmbeddedId.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/WithEmbeddedId.java
@@ -13,6 +13,6 @@ import jakarta.persistence.Entity;
 @Entity
 @Cacheable
 public class WithEmbeddedId {
-	@EmbeddedId
-	private PK embeddedId;
+   @EmbeddedId
+   private PK embeddedId;
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/WithSimpleId.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/functional/entities/WithSimpleId.java
@@ -13,6 +13,6 @@ import jakarta.persistence.Id;
 @Entity
 @Cacheable
 public class WithSimpleId {
-	@Id
-	private Long id;
+   @Id
+   private Long id;
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/query/QueryRegionImplTest.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/query/QueryRegionImplTest.java
@@ -44,405 +44,400 @@ import junit.framework.AssertionFailedError;
  */
 @Category(Smoke.class)
 public class QueryRegionImplTest extends AbstractGeneralDataRegionTest {
-	private static final Logger log = Logger.getLogger( QueryRegionImplTest.class );
+   private static final Logger log = Logger.getLogger(QueryRegionImplTest.class);
 
-	@Override
-	protected InfinispanBaseRegion createRegion(
-			TestRegionFactory regionFactory,
-			String regionName) {
-		return regionFactory.buildQueryResultsRegion(regionName);
-	}
+   @Override
+   protected InfinispanBaseRegion createRegion(
+         TestRegionFactory regionFactory,
+         String regionName) {
+      return regionFactory.buildQueryResultsRegion(regionName);
+   }
 
-	@Override
-	protected StandardServiceRegistryBuilder createStandardServiceRegistryBuilder() {
-		return CacheTestUtil.buildCustomQueryCacheStandardServiceRegistryBuilder( REGION_PREFIX, "replicated-query", jtaPlatform );
-	}
+   @Override
+   protected StandardServiceRegistryBuilder createStandardServiceRegistryBuilder() {
+      return CacheTestUtil.buildCustomQueryCacheStandardServiceRegistryBuilder(REGION_PREFIX, "replicated-query", jtaPlatform);
+   }
 
-	private interface RegionConsumer {
-		void accept(SessionFactory sessionFactory, InfinispanBaseRegion region) throws Exception;
-	}
+   private interface RegionConsumer {
+      void accept(SessionFactory sessionFactory, InfinispanBaseRegion region) throws Exception;
+   }
 
-	private void withQueryRegion(RegionConsumer callable) throws Exception {
-		withSessionFactoriesAndRegions(1, (sessionFactories, regions) ->  callable.accept(sessionFactories.get(0), regions.get(0)));
-	}
+   private void withQueryRegion(RegionConsumer callable) throws Exception {
+      withSessionFactoriesAndRegions(1, (sessionFactories, regions) -> callable.accept(sessionFactories.get(0), regions.get(0)));
+   }
 
-	@Test
-	public void testPutDoesNotBlockGet() throws Exception {
-		withQueryRegion((sessionFactory, region) -> {
-			withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
-			assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+   @Test
+   public void testPutDoesNotBlockGet() throws Exception {
+      withQueryRegion((sessionFactory, region) -> {
+         withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
+         assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
 
-			final CountDownLatch readerLatch = new CountDownLatch(1);
-			final CountDownLatch writerLatch = new CountDownLatch(1);
-			final CountDownLatch completionLatch = new CountDownLatch(1);
-			final ExceptionHolder holder = new ExceptionHolder();
+         final CountDownLatch readerLatch = new CountDownLatch(1);
+         final CountDownLatch writerLatch = new CountDownLatch(1);
+         final CountDownLatch completionLatch = new CountDownLatch(1);
+         final ExceptionHolder holder = new ExceptionHolder();
 
-			Thread reader = new Thread() {
-				@Override
-				public void run() {
-					try {
-						assertNotEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
-					} catch (AssertionFailedError e) {
-						holder.addAssertionFailure(e);
-					} catch (Exception e) {
-						holder.addException(e);
-					} finally {
-						readerLatch.countDown();
-					}
-				}
-			};
+         Thread reader = new Thread() {
+            @Override
+            public void run() {
+               try {
+                  assertNotEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+               } catch (AssertionFailedError e) {
+                  holder.addAssertionFailure(e);
+               } catch (Exception e) {
+                  holder.addException(e);
+               } finally {
+                  readerLatch.countDown();
+               }
+            }
+         };
 
-			Thread writer = new Thread() {
-				@Override
-				public void run() {
-					try {
-						withSession(sessionFactory, session -> {
-							TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2);
-							writerLatch.await();
-						});
-					} catch (Exception e) {
-						holder.addException(e);
-					} finally {
-						completionLatch.countDown();
-					}
-				}
-			};
+         Thread writer = new Thread() {
+            @Override
+            public void run() {
+               try {
+                  withSession(sessionFactory, session -> {
+                     TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2);
+                     writerLatch.await();
+                  });
+               } catch (Exception e) {
+                  holder.addException(e);
+               } finally {
+                  completionLatch.countDown();
+               }
+            }
+         };
 
-			reader.setDaemon(true);
-			writer.setDaemon(true);
+         reader.setDaemon(true);
+         writer.setDaemon(true);
 
-			writer.start();
-			assertFalse("Writer is blocking", completionLatch.await(100, TimeUnit.MILLISECONDS));
+         writer.start();
+         assertFalse("Writer is blocking", completionLatch.await(100, TimeUnit.MILLISECONDS));
 
-			// Start the reader
-			reader.start();
-			assertTrue("Reader finished promptly", readerLatch.await(100, TimeUnit.MILLISECONDS));
+         // Start the reader
+         reader.start();
+         assertTrue("Reader finished promptly", readerLatch.await(100, TimeUnit.MILLISECONDS));
 
-			writerLatch.countDown();
+         writerLatch.countDown();
 
-			assertTrue("Reader finished promptly", completionLatch.await(100, TimeUnit.MILLISECONDS));
+         assertTrue("Reader finished promptly", completionLatch.await(100, TimeUnit.MILLISECONDS));
 
-			assertEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
-		});
-	}
+         assertEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+      });
+   }
 
-	@Test
-	public void testGetDoesNotBlockPut() throws Exception {
-		withQueryRegion((sessionFactory, region) -> {
-			withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put( session, KEY, VALUE1 ));
-			assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get( session, KEY )));
+   @Test
+   public void testGetDoesNotBlockPut() throws Exception {
+      withQueryRegion((sessionFactory, region) -> {
+         withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
+         assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
 
-			final AdvancedCache cache = region.getCache();
-			final CountDownLatch blockerLatch = new CountDownLatch( 1 );
-			final CountDownLatch writerLatch = new CountDownLatch( 1 );
-			final CountDownLatch completionLatch = new CountDownLatch( 1 );
-			final ExceptionHolder holder = new ExceptionHolder();
+         final AdvancedCache cache = region.getCache();
+         final CountDownLatch blockerLatch = new CountDownLatch(1);
+         final CountDownLatch writerLatch = new CountDownLatch(1);
+         final CountDownLatch completionLatch = new CountDownLatch(1);
+         final ExceptionHolder holder = new ExceptionHolder();
 
-			Thread reader = new Thread() {
-				@Override
-				public void run() {
-					GetBlocker blocker = new GetBlocker(blockerLatch, KEY);
-					try {
-						cache.addListener( blocker );
-						withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY ));
-					}
-					catch (Exception e) {
-						holder.addException(e);
-					}
-					finally {
-						cache.removeListener( blocker );
-					}
-				}
-			};
+         Thread reader = new Thread() {
+            @Override
+            public void run() {
+               GetBlocker blocker = new GetBlocker(blockerLatch, KEY);
+               try {
+                  cache.addListener(blocker);
+                  withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+               } catch (Exception e) {
+                  holder.addException(e);
+               } finally {
+                  cache.removeListener(blocker);
+               }
+            }
+         };
 
-			Thread writer = new Thread() {
-				@Override
-				public void run() {
-					try {
-						writerLatch.await();
-						withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put( session, KEY, VALUE2 ));
-					}
-					catch (Exception e) {
-						holder.addException(e);
-					}
-					finally {
-						completionLatch.countDown();
-					}
-				}
-			};
+         Thread writer = new Thread() {
+            @Override
+            public void run() {
+               try {
+                  writerLatch.await();
+                  withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2));
+               } catch (Exception e) {
+                  holder.addException(e);
+               } finally {
+                  completionLatch.countDown();
+               }
+            }
+         };
 
-			reader.setDaemon( true );
-			writer.setDaemon( true );
+         reader.setDaemon(true);
+         writer.setDaemon(true);
 
-			boolean unblocked = false;
-			try {
-				reader.start();
-				writer.start();
+         boolean unblocked = false;
+         try {
+            reader.start();
+            writer.start();
 
-				assertFalse( "Reader is blocking", completionLatch.await( 100, TimeUnit.MILLISECONDS ) );
-				// Start the writer
-				writerLatch.countDown();
-				assertTrue( "Writer finished promptly", completionLatch.await( 100, TimeUnit.MILLISECONDS ) );
+            assertFalse("Reader is blocking", completionLatch.await(100, TimeUnit.MILLISECONDS));
+            // Start the writer
+            writerLatch.countDown();
+            assertTrue("Writer finished promptly", completionLatch.await(100, TimeUnit.MILLISECONDS));
 
-				blockerLatch.countDown();
-				unblocked = true;
+            blockerLatch.countDown();
+            unblocked = true;
 
-				if ( IsolationLevel.REPEATABLE_READ.equals( cache.getCacheConfiguration().locking().lockIsolationLevel() ) ) {
-					assertEquals( VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get( session, KEY )) );
-				}
-				else {
-					assertEquals( VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get( session, KEY )) );
-				}
+            if (IsolationLevel.REPEATABLE_READ.equals(cache.getCacheConfiguration().locking().lockIsolationLevel())) {
+               assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+            } else {
+               assertEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+            }
 
-				holder.checkExceptions();
-			}
-			finally {
-				if ( !unblocked ) {
-					blockerLatch.countDown();
-				}
-			}
-		});
-	}
+            holder.checkExceptions();
+         } finally {
+            if (!unblocked) {
+               blockerLatch.countDown();
+            }
+         }
+      });
+   }
 
-	protected interface SessionConsumer {
-		void accept(Object session) throws Exception;
-	}
+   protected interface SessionConsumer {
+      void accept(Object session) throws Exception;
+   }
 
-	protected interface SessionCallable<T> {
-		T call(Object session) throws Exception;
-	}
+   protected interface SessionCallable<T> {
+      T call(Object session) throws Exception;
+   }
 
-	protected <T> T callWithSession(SessionFactory sessionFactory, SessionCallable<T> callable) throws Exception {
-		Session session = sessionFactory.openSession();
-		Transaction tx = session.getTransaction();
-		tx.begin();
-		try {
-			T retval = callable.call(session);
-			tx.commit();
-			return retval;
-		} catch (Exception e) {
-			tx.rollback();
-			throw e;
-		} finally {
-			session.close();
-		}
-	}
+   protected <T> T callWithSession(SessionFactory sessionFactory, SessionCallable<T> callable) throws Exception {
+      Session session = sessionFactory.openSession();
+      Transaction tx = session.getTransaction();
+      tx.begin();
+      try {
+         T retval = callable.call(session);
+         tx.commit();
+         return retval;
+      } catch (Exception e) {
+         tx.rollback();
+         throw e;
+      } finally {
+         session.close();
+      }
+   }
 
-	protected void withSession(SessionFactory sessionFactory, SessionConsumer consumer) throws Exception {
-		callWithSession(sessionFactory, session -> { consumer.accept(session); return null;} );
-	}
+   protected void withSession(SessionFactory sessionFactory, SessionConsumer consumer) throws Exception {
+      callWithSession(sessionFactory, session -> {
+         consumer.accept(session);
+         return null;
+      });
+   }
 
-	@Test
-	@JiraKey(value = "HHH-7898")
-	public void testPutDuringPut() throws Exception {
-		withQueryRegion((sessionFactory, region) -> {
-			withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
-			assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY) ));
+   @Test
+   @JiraKey(value = "HHH-7898")
+   public void testPutDuringPut() throws Exception {
+      withQueryRegion((sessionFactory, region) -> {
+         withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
+         assertEquals(VALUE1, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
 
-			final AdvancedCache cache = region.getCache();
-			CountDownLatch blockerLatch = new CountDownLatch(1);
-			CountDownLatch triggerLatch = new CountDownLatch(1);
-			ExceptionHolder holder = new ExceptionHolder();
+         final AdvancedCache cache = region.getCache();
+         CountDownLatch blockerLatch = new CountDownLatch(1);
+         CountDownLatch triggerLatch = new CountDownLatch(1);
+         ExceptionHolder holder = new ExceptionHolder();
 
-			Thread blocking = new Thread() {
-				@Override
-				public void run() {
-					PutBlocker blocker = null;
-					try {
-						blocker = new PutBlocker(blockerLatch, triggerLatch, KEY);
-						cache.addListener(blocker);
-						withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2));
-					} catch (Exception e) {
-						holder.addException(e);
-					} finally {
-						if (blocker != null) {
-							cache.removeListener(blocker);
-						}
-						if (triggerLatch.getCount() > 0) {
-							triggerLatch.countDown();
-						}
-					}
-				}
-			};
+         Thread blocking = new Thread() {
+            @Override
+            public void run() {
+               PutBlocker blocker = null;
+               try {
+                  blocker = new PutBlocker(blockerLatch, triggerLatch, KEY);
+                  cache.addListener(blocker);
+                  withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2));
+               } catch (Exception e) {
+                  holder.addException(e);
+               } finally {
+                  if (blocker != null) {
+                     cache.removeListener(blocker);
+                  }
+                  if (triggerLatch.getCount() > 0) {
+                     triggerLatch.countDown();
+                  }
+               }
+            }
+         };
 
-			Thread blocked = new Thread() {
-				@Override
-				public void run() {
-					try {
-						triggerLatch.await();
-						// this should silently fail
-						withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE3));
-					} catch (Exception e) {
-						holder.addException(e);
-					}
-				}
-			};
+         Thread blocked = new Thread() {
+            @Override
+            public void run() {
+               try {
+                  triggerLatch.await();
+                  // this should silently fail
+                  withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE3));
+               } catch (Exception e) {
+                  holder.addException(e);
+               }
+            }
+         };
 
-			blocking.setName("blocking-thread");
-			blocking.start();
-			blocked.setName("blocked-thread");
-			blocked.start();
-			blocked.join();
-			blockerLatch.countDown();
-			blocking.join();
+         blocking.setName("blocking-thread");
+         blocking.start();
+         blocked.setName("blocked-thread");
+         blocked.start();
+         blocked.join();
+         blockerLatch.countDown();
+         blocking.join();
 
-			holder.checkExceptions();
+         holder.checkExceptions();
 
-			assertEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
-		});
-	}
+         assertEquals(VALUE2, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+      });
+   }
 
-	@Test
-	public void testQueryUpdate() throws Exception {
-		withQueryRegion((sessionFactory, region) -> {
-			ExceptionHolder holder = new ExceptionHolder();
-			CyclicBarrier barrier = new CyclicBarrier(2);
-			withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
+   @Test
+   public void testQueryUpdate() throws Exception {
+      withQueryRegion((sessionFactory, region) -> {
+         ExceptionHolder holder = new ExceptionHolder();
+         CyclicBarrier barrier = new CyclicBarrier(2);
+         withSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE1));
 
-			Thread updater = new Thread() {
-				@Override
-				public void run() {
-					try {
-						withSession(sessionFactory, (session) -> {
-							assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
-							TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2);
-							assertEquals(VALUE2, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
-							barrier.await(5, TimeUnit.SECONDS);
-							barrier.await(5, TimeUnit.SECONDS);
-							TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE3);
-							assertEquals(VALUE3, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
-							barrier.await(5, TimeUnit.SECONDS);
-							barrier.await(5, TimeUnit.SECONDS);
-						});
-					} catch (AssertionFailedError e) {
-						holder.addAssertionFailure(e);
-						barrier.reset();
-					} catch (Exception e) {
-						holder.addException(e);
-						barrier.reset();
-					}
-				}
-			};
+         Thread updater = new Thread() {
+            @Override
+            public void run() {
+               try {
+                  withSession(sessionFactory, (session) -> {
+                     assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+                     TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE2);
+                     assertEquals(VALUE2, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+                     barrier.await(5, TimeUnit.SECONDS);
+                     barrier.await(5, TimeUnit.SECONDS);
+                     TEST_SESSION_ACCESS.fromRegion(region).put(session, KEY, VALUE3);
+                     assertEquals(VALUE3, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+                     barrier.await(5, TimeUnit.SECONDS);
+                     barrier.await(5, TimeUnit.SECONDS);
+                  });
+               } catch (AssertionFailedError e) {
+                  holder.addAssertionFailure(e);
+                  barrier.reset();
+               } catch (Exception e) {
+                  holder.addException(e);
+                  barrier.reset();
+               }
+            }
+         };
 
-			Thread reader = new Thread() {
-				@Override
-				public void run() {
-					try {
-						withSession(sessionFactory, (session) -> {
-							assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
-							barrier.await(5, TimeUnit.SECONDS);
-							assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
-							barrier.await(5, TimeUnit.SECONDS);
-							barrier.await(5, TimeUnit.SECONDS);
-							assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
-							barrier.await(5, TimeUnit.SECONDS);
-						});
-					} catch (AssertionFailedError e) {
-						holder.addAssertionFailure(e);
-						barrier.reset();
-					} catch (Exception e) {
-						holder.addException(e);
-						barrier.reset();
-					}
-				}
-			};
+         Thread reader = new Thread() {
+            @Override
+            public void run() {
+               try {
+                  withSession(sessionFactory, (session) -> {
+                     assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+                     barrier.await(5, TimeUnit.SECONDS);
+                     assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+                     barrier.await(5, TimeUnit.SECONDS);
+                     barrier.await(5, TimeUnit.SECONDS);
+                     assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY));
+                     barrier.await(5, TimeUnit.SECONDS);
+                  });
+               } catch (AssertionFailedError e) {
+                  holder.addAssertionFailure(e);
+                  barrier.reset();
+               } catch (Exception e) {
+                  holder.addException(e);
+                  barrier.reset();
+               }
+            }
+         };
 
-			updater.start();
-			reader.start();
-			updater.join();
-			reader.join();
-			holder.checkExceptions();
+         updater.start();
+         reader.start();
+         updater.join();
+         reader.join();
+         holder.checkExceptions();
 
-			assertEquals(VALUE3, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
-		});
-	}
+         assertEquals(VALUE3, callWithSession(sessionFactory, session -> TEST_SESSION_ACCESS.fromRegion(region).get(session, KEY)));
+      });
+   }
 
-	@Test
-	@JiraKey(value = "HHH-10163")
-	public void testEvictAll() throws Exception {
-		withQueryRegion((sessionFactory, region) -> {
-			withSession(sessionFactory, s -> TEST_SESSION_ACCESS.fromRegion(region).put(s, KEY, VALUE1));
-			withSession(sessionFactory, s -> assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(s, KEY)));
-			TEST_SESSION_ACCESS.fromRegion(region).evictAll();
-			withSession(sessionFactory, s -> assertNull(TEST_SESSION_ACCESS.fromRegion(region).get(s, KEY)));
-			assertTrue(region.getCache().isEmpty());
-		});
-	}
+   @Test
+   @JiraKey(value = "HHH-10163")
+   public void testEvictAll() throws Exception {
+      withQueryRegion((sessionFactory, region) -> {
+         withSession(sessionFactory, s -> TEST_SESSION_ACCESS.fromRegion(region).put(s, KEY, VALUE1));
+         withSession(sessionFactory, s -> assertEquals(VALUE1, TEST_SESSION_ACCESS.fromRegion(region).get(s, KEY)));
+         TEST_SESSION_ACCESS.fromRegion(region).evictAll();
+         withSession(sessionFactory, s -> assertNull(TEST_SESSION_ACCESS.fromRegion(region).get(s, KEY)));
+         assertTrue(region.getCache().isEmpty());
+      });
+   }
 
-	@Listener
-	public static class GetBlocker {
-		private final CountDownLatch latch;
-		private final Object key;
+   @Listener
+   public static class GetBlocker {
+      private final CountDownLatch latch;
+      private final Object key;
 
-		GetBlocker(CountDownLatch latch,	Object key) {
-			this.latch = latch;
-			this.key = key;
-		}
+      GetBlocker(CountDownLatch latch, Object key) {
+         this.latch = latch;
+         this.key = key;
+      }
 
-		@CacheEntryVisited
-		public void nodeVisisted(CacheEntryVisitedEvent event) {
-			if ( event.isPre() && event.getKey().equals( key ) ) {
-				try {
-					latch.await();
-				}
-				catch (InterruptedException e) {
-					log.error( "Interrupted waiting for latch", e );
-				}
-			}
-		}
-	}
+      @CacheEntryVisited
+      public void nodeVisisted(CacheEntryVisitedEvent event) {
+         if (event.isPre() && event.getKey().equals(key)) {
+            try {
+               latch.await();
+            } catch (InterruptedException e) {
+               log.error("Interrupted waiting for latch", e);
+            }
+         }
+      }
+   }
 
-	@Listener
-	public static class PutBlocker {
-		private final CountDownLatch blockLatch, triggerLatch;
-		private final Object key;
-		private boolean enabled = true;
+   @Listener
+   public static class PutBlocker {
+      private final CountDownLatch blockLatch, triggerLatch;
+      private final Object key;
+      private boolean enabled = true;
 
-		PutBlocker(CountDownLatch blockLatch, CountDownLatch triggerLatch, Object key) {
-			this.blockLatch = blockLatch;
-			this.triggerLatch = triggerLatch;
-			this.key = key;
-		}
+      PutBlocker(CountDownLatch blockLatch, CountDownLatch triggerLatch, Object key) {
+         this.blockLatch = blockLatch;
+         this.triggerLatch = triggerLatch;
+         this.key = key;
+      }
 
-		@CacheEntryModified
-		public void nodeVisisted(CacheEntryModifiedEvent event) {
-			// we need isPre since lock is acquired in the commit phase
-			if ( !event.isPre() && event.getKey().equals( key ) ) {
-				try {
-					synchronized (this) {
-						if (enabled) {
-							triggerLatch.countDown();
-							enabled = false;
-							blockLatch.await();
-						}
-					}
-				}
-				catch (InterruptedException e) {
-					log.error( "Interrupted waiting for latch", e );
-				}
-			}
-		}
-	}
+      @CacheEntryModified
+      public void nodeVisisted(CacheEntryModifiedEvent event) {
+         // we need isPre since lock is acquired in the commit phase
+         if (!event.isPre() && event.getKey().equals(key)) {
+            try {
+               synchronized (this) {
+                  if (enabled) {
+                     triggerLatch.countDown();
+                     enabled = false;
+                     blockLatch.await();
+                  }
+               }
+            } catch (InterruptedException e) {
+               log.error("Interrupted waiting for latch", e);
+            }
+         }
+      }
+   }
 
-	private static class ExceptionHolder {
-		private final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
-		private final List<AssertionFailedError> assertionFailures = Collections.synchronizedList(new ArrayList<>());
+   private static class ExceptionHolder {
+      private final List<Exception> exceptions = Collections.synchronizedList(new ArrayList<>());
+      private final List<AssertionFailedError> assertionFailures = Collections.synchronizedList(new ArrayList<>());
 
-		public void addException(Exception e) {
-			exceptions.add(e);
-		}
+      public void addException(Exception e) {
+         exceptions.add(e);
+      }
 
-		public void addAssertionFailure(AssertionFailedError e) {
-			assertionFailures.add(e);
-		}
+      public void addAssertionFailure(AssertionFailedError e) {
+         assertionFailures.add(e);
+      }
 
-		public void checkExceptions() throws Exception {
-			for (AssertionFailedError a : assertionFailures) {
-				throw a;
-			}
-			for (Exception e : exceptions) {
-				throw e;
-			}
-		}
-	}
+      public void checkExceptions() throws Exception {
+         for (AssertionFailedError a : assertionFailures) {
+            throw a;
+         }
+         for (Exception e : exceptions) {
+            throw e;
+         }
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/CorrectnessTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/CorrectnessTestCase.java
@@ -1,4 +1,3 @@
-
 package org.infinispan.test.hibernate.cache.commons.stress;
 
 import java.io.BufferedWriter;
@@ -112,7 +111,7 @@ import jakarta.transaction.TransactionManager;
 
 /**
  * Tries to execute random operations for {@link #EXECUTION_TIME} and then verify the log for correctness.
- *
+ * <p>
  * Assumes serializable consistency.
  *
  * @author Radim Vansa
@@ -167,26 +166,26 @@ public abstract class CorrectnessTestCase {
    }
 
    public static class Jta extends CorrectnessTestCase {
-      private final TransactionManager transactionManager  = TestingJtaPlatformImpl.transactionManager();
+      private final TransactionManager transactionManager = TestingJtaPlatformImpl.transactionManager();
 
       @Parameterized.Parameters(name = "{0}")
       public List<Object[]> getParameters() {
          return Arrays.<Object[]>asList(
-               new Object[] { "transactional, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.TRANSACTIONAL },
-               new Object[] { "read-only, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.READ_ONLY }, // maybe not needed
-               new Object[] { "read-write, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE },
-               new Object[] { "read-write, replicated", CacheMode.REPL_SYNC, AccessType.READ_WRITE },
-               new Object[] { "read-write, distributed", CacheMode.DIST_SYNC, AccessType.READ_WRITE },
-               new Object[] { "non-strict, replicated", CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE }
+               new Object[]{"transactional, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.TRANSACTIONAL},
+               new Object[]{"read-only, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.READ_ONLY}, // maybe not needed
+               new Object[]{"read-write, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE},
+               new Object[]{"read-write, replicated", CacheMode.REPL_SYNC, AccessType.READ_WRITE},
+               new Object[]{"read-write, distributed", CacheMode.DIST_SYNC, AccessType.READ_WRITE},
+               new Object[]{"non-strict, replicated", CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE}
          );
       }
 
       @Override
       protected void applySettings(StandardServiceRegistryBuilder ssrb) {
          super.applySettings(ssrb);
-         ssrb.applySetting( Environment.JTA_PLATFORM, TestingJtaPlatformImpl.class.getName() );
-         ssrb.applySetting( Environment.CONNECTION_PROVIDER, JtaAwareConnectionProviderImpl.class.getName() );
-         ssrb.applySetting( Environment.TRANSACTION_COORDINATOR_STRATEGY, JtaTransactionCoordinatorBuilderImpl.class.getName() );
+         ssrb.applySetting(Environment.JTA_PLATFORM, TestingJtaPlatformImpl.class.getName());
+         ssrb.applySetting(Environment.CONNECTION_PROVIDER, JtaAwareConnectionProviderImpl.class.getName());
+         ssrb.applySetting(Environment.TRANSACTION_COORDINATOR_STRATEGY, JtaTransactionCoordinatorBuilderImpl.class.getName());
       }
 
       @Override
@@ -210,10 +209,10 @@ public abstract class CorrectnessTestCase {
       @Parameterized.Parameters(name = "{0}")
       public List<Object[]> getParameters() {
          return Arrays.<Object[]>asList(
-               new Object[] { "read-write, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE },
-               new Object[] { "read-write, replicated", CacheMode.REPL_SYNC, AccessType.READ_WRITE },
-               new Object[] { "read-write, distributed", CacheMode.DIST_SYNC, AccessType.READ_WRITE },
-               new Object[] { "non-strict, replicated", CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE }
+               new Object[]{"read-write, invalidation", CacheMode.INVALIDATION_SYNC, AccessType.READ_WRITE},
+               new Object[]{"read-write, replicated", CacheMode.REPL_SYNC, AccessType.READ_WRITE},
+               new Object[]{"read-write, distributed", CacheMode.DIST_SYNC, AccessType.READ_WRITE},
+               new Object[]{"non-strict, replicated", CacheMode.REPL_SYNC, AccessType.NONSTRICT_READ_WRITE}
          );
       }
 
@@ -229,31 +228,31 @@ public abstract class CorrectnessTestCase {
    public void beforeClass() {
       TestResourceTracker.testStarted(getClass().getSimpleName());
       Arrays.asList(new File(System.getProperty("java.io.tmpdir"))
-            .listFiles((dir, name) -> name.startsWith("family_") || name.startsWith("invalidations-")))
+                  .listFiles((dir, name) -> name.startsWith("family_") || name.startsWith("invalidations-")))
             .stream().forEach(f -> f.delete());
       StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder().enableAutoClose()
-              .applySetting( Environment.USE_SECOND_LEVEL_CACHE, "true" )
-              .applySetting( Environment.USE_QUERY_CACHE, "true" )
-              .applySetting( Environment.DRIVER, "org.h2.Driver" )
-              .applySetting( Environment.URL, "jdbc:h2:mem:" + getDbName() + ";TRACE_LEVEL_FILE=4")
-              .applySetting( Environment.DIALECT, H2Dialect.class.getName() )
-              .applySetting( Environment.HBM2DDL_AUTO, "create-drop" )
-              .applySetting( TestRegionFactory.CONFIGURATION_HOOK, InjectFailures.class)
-              .applySetting( TestRegionFactory.CACHE_MODE, cacheMode )
-              .applySetting( Environment.USE_MINIMAL_PUTS, "false" )
-              .applySetting( Environment.GENERATE_STATISTICS, "false" );
+            .applySetting(Environment.USE_SECOND_LEVEL_CACHE, "true")
+            .applySetting(Environment.USE_QUERY_CACHE, "true")
+            .applySetting(Environment.DRIVER, "org.h2.Driver")
+            .applySetting(Environment.URL, "jdbc:h2:mem:" + getDbName() + ";TRACE_LEVEL_FILE=4")
+            .applySetting(Environment.DIALECT, H2Dialect.class.getName())
+            .applySetting(Environment.HBM2DDL_AUTO, "create-drop")
+            .applySetting(TestRegionFactory.CONFIGURATION_HOOK, InjectFailures.class)
+            .applySetting(TestRegionFactory.CACHE_MODE, cacheMode)
+            .applySetting(Environment.USE_MINIMAL_PUTS, "false")
+            .applySetting(Environment.GENERATE_STATISTICS, "false");
       applySettings(ssrb);
 
       sessionFactories = new SessionFactory[NUM_NODES];
       for (int i = 0; i < NUM_NODES; ++i) {
          StandardServiceRegistry registry = ssrb.build();
-         Metadata metadata = buildMetadata( registry );
+         Metadata metadata = buildMetadata(registry);
          sessionFactories[i] = metadata.buildSessionFactory();
       }
    }
 
    protected void applySettings(StandardServiceRegistryBuilder ssrb) {
-      ssrb.applySetting( Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, accessType.getExternalName());
+      ssrb.applySetting(Environment.DEFAULT_CACHE_CONCURRENCY_STRATEGY, accessType.getExternalName());
       ssrb.applySetting(TestRegionFactory.TRANSACTIONAL, TestRegionFactoryProvider.load().supportTransactionalCaches() && accessType == AccessType.TRANSACTIONAL);
    }
 
@@ -266,28 +265,28 @@ public abstract class CorrectnessTestCase {
    }
 
    public static Class[] getAnnotatedClasses() {
-      return new Class[] {Family.class, Person.class, Address.class};
+      return new Class[]{Family.class, Person.class, Address.class};
    }
 
    private Metadata buildMetadata(StandardServiceRegistry registry) {
-      MetadataSources metadataSources = new MetadataSources( registry );
-      for ( Class entityClass : getAnnotatedClasses() ) {
-         metadataSources.addAnnotatedClass( entityClass );
+      MetadataSources metadataSources = new MetadataSources(registry);
+      for (Class entityClass : getAnnotatedClasses()) {
+         metadataSources.addAnnotatedClass(entityClass);
       }
 
       Metadata metadata = metadataSources.buildMetadata();
 
-      for ( PersistentClass entityBinding : metadata.getEntityBindings() ) {
+      for (PersistentClass entityBinding : metadata.getEntityBindings()) {
          if (!entityBinding.isInherited()) {
-            ( (RootClass) entityBinding ).setCacheConcurrencyStrategy( accessType.getExternalName() );
+            ((RootClass) entityBinding).setCacheConcurrencyStrategy(accessType.getExternalName());
          }
       }
 
       // Collections don't have integrated version, these piggyback on parent's owner version (for DB).
       // However, this version number isn't extractable and is not passed to cache methods.
       AccessType collectionAccessType = accessType == AccessType.NONSTRICT_READ_WRITE ? AccessType.READ_WRITE : accessType;
-      for ( Collection collectionBinding : metadata.getCollectionBindings() ) {
-         collectionBinding.setCacheConcurrencyStrategy( collectionAccessType.getExternalName() );
+      for (Collection collectionBinding : metadata.getCollectionBindings()) {
+         collectionBinding.setCacheConcurrencyStrategy(collectionAccessType.getExternalName());
       }
 
       return metadata;
@@ -367,7 +366,7 @@ public abstract class CorrectnessTestCase {
          for (int i = 0; i < NUM_THREADS_PER_NODE; ++i) {
             final int I = i;
             futures.add(exec.submit(() -> {
-               Thread.currentThread().setName("Node" + (char)('A' + NODE) + "-thread-" + I);
+               Thread.currentThread().setName("Node" + (char) ('A' + NODE) + "-thread-" + I);
                threadNode.set(NODE);
                while (running) {
                   Operation operation;
@@ -496,7 +495,8 @@ public abstract class CorrectnessTestCase {
       // poll until all invalidations come
       long deadline = System.currentTimeMillis() + 30000;
       while (System.currentTimeMillis() < deadline) {
-         iterateInvalidators(delayed, getInvalidators, (k, i) -> {});
+         iterateInvalidators(delayed, getInvalidators, (k, i) -> {
+         });
          if (delayed.isEmpty()) {
             break;
          }
@@ -514,8 +514,7 @@ public abstract class CorrectnessTestCase {
          Object pendingPutMap = entry.getPendingPutMap();
          if (pendingPutMap == null) {
             iterator.remove();
-         }
-         else {
+         } else {
             java.util.Collection invalidators = (java.util.Collection) getInvalidators.invoke(pendingPutMap);
             if (invalidators == null || invalidators.isEmpty()) {
                iterator.remove();
@@ -614,7 +613,7 @@ public abstract class CorrectnessTestCase {
 
    private <T> void dumpLogs(String prefix, List<Log<T>> logs) {
       try {
-         File f = File.createTempFile(prefix,  ".log");
+         File f = File.createTempFile(prefix, ".log");
          log.info("Dumping logs into " + f.getAbsolutePath());
          try (BufferedWriter writer = Files.newBufferedWriter(f.toPath())) {
             for (Log<T> log : logs) {
@@ -820,10 +819,10 @@ public abstract class CorrectnessTestCase {
       @Override
       public void run() throws Exception {
          withRandomFamily((s, f) -> {
-               if (evict) {
-                  sessionFactory(threadNode.get()).getCache().evictEntityData(Family.class, f.getId());
-               }
-            }, Ref.empty(), Ref.empty(), null);
+            if (evict) {
+               sessionFactory(threadNode.get()).getCache().evictEntityData(Family.class, f.getId());
+            }
+         }, Ref.empty(), Ref.empty(), null);
       }
    }
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/PutFromLoadStressTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/PutFromLoadStressTestCase.java
@@ -60,37 +60,37 @@ public class PutFromLoadStressTestCase {
    public static void beforeClass() {
       // Extra options located in src/test/resources/hibernate.properties
       StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder()
-              .applySetting( Environment.USE_SECOND_LEVEL_CACHE, "true" )
-              .applySetting( Environment.USE_QUERY_CACHE, "true" )
-              // TODO: Tweak to have a fully local region factory (no transport, cache mode = local, no marshalling, ...etc)
-              .applySetting(
-                      Environment.CACHE_REGION_FACTORY,
-                      "org.infinispan.hibernate.cache.InfinispanRegionFactory"
-              )
-              .applySetting(
-                      Environment.JTA_PLATFORM,
-                      new NarayanaStandaloneJtaPlatform()
-              )
-              // Force minimal puts off to simplify stressing putFromLoad logic
-              .applySetting( Environment.USE_MINIMAL_PUTS, "false" )
-              .applySetting( Environment.HBM2DDL_AUTO, "create-drop" );
+            .applySetting(Environment.USE_SECOND_LEVEL_CACHE, "true")
+            .applySetting(Environment.USE_QUERY_CACHE, "true")
+            // TODO: Tweak to have a fully local region factory (no transport, cache mode = local, no marshalling, ...etc)
+            .applySetting(
+                  Environment.CACHE_REGION_FACTORY,
+                  "org.infinispan.hibernate.cache.InfinispanRegionFactory"
+            )
+            .applySetting(
+                  Environment.JTA_PLATFORM,
+                  new NarayanaStandaloneJtaPlatform()
+            )
+            // Force minimal puts off to simplify stressing putFromLoad logic
+            .applySetting(Environment.USE_MINIMAL_PUTS, "false")
+            .applySetting(Environment.HBM2DDL_AUTO, "create-drop");
 
       StandardServiceRegistry serviceRegistry = ssrb.build();
 
-      MetadataSources metadataSources = new MetadataSources( serviceRegistry )
-              .addResource( "cache/infinispan/functional/Item.hbm.xml" )
-              .addResource( "cache/infinispan/functional/Customer.hbm.xml" )
-              .addResource( "cache/infinispan/functional/Contact.hbm.xml" )
-              .addAnnotatedClass( Age.class );
+      MetadataSources metadataSources = new MetadataSources(serviceRegistry)
+            .addResource("cache/infinispan/functional/Item.hbm.xml")
+            .addResource("cache/infinispan/functional/Customer.hbm.xml")
+            .addResource("cache/infinispan/functional/Contact.hbm.xml")
+            .addAnnotatedClass(Age.class);
 
       Metadata metadata = metadataSources.buildMetadata();
-      for ( PersistentClass entityBinding : metadata.getEntityBindings() ) {
-         if ( entityBinding instanceof RootClass ) {
-            ( (RootClass) entityBinding ).setCacheConcurrencyStrategy( "transactional" );
+      for (PersistentClass entityBinding : metadata.getEntityBindings()) {
+         if (entityBinding instanceof RootClass) {
+            ((RootClass) entityBinding).setCacheConcurrencyStrategy("transactional");
          }
       }
-      for ( Collection collectionBinding : metadata.getCollectionBindings() ) {
-         collectionBinding.setCacheConcurrencyStrategy( "transactional" );
+      for (Collection collectionBinding : metadata.getCollectionBindings()) {
+         collectionBinding.setCacheConcurrencyStrategy("transactional");
       }
 
       sessionFactory = metadata.buildSessionFactory();

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/SecondLevelCacheStressTestCase.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/SecondLevelCacheStressTestCase.java
@@ -1,4 +1,3 @@
-
 package org.infinispan.test.hibernate.cache.commons.stress;
 
 import static org.infinispan.test.hibernate.cache.commons.util.TestingUtil.withTx;
@@ -49,7 +48,7 @@ import jakarta.transaction.TransactionManager;
 
 /**
  * Stress test for second level cache.
- *
+ * <p>
  * TODO Various:
  * - Switch to a JDBC connection pool to avoid too many connections created
  * (as well as consuming memory, it's expensive to create)
@@ -85,21 +84,21 @@ public class SecondLevelCacheStressTestCase {
       removeIds = new ConcurrentLinkedQueue<Integer>();
 
       StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder().enableAutoClose()
-              .applySetting( Environment.USE_SECOND_LEVEL_CACHE, "true" )
-              .applySetting( Environment.USE_QUERY_CACHE, "true" )
-              .applySetting( Environment.DRIVER, "com.mysql.jdbc.Driver" )
-              .applySetting( Environment.URL, "jdbc:mysql://localhost:3306/hibernate" )
-              .applySetting( Environment.DIALECT, "org.hibernate.dialect.MySQL5InnoDBDialect" )
-              .applySetting( Environment.USER, "root" )
-              .applySetting( Environment.PASS, "password" )
-              .applySetting( Environment.HBM2DDL_AUTO, "create-drop" );
+            .applySetting(Environment.USE_SECOND_LEVEL_CACHE, "true")
+            .applySetting(Environment.USE_QUERY_CACHE, "true")
+            .applySetting(Environment.DRIVER, "com.mysql.jdbc.Driver")
+            .applySetting(Environment.URL, "jdbc:mysql://localhost:3306/hibernate")
+            .applySetting(Environment.DIALECT, "org.hibernate.dialect.MySQL5InnoDBDialect")
+            .applySetting(Environment.USER, "root")
+            .applySetting(Environment.PASS, "password")
+            .applySetting(Environment.HBM2DDL_AUTO, "create-drop");
 
       // Create database schema in each run
-      applyCacheSettings( ssrb );
+      applyCacheSettings(ssrb);
 
       StandardServiceRegistry registry = ssrb.build();
 
-      Metadata metadata = buildMetadata( registry );
+      Metadata metadata = buildMetadata(registry);
 
       sessionFactory = metadata.buildSessionFactory();
 
@@ -111,9 +110,9 @@ public class SecondLevelCacheStressTestCase {
    }
 
    protected void applyCacheSettings(StandardServiceRegistryBuilder ssrb) {
-      ssrb.applySetting( Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName() );
-      ssrb.applySetting( Environment.JTA_PLATFORM, new NarayanaStandaloneJtaPlatform() );
-      ssrb.applySetting( InfinispanProperties.INFINISPAN_CONFIG_RESOURCE_PROP, "stress-local-infinispan.xml" );
+      ssrb.applySetting(Environment.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass().getName());
+      ssrb.applySetting(Environment.JTA_PLATFORM, new NarayanaStandaloneJtaPlatform());
+      ssrb.applySetting(InfinispanProperties.INFINISPAN_CONFIG_RESOURCE_PROP, "stress-local-infinispan.xml");
    }
 
    @After
@@ -209,7 +208,7 @@ public class SecondLevelCacheStressTestCase {
    }
 
    TotalStats runEntityFindUpdated(long runningTimeout,
-         List<Integer> updatedIdsSeq) {
+                                   List<Integer> updatedIdsSeq) {
       return runSingleWork(runningTimeout, "find-updated", findUpdatedOperation(updatedIdsSeq));
    }
 
@@ -230,13 +229,14 @@ public class SecondLevelCacheStressTestCase {
 
       ExecutorService exec = Executors.newFixedThreadPool(
             NUM_THREADS, new ThreadFactory() {
-         volatile int i = 0;
-         @Override
-         public Thread newThread(Runnable r) {
-            return new Thread(new ThreadGroup(name),
-                  r, "worker-" + name + "-" + i++);
-         }
-      });
+               volatile int i = 0;
+
+               @Override
+               public Thread newThread(Runnable r) {
+                  return new Thread(new ThreadGroup(name),
+                        r, "worker-" + name + "-" + i++);
+               }
+            });
 
       try {
          List<Future<Void>> futures = new ArrayList<Future<Void>>(NUM_THREADS);
@@ -396,7 +396,7 @@ public class SecondLevelCacheStressTestCase {
                   Family family = (Family) s.getReference(Family.class, id);
                   String familyName = family.getName();
                   // Skip ñ check in order to avoid issues...
-                  assertTrue("Unexpected family: " + familyName ,
+                  assertTrue("Unexpected family: " + familyName,
                         familyName.startsWith("Zamarre"));
 
                   s.close();
@@ -425,7 +425,7 @@ public class SecondLevelCacheStressTestCase {
                         Family family = (Family) s.getReference(Family.class, id);
                         String familyName = family.getName();
                         // Skip ñ check in order to avoid issues...
-                        assertTrue("Unexpected family: " + familyName ,
+                        assertTrue("Unexpected family: " + familyName,
                               familyName.startsWith("Zamarre"));
                         s.remove(family);
 
@@ -442,27 +442,27 @@ public class SecondLevelCacheStressTestCase {
    }
 
    public static Class[] getAnnotatedClasses() {
-      return new Class[] {Family.class, Person.class, Address.class};
+      return new Class[]{Family.class, Person.class, Address.class};
    }
 
    private static Metadata buildMetadata(StandardServiceRegistry registry) {
       final String cacheStrategy = "transactional";
 
-      MetadataSources metadataSources = new MetadataSources( registry );
-      for ( Class entityClass : getAnnotatedClasses() ) {
-         metadataSources.addAnnotatedClass( entityClass );
+      MetadataSources metadataSources = new MetadataSources(registry);
+      for (Class entityClass : getAnnotatedClasses()) {
+         metadataSources.addAnnotatedClass(entityClass);
       }
 
       Metadata metadata = metadataSources.buildMetadata();
 
-      for ( PersistentClass entityBinding : metadata.getEntityBindings() ) {
+      for (PersistentClass entityBinding : metadata.getEntityBindings()) {
          if (!entityBinding.isInherited()) {
-            ( (RootClass) entityBinding ).setCacheConcurrencyStrategy( cacheStrategy);
+            ((RootClass) entityBinding).setCacheConcurrencyStrategy(cacheStrategy);
          }
       }
 
-      for ( Collection collectionBinding : metadata.getCollectionBindings() ) {
-         collectionBinding.setCacheConcurrencyStrategy( cacheStrategy );
+      for (Collection collectionBinding : metadata.getCollectionBindings()) {
+         collectionBinding.setCacheConcurrencyStrategy(cacheStrategy);
       }
 
       return metadata;
@@ -487,7 +487,7 @@ public class SecondLevelCacheStressTestCase {
       private final CyclicBarrier barrier;
 
       public WorkerThread(long runningTimeout, TotalStats perf,
-            Operation op, CyclicBarrier barrier) {
+                          Operation op, CyclicBarrier barrier) {
          this.runningTimeout = runningTimeout;
          this.perf = perf;
          this.op = op;
@@ -532,7 +532,7 @@ public class SecondLevelCacheStressTestCase {
             new ConcurrentHashMap<String, OpStats>();
 
       public void addStats(String opName, long opCount,
-            long runningTime, long missCount) {
+                           long runningTime, long missCount) {
          OpStats s = new OpStats(opName, opCount, runningTime, missCount);
          OpStats old = statsMap.putIfAbsent(opName, s);
          boolean replaced = old == null;
@@ -588,7 +588,7 @@ public class SecondLevelCacheStressTestCase {
       public final long missCount;
 
       private OpStats(String opName, long opCount,
-            long runningTime, long missCount) {
+                      long runningTime, long missCount) {
          this.opName = opName;
          this.threadCount = 1;
          this.opCount = opCount;
@@ -597,7 +597,7 @@ public class SecondLevelCacheStressTestCase {
       }
 
       private OpStats(OpStats base, long opCount,
-            long runningTime, long missCount) {
+                      long runningTime, long missCount) {
          this.opName = base.opName;
          this.threadCount = base.threadCount + 1;
          this.opCount = base.opCount + opCount;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/entities/Address.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/entities/Address.java
@@ -1,4 +1,3 @@
-
 package org.infinispan.test.hibernate.cache.commons.stress.entities;
 
 import java.util.HashSet;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/entities/Family.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/entities/Family.java
@@ -1,4 +1,3 @@
-
 package org.infinispan.test.hibernate.cache.commons.stress.entities;
 
 import java.util.HashSet;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/entities/Person.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/stress/entities/Person.java
@@ -1,4 +1,3 @@
-
 package org.infinispan.test.hibernate.cache.commons.stress.entities;
 
 import java.util.Date;

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/JtaPlatformImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/JtaPlatformImpl.java
@@ -14,38 +14,37 @@ import jakarta.transaction.UserTransaction;
  * @author Steve Ebersole
  */
 public class JtaPlatformImpl implements JtaPlatform {
-	@Override
-	public TransactionManager retrieveTransactionManager(){
-		return XaTransactionManagerImpl.getInstance();
-	}
+   @Override
+   public TransactionManager retrieveTransactionManager() {
+      return XaTransactionManagerImpl.getInstance();
+   }
 
-	@Override
-	public UserTransaction retrieveUserTransaction() {
-		throw new TransactionException( "UserTransaction not used in these tests" );
-	}
+   @Override
+   public UserTransaction retrieveUserTransaction() {
+      throw new TransactionException("UserTransaction not used in these tests");
+   }
 
-	@Override
-	public Object getTransactionIdentifier(Transaction transaction) {
-		return transaction;
-	}
+   @Override
+   public Object getTransactionIdentifier(Transaction transaction) {
+      return transaction;
+   }
 
-	@Override
-	public boolean canRegisterSynchronization() {
-		return JtaStatusHelper.isActive( XaTransactionManagerImpl.getInstance() );
-	}
+   @Override
+   public boolean canRegisterSynchronization() {
+      return JtaStatusHelper.isActive(XaTransactionManagerImpl.getInstance());
+   }
 
-	@Override
-	public void registerSynchronization(Synchronization synchronization) {
-		try {
-			XaTransactionManagerImpl.getInstance().getTransaction().registerSynchronization( synchronization );
-		}
-		catch (Exception e) {
-			throw new TransactionException( "Could not obtain transaction from TM" );
-		}
-	}
+   @Override
+   public void registerSynchronization(Synchronization synchronization) {
+      try {
+         XaTransactionManagerImpl.getInstance().getTransaction().registerSynchronization(synchronization);
+      } catch (Exception e) {
+         throw new TransactionException("Could not obtain transaction from TM");
+      }
+   }
 
-	@Override
-	public int getCurrentStatus() throws SystemException {
-		return JtaStatusHelper.getStatus( XaTransactionManagerImpl.getInstance() );
-	}
+   @Override
+   public int getCurrentStatus() throws SystemException {
+      return JtaStatusHelper.getStatus(XaTransactionManagerImpl.getInstance());
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/XaConnectionProvider.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/XaConnectionProvider.java
@@ -17,77 +17,74 @@ import org.infinispan.test.hibernate.cache.commons.util.TestingUtil;
  * @since 3.5
  */
 public class XaConnectionProvider implements ConnectionProvider, Stoppable {
-	private final ConnectionProvider actualConnectionProvider;
-	private boolean isTransactional;
+   private final ConnectionProvider actualConnectionProvider;
+   private boolean isTransactional;
 
-	public XaConnectionProvider() {
-		this(TestingUtil.buildConnectionProvider());
-	}
+   public XaConnectionProvider() {
+      this(TestingUtil.buildConnectionProvider());
+   }
 
-	public XaConnectionProvider(ConnectionProvider connectionProvider) {
-		this.actualConnectionProvider = connectionProvider;
-	}
+   public XaConnectionProvider(ConnectionProvider connectionProvider) {
+      this.actualConnectionProvider = connectionProvider;
+   }
 
-	public ConnectionProvider getActualConnectionProvider() {
-		return actualConnectionProvider;
-	}
+   public ConnectionProvider getActualConnectionProvider() {
+      return actualConnectionProvider;
+   }
 
-	@Override
-	public boolean isUnwrappableAs(Class unwrapType) {
-		return XaConnectionProvider.class.isAssignableFrom( unwrapType ) ||
+   @Override
+   public boolean isUnwrappableAs(Class unwrapType) {
+      return XaConnectionProvider.class.isAssignableFrom(unwrapType) ||
             ConnectionProvider.class == unwrapType ||
-				actualConnectionProvider.getClass().isAssignableFrom( unwrapType );
-	}
+            actualConnectionProvider.getClass().isAssignableFrom(unwrapType);
+   }
 
-	@Override
-	@SuppressWarnings( {"unchecked"})
-	public <T> T unwrap(Class<T> unwrapType) {
-		if ( XaConnectionProvider.class.isAssignableFrom( unwrapType ) ) {
-			return (T) this;
-		}
-		else if ( ConnectionProvider.class.isAssignableFrom( unwrapType ) ||
-				actualConnectionProvider.getClass().isAssignableFrom( unwrapType ) ) {
-			return (T) getActualConnectionProvider();
-		}
-		else {
-			throw new UnknownUnwrapTypeException( unwrapType );
-		}
-	}
+   @Override
+   @SuppressWarnings({"unchecked"})
+   public <T> T unwrap(Class<T> unwrapType) {
+      if (XaConnectionProvider.class.isAssignableFrom(unwrapType)) {
+         return (T) this;
+      } else if (ConnectionProvider.class.isAssignableFrom(unwrapType) ||
+            actualConnectionProvider.getClass().isAssignableFrom(unwrapType)) {
+         return (T) getActualConnectionProvider();
+      } else {
+         throw new UnknownUnwrapTypeException(unwrapType);
+      }
+   }
 
-	public void configure(Properties props) throws HibernateException {
-	}
+   public void configure(Properties props) throws HibernateException {
+   }
 
-	public Connection getConnection() throws SQLException {
-		XaTransactionImpl currentTransaction = XaTransactionManagerImpl.getInstance().getCurrentTransaction();
-		if ( currentTransaction == null ) {
-			isTransactional = false;
-			return actualConnectionProvider.getConnection();
-		}
-		else {
-			isTransactional = true;
-			Connection connection = currentTransaction.getEnlistedConnection();
-			if ( connection == null ) {
-				connection = actualConnectionProvider.getConnection();
-				currentTransaction.enlistConnection( connection, actualConnectionProvider );
-			}
-			return connection;
-		}
-	}
+   public Connection getConnection() throws SQLException {
+      XaTransactionImpl currentTransaction = XaTransactionManagerImpl.getInstance().getCurrentTransaction();
+      if (currentTransaction == null) {
+         isTransactional = false;
+         return actualConnectionProvider.getConnection();
+      } else {
+         isTransactional = true;
+         Connection connection = currentTransaction.getEnlistedConnection();
+         if (connection == null) {
+            connection = actualConnectionProvider.getConnection();
+            currentTransaction.enlistConnection(connection, actualConnectionProvider);
+         }
+         return connection;
+      }
+   }
 
-	public void closeConnection(Connection conn) throws SQLException {
-		if ( !isTransactional ) {
-			actualConnectionProvider.closeConnection(conn);
-		}
-	}
+   public void closeConnection(Connection conn) throws SQLException {
+      if (!isTransactional) {
+         actualConnectionProvider.closeConnection(conn);
+      }
+   }
 
-	@Override
-	public void stop() {
-		if ( actualConnectionProvider instanceof Stoppable ) {
-			((Stoppable) actualConnectionProvider).stop();
-		}
-	}
+   @Override
+   public void stop() {
+      if (actualConnectionProvider instanceof Stoppable) {
+         ((Stoppable) actualConnectionProvider).stop();
+      }
+   }
 
-	public boolean supportsAggressiveRelease() {
-		return actualConnectionProvider.supportsAggressiveRelease();
-	}
+   public boolean supportsAggressiveRelease() {
+      return actualConnectionProvider.supportsAggressiveRelease();
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/XaTransactionImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/XaTransactionImpl.java
@@ -56,7 +56,7 @@ public class XaTransactionImpl implements Transaction {
    }
 
    public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException,
-            IllegalStateException, SystemException {
+         IllegalStateException, SystemException {
 
       if (status == Status.STATUS_MARKED_ROLLBACK) {
          log.trace("on commit, status was marked for rollback-only");
@@ -64,9 +64,9 @@ public class XaTransactionImpl implements Transaction {
       } else {
          status = Status.STATUS_PREPARING;
 
-         if ( synchronizations != null ) {
-            for ( int i = 0; i < synchronizations.size(); i++ ) {
-               Synchronization s = (Synchronization) synchronizations.get( i );
+         if (synchronizations != null) {
+            for (int i = 0; i < synchronizations.size(); i++) {
+               Synchronization s = (Synchronization) synchronizations.get(i);
                s.beforeCompletion();
             }
          }
@@ -94,10 +94,10 @@ public class XaTransactionImpl implements Transaction {
 
          status = Status.STATUS_COMMITTED;
 
-         if ( synchronizations != null ) {
-            for ( int i = 0; i < synchronizations.size(); i++ ) {
-               Synchronization s = (Synchronization) synchronizations.get( i );
-               s.afterCompletion( status );
+         if (synchronizations != null) {
+            for (int i = 0; i < synchronizations.size(); i++) {
+               Synchronization s = (Synchronization) synchronizations.get(i);
+               s.afterCompletion(status);
             }
          }
 
@@ -138,7 +138,7 @@ public class XaTransactionImpl implements Transaction {
    }
 
    public void registerSynchronization(Synchronization synchronization) throws RollbackException,
-            IllegalStateException, SystemException {
+         IllegalStateException, SystemException {
       // todo : find the spec-allowable statuses during which synch can be registered...
       if (synchronizations == null) {
          synchronizations = new LinkedList();
@@ -159,7 +159,7 @@ public class XaTransactionImpl implements Transaction {
    }
 
    public boolean enlistResource(XAResource xaResource) throws RollbackException, IllegalStateException,
-            SystemException {
+         SystemException {
       enlistedResources.add(new WrappedXaResource(xaResource));
       try {
          xaResource.start(xid, 0);
@@ -200,7 +200,7 @@ public class XaTransactionImpl implements Transaction {
          try {
             res.rollback(xid);
          } catch (XAException e) {
-            log.warn("Error while rolling back",e);
+            log.warn("Error while rolling back", e);
          }
       }
    }
@@ -211,7 +211,7 @@ public class XaTransactionImpl implements Transaction {
          try {
             res.commit(xid, false);//todo we only support one phase commit for now, change this!!!
          } catch (XAException e) {
-            log.warn("exception while committing",e);
+            log.warn("exception while committing", e);
             throw new HeuristicMixedException(e.getMessage());
          }
       }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/XaTransactionManagerImpl.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/tm/XaTransactionManagerImpl.java
@@ -1,4 +1,5 @@
 package org.infinispan.test.hibernate.cache.commons.tm;
+
 import jakarta.transaction.HeuristicMixedException;
 import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.InvalidTransactionException;
@@ -48,12 +49,12 @@ public class XaTransactionManagerImpl implements TransactionManager {
    }
 
    public void resume(Transaction transaction) throws InvalidTransactionException, IllegalStateException,
-            SystemException {
+         SystemException {
       currentTransaction.set((XaTransactionImpl) transaction);
    }
 
    public void commit() throws RollbackException, HeuristicMixedException, HeuristicRollbackException,
-            SecurityException, IllegalStateException, SystemException {
+         SecurityException, IllegalStateException, SystemException {
       XaTransactionImpl currentTransaction = this.currentTransaction.get();
       if (currentTransaction == null) {
          throw new IllegalStateException("no current transaction to commit");

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/BatchModeJtaPlatform.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/BatchModeJtaPlatform.java
@@ -16,43 +16,41 @@ import jakarta.transaction.UserTransaction;
  * @author Steve Ebersole
  */
 public class BatchModeJtaPlatform implements JtaPlatform {
-	@Override
-	public TransactionManager retrieveTransactionManager() {
-        try {
-            return BatchModeTransactionManager.getInstance();
-        }
-        catch (Exception e) {
-            throw new HibernateException("Failed getting BatchModeTransactionManager", e);
-        }
-	}
+   @Override
+   public TransactionManager retrieveTransactionManager() {
+      try {
+         return BatchModeTransactionManager.getInstance();
+      } catch (Exception e) {
+         throw new HibernateException("Failed getting BatchModeTransactionManager", e);
+      }
+   }
 
-	@Override
-	public UserTransaction retrieveUserTransaction() {
-        throw new UnsupportedOperationException();
-	}
+   @Override
+   public UserTransaction retrieveUserTransaction() {
+      throw new UnsupportedOperationException();
+   }
 
-	@Override
-	public Object getTransactionIdentifier(Transaction transaction) {
-		return transaction;
-	}
+   @Override
+   public Object getTransactionIdentifier(Transaction transaction) {
+      return transaction;
+   }
 
-	@Override
-	public boolean canRegisterSynchronization() {
-		return JtaStatusHelper.isActive( retrieveTransactionManager() );
-	}
+   @Override
+   public boolean canRegisterSynchronization() {
+      return JtaStatusHelper.isActive(retrieveTransactionManager());
+   }
 
-	@Override
-	public void registerSynchronization(Synchronization synchronization) {
-		try {
-			retrieveTransactionManager().getTransaction().registerSynchronization( synchronization );
-		}
-		catch (Exception e) {
-			throw new TransactionException( "Could not obtain transaction from TM" );
-		}
-	}
+   @Override
+   public void registerSynchronization(Synchronization synchronization) {
+      try {
+         retrieveTransactionManager().getTransaction().registerSynchronization(synchronization);
+      } catch (Exception e) {
+         throw new TransactionException("Could not obtain transaction from TM");
+      }
+   }
 
-	@Override
-	public int getCurrentStatus() throws SystemException {
-		return JtaStatusHelper.getStatus( retrieveTransactionManager() );
-	}
+   @Override
+   public int getCurrentStatus() throws SystemException {
+      return JtaStatusHelper.getStatus(retrieveTransactionManager());
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/CacheTestSupport.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/CacheTestSupport.java
@@ -12,88 +12,84 @@ import org.infinispan.Cache;
  * @author <a href="brian.stansberry@jboss.com">Brian Stansberry</a>
  */
 public class CacheTestSupport {
-	private static final String PREFER_IPV4STACK = "java.net.preferIPv4Stack";
+   private static final String PREFER_IPV4STACK = "java.net.preferIPv4Stack";
 
-    private final Set<Cache> caches = new HashSet<>();
-    private final Set<TestRegionFactory> factories = new HashSet<>();
-    private Exception exception;
-    private String preferIPv4Stack;
+   private final Set<Cache> caches = new HashSet<>();
+   private final Set<TestRegionFactory> factories = new HashSet<>();
+   private Exception exception;
+   private String preferIPv4Stack;
 
-    public void registerCache(Cache cache) {
-        caches.add(cache);
-    }
+   public void registerCache(Cache cache) {
+      caches.add(cache);
+   }
 
-    public void registerFactory(TestRegionFactory factory) {
-        factories.add(factory);
-    }
+   public void registerFactory(TestRegionFactory factory) {
+      factories.add(factory);
+   }
 
-    public void unregisterCache(Cache cache) {
-        caches.remove( cache );
-    }
+   public void unregisterCache(Cache cache) {
+      caches.remove(cache);
+   }
 
-    public void unregisterFactory(TestRegionFactory factory) {
-        factories.remove( factory );
-    }
+   public void unregisterFactory(TestRegionFactory factory) {
+      factories.remove(factory);
+   }
 
-    public void setUp() throws Exception {
-        // Try to ensure we use IPv4; otherwise cluster formation is very slow
-        preferIPv4Stack = System.getProperty(PREFER_IPV4STACK);
-        System.setProperty(PREFER_IPV4STACK, "true");
+   public void setUp() throws Exception {
+      // Try to ensure we use IPv4; otherwise cluster formation is very slow
+      preferIPv4Stack = System.getProperty(PREFER_IPV4STACK);
+      System.setProperty(PREFER_IPV4STACK, "true");
 
-        cleanUp();
-        throwStoredException();
-    }
+      cleanUp();
+      throwStoredException();
+   }
 
-    public void tearDown() throws Exception {
-        if (preferIPv4Stack == null)
-            System.clearProperty(PREFER_IPV4STACK);
-        else
-            System.setProperty(PREFER_IPV4STACK, preferIPv4Stack);
+   public void tearDown() throws Exception {
+      if (preferIPv4Stack == null)
+         System.clearProperty(PREFER_IPV4STACK);
+      else
+         System.setProperty(PREFER_IPV4STACK, preferIPv4Stack);
 
-        cleanUp();
-        throwStoredException();
-    }
+      cleanUp();
+      throwStoredException();
+   }
 
-    private void cleanUp() {
-        for (Iterator<TestRegionFactory> it = factories.iterator(); it.hasNext(); ) {
-            try {
-                it.next().stop();
-            }
-            catch (Exception e) {
-                storeException(e);
-            }
-            finally {
-                it.remove();
-            }
-        }
-        factories.clear();
+   private void cleanUp() {
+      for (Iterator<TestRegionFactory> it = factories.iterator(); it.hasNext(); ) {
+         try {
+            it.next().stop();
+         } catch (Exception e) {
+            storeException(e);
+         } finally {
+            it.remove();
+         }
+      }
+      factories.clear();
 
-        for (Iterator<Cache> it = caches.iterator(); it.hasNext(); ) {
-            try {
-                it.next().stop();
-            }
-            catch (Exception e) {
-                storeException(e);
-            }
-            finally {
-                it.remove();
-            }
-        }
-        caches.clear();
-    }
+      for (Iterator<Cache> it = caches.iterator(); it.hasNext(); ) {
+         try {
+            it.next().stop();
+         } catch (Exception e) {
+            storeException(e);
+         } finally {
+            it.remove();
+         }
+      }
+      caches.clear();
+   }
 
-    private void storeException(Exception e) {
-        if (this.exception == null) {
-            this.exception = e;
-        }
-    }
+   private void storeException(Exception e) {
+      if (this.exception == null) {
+         this.exception = e;
+      }
+   }
 
-    private void throwStoredException() throws Exception {
-        if (exception != null) {
-            Exception toThrow = exception;
-            exception = null;
-            throw toThrow;
-        }
-    }
+   private void throwStoredException() throws Exception {
+      if (exception != null) {
+         Exception toThrow = exception;
+         exception = null;
+         throw toThrow;
+      }
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/CacheTestUtil.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/CacheTestUtil.java
@@ -7,15 +7,15 @@ import java.util.Properties;
 
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cache.spi.RegionFactory;
-import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
-import org.infinispan.hibernate.cache.spi.InfinispanProperties;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Environment;
 import org.hibernate.engine.config.spi.ConfigurationService;
+import org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorBuilderImpl;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.hibernate.service.ServiceRegistry;
+import org.infinispan.hibernate.cache.spi.InfinispanProperties;
 
 /**
  * Utilities for cache testing.
@@ -23,124 +23,119 @@ import org.hibernate.service.ServiceRegistry;
  * @author <a href="brian.stansberry@jboss.com">Brian Stansberry</a>
  */
 public class CacheTestUtil {
-	@SuppressWarnings("unchecked")
-	public static Map buildBaselineSettings(
-			String regionPrefix,
-			boolean use2ndLevel,
-			boolean useQueries,
-			Class<? extends JtaPlatform> jtaPlatform) {
-		Map settings = new HashMap();
+   @SuppressWarnings("unchecked")
+   public static Map buildBaselineSettings(
+         String regionPrefix,
+         boolean use2ndLevel,
+         boolean useQueries,
+         Class<? extends JtaPlatform> jtaPlatform) {
+      Map settings = new HashMap();
 
-		settings.put( AvailableSettings.GENERATE_STATISTICS, "true" );
-		settings.put( AvailableSettings.USE_STRUCTURED_CACHE, "true" );
-		if (jtaPlatform == null || jtaPlatform == NoJtaPlatform.class) {
-			settings.put(Environment.TRANSACTION_COORDINATOR_STRATEGY, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class.getName());
-			settings.put(AvailableSettings.JTA_PLATFORM, NoJtaPlatform.class);
-		} else {
-			settings.put(Environment.TRANSACTION_COORDINATOR_STRATEGY, JtaTransactionCoordinatorBuilderImpl.class.getName());
-			settings.put(AvailableSettings.JTA_PLATFORM, jtaPlatform);
-		}
-		settings.put( AvailableSettings.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass() );
-		settings.put( AvailableSettings.CACHE_REGION_PREFIX, regionPrefix );
-		settings.put( AvailableSettings.USE_SECOND_LEVEL_CACHE, String.valueOf( use2ndLevel ) );
-		settings.put( AvailableSettings.USE_QUERY_CACHE, String.valueOf( useQueries ) );
+      settings.put(AvailableSettings.GENERATE_STATISTICS, "true");
+      settings.put(AvailableSettings.USE_STRUCTURED_CACHE, "true");
+      if (jtaPlatform == null || jtaPlatform == NoJtaPlatform.class) {
+         settings.put(Environment.TRANSACTION_COORDINATOR_STRATEGY, JdbcResourceLocalTransactionCoordinatorBuilderImpl.class.getName());
+         settings.put(AvailableSettings.JTA_PLATFORM, NoJtaPlatform.class);
+      } else {
+         settings.put(Environment.TRANSACTION_COORDINATOR_STRATEGY, JtaTransactionCoordinatorBuilderImpl.class.getName());
+         settings.put(AvailableSettings.JTA_PLATFORM, jtaPlatform);
+      }
+      settings.put(AvailableSettings.CACHE_REGION_FACTORY, TestRegionFactoryProvider.load().getRegionFactoryClass());
+      settings.put(AvailableSettings.CACHE_REGION_PREFIX, regionPrefix);
+      settings.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, String.valueOf(use2ndLevel));
+      settings.put(AvailableSettings.USE_QUERY_CACHE, String.valueOf(useQueries));
 
-		return settings;
-	}
+      return settings;
+   }
 
-	public static StandardServiceRegistryBuilder buildBaselineStandardServiceRegistryBuilder(
-			String regionPrefix,
-			boolean use2ndLevel,
-			boolean useQueries,
-			Class<? extends JtaPlatform> jtaPlatform) {
-		StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
+   public static StandardServiceRegistryBuilder buildBaselineStandardServiceRegistryBuilder(
+         String regionPrefix,
+         boolean use2ndLevel,
+         boolean useQueries,
+         Class<? extends JtaPlatform> jtaPlatform) {
+      StandardServiceRegistryBuilder ssrb = new StandardServiceRegistryBuilder();
 
-		ssrb.applySettings(
-				  buildBaselineSettings( regionPrefix, use2ndLevel, useQueries, jtaPlatform )
-		);
+      ssrb.applySettings(
+            buildBaselineSettings(regionPrefix, use2ndLevel, useQueries, jtaPlatform)
+      );
 
-		return ssrb;
-	}
+      return ssrb;
+   }
 
-	public static StandardServiceRegistryBuilder buildCustomQueryCacheStandardServiceRegistryBuilder(
-			  String regionPrefix,
-			  String queryCacheName,
-			  Class<? extends JtaPlatform> jtaPlatform) {
-		final StandardServiceRegistryBuilder ssrb = buildBaselineStandardServiceRegistryBuilder(
-				  regionPrefix, true, true, jtaPlatform
-		);
-		ssrb.applySetting( InfinispanProperties.QUERY_CACHE_RESOURCE_PROP, queryCacheName );
-		return ssrb;
-	}
+   public static StandardServiceRegistryBuilder buildCustomQueryCacheStandardServiceRegistryBuilder(
+         String regionPrefix,
+         String queryCacheName,
+         Class<? extends JtaPlatform> jtaPlatform) {
+      final StandardServiceRegistryBuilder ssrb = buildBaselineStandardServiceRegistryBuilder(
+            regionPrefix, true, true, jtaPlatform
+      );
+      ssrb.applySetting(InfinispanProperties.QUERY_CACHE_RESOURCE_PROP, queryCacheName);
+      return ssrb;
+   }
 
-	public static <RF extends RegionFactory> RF createRegionFactory(Class<RF> clazz, Properties properties) {
-		try {
-			try {
-				Constructor<RF> constructor = clazz.getConstructor(Properties.class);
-				return constructor.newInstance(properties);
-			}
-			catch (NoSuchMethodException e) {
-				return clazz.newInstance();
-			}
-		}
-		catch (RuntimeException e) {
-			throw e;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+   public static <RF extends RegionFactory> RF createRegionFactory(Class<RF> clazz, Properties properties) {
+      try {
+         try {
+            Constructor<RF> constructor = clazz.getConstructor(Properties.class);
+            return constructor.newInstance(properties);
+         } catch (NoSuchMethodException e) {
+            return clazz.newInstance();
+         }
+      } catch (RuntimeException e) {
+         throw e;
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
 
-	public static TestRegionFactory startRegionFactory(ServiceRegistry serviceRegistry) {
-		try {
-			final ConfigurationService cfgService = serviceRegistry.getService( ConfigurationService.class );
-			final Properties properties = toProperties( cfgService.getSettings() );
+   public static TestRegionFactory startRegionFactory(ServiceRegistry serviceRegistry) {
+      try {
+         final ConfigurationService cfgService = serviceRegistry.getService(ConfigurationService.class);
+         final Properties properties = toProperties(cfgService.getSettings());
 
-			TestRegionFactory regionFactory = TestRegionFactoryProvider.load().create(properties);
-			regionFactory.start( serviceRegistry, properties );
+         TestRegionFactory regionFactory = TestRegionFactoryProvider.load().create(properties);
+         regionFactory.start(serviceRegistry, properties);
 
-			return regionFactory;
-		}
-		catch (RuntimeException e) {
-			throw e;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+         return regionFactory;
+      } catch (RuntimeException e) {
+         throw e;
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
 
-	public static TestRegionFactory startRegionFactory(
-			  ServiceRegistry serviceRegistry,
-			  CacheTestSupport testSupport) {
-		TestRegionFactory factory = startRegionFactory( serviceRegistry );
-		testSupport.registerFactory( factory );
-		return factory;
-	}
+   public static TestRegionFactory startRegionFactory(
+         ServiceRegistry serviceRegistry,
+         CacheTestSupport testSupport) {
+      TestRegionFactory factory = startRegionFactory(serviceRegistry);
+      testSupport.registerFactory(factory);
+      return factory;
+   }
 
-	public static void stopRegionFactory(
-			  TestRegionFactory factory,
-			  CacheTestSupport testSupport) {
-		testSupport.unregisterFactory( factory );
-		factory.stop();
-	}
+   public static void stopRegionFactory(
+         TestRegionFactory factory,
+         CacheTestSupport testSupport) {
+      testSupport.unregisterFactory(factory);
+      factory.stop();
+   }
 
-	public static Properties toProperties(Map map) {
-		if ( map == null ) {
-			return null;
-		}
+   public static Properties toProperties(Map map) {
+      if (map == null) {
+         return null;
+      }
 
-		if ( map instanceof Properties ) {
-			return (Properties) map;
-		}
+      if (map instanceof Properties) {
+         return (Properties) map;
+      }
 
-		Properties properties = new Properties();
-		properties.putAll( map );
-		return properties;
-	}
+      Properties properties = new Properties();
+      properties.putAll(map);
+      return properties;
+   }
 
-	/**
-	 * Prevent instantiation.
-	 */
-	private CacheTestUtil() {
-	}
+   /**
+    * Prevent instantiation.
+    */
+   private CacheTestUtil() {
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/ClassLoaderAwareCache.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/ClassLoaderAwareCache.java
@@ -135,13 +135,11 @@ public class ClassLoaderAwareCache<K, V> extends AbstractDelegatingAdvancedCache
                for (Method method : this.methods.get(event.getType())) {
                   try {
                      method.invoke(this.listener, event);
-                  }
-                  catch (InvocationTargetException e) {
+                  } catch (InvocationTargetException e) {
                      throw e.getCause();
                   }
                }
-            }
-            finally {
+            } finally {
                cache.setContextClassLoader(classLoader);
             }
          }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/ExpectingInterceptor.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/ExpectingInterceptor.java
@@ -112,9 +112,9 @@ public class ExpectingInterceptor extends BaseCustomAsyncInterceptor {
 
       public Condition countDown(CountDownLatch latch) {
          return run(() -> {
-               log.debugf("Count down latch %s", latch);
-               latch.countDown();
-            }).removeWhen(() -> latch.getCount() == 0);
+            log.debugf("Count down latch %s", latch);
+            latch.countDown();
+         }).removeWhen(() -> latch.getCount() == 0);
       }
 
       public Condition removeWhen(BooleanSupplier check) {

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/InfinispanTestingSetup.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/InfinispanTestingSetup.java
@@ -21,35 +21,35 @@ import org.junit.runners.model.Statement;
  */
 public final class InfinispanTestingSetup implements TestRule {
 
-    private volatile String runningTest;
+   private volatile String runningTest;
 
-    public InfinispanTestingSetup() {
-    }
+   public InfinispanTestingSetup() {
+   }
 
-    public Statement apply(Statement base, Description d) {
-        final String methodName = d.getMethodName();
-        final String testName = methodName == null ? d.getClassName() : d.getClassName() + "#" + d.getMethodName();
-        runningTest = testName;
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                TestResourceTracker.testStarted( testName );
-                ThreadLeakChecker.testStarted( testName );
-                try {
-                    base.evaluate();
-                } finally {
-                    TestResourceTracker.testFinished( testName );
-                    ThreadLeakChecker.testFinished( testName );
-                }
+   public Statement apply(Statement base, Description d) {
+      final String methodName = d.getMethodName();
+      final String testName = methodName == null ? d.getClassName() : d.getClassName() + "#" + d.getMethodName();
+      runningTest = testName;
+      return new Statement() {
+         @Override
+         public void evaluate() throws Throwable {
+            TestResourceTracker.testStarted(testName);
+            ThreadLeakChecker.testStarted(testName);
+            try {
+               base.evaluate();
+            } finally {
+               TestResourceTracker.testFinished(testName);
+               ThreadLeakChecker.testFinished(testName);
             }
-        };
-    }
+         }
+      };
+   }
 
    /**
     * Make a new thread join the test context.
     */
    public void joinContext() {
-        TestResourceTracker.setThreadTestName( runningTest );
-    }
+      TestResourceTracker.setThreadTestName(runningTest);
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/JdbcResourceTransactionMock.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/JdbcResourceTransactionMock.java
@@ -1,35 +1,35 @@
 package org.infinispan.test.hibernate.cache.commons.util;
 
+import static org.junit.Assert.assertEquals;
+
 import org.hibernate.resource.transaction.backend.jdbc.spi.JdbcResourceTransaction;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public class JdbcResourceTransactionMock implements JdbcResourceTransaction {
-	private TransactionStatus status = TransactionStatus.NOT_ACTIVE;
+   private TransactionStatus status = TransactionStatus.NOT_ACTIVE;
 
-	@Override
-	public void begin() {
-		assertEquals(TransactionStatus.NOT_ACTIVE, status);
-		status = TransactionStatus.ACTIVE;
-	}
+   @Override
+   public void begin() {
+      assertEquals(TransactionStatus.NOT_ACTIVE, status);
+      status = TransactionStatus.ACTIVE;
+   }
 
-	@Override
-	public void commit() {
-		assertEquals(TransactionStatus.ACTIVE, status);
-		status = TransactionStatus.COMMITTED;
-	}
+   @Override
+   public void commit() {
+      assertEquals(TransactionStatus.ACTIVE, status);
+      status = TransactionStatus.COMMITTED;
+   }
 
-	@Override
-	public void rollback() {
-		status = TransactionStatus.ROLLED_BACK;
-	}
+   @Override
+   public void rollback() {
+      status = TransactionStatus.ROLLED_BACK;
+   }
 
-	@Override
-	public TransactionStatus getStatus() {
-		return status;
-	}
+   @Override
+   public TransactionStatus getStatus() {
+      return status;
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestRegionFactory.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestRegionFactory.java
@@ -6,8 +6,8 @@ import org.hibernate.cache.spi.RegionFactory;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.service.ServiceRegistry;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.hibernate.cache.commons.TimeSource;
 import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
+import org.infinispan.hibernate.cache.commons.TimeSource;
 import org.infinispan.manager.EmbeddedCacheManager;
 
 public interface TestRegionFactory extends TimeSource {

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestSessionAccess.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestSessionAccess.java
@@ -11,8 +11,8 @@ import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
-import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
 import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.hibernate.cache.commons.InfinispanBaseRegion;
 
 public interface TestSessionAccess {
 

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestSynchronization.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestSynchronization.java
@@ -7,66 +7,66 @@ import org.infinispan.test.hibernate.cache.commons.util.TestSessionAccess.TestRe
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public abstract class TestSynchronization implements jakarta.transaction.Synchronization {
-	protected final Object session;
-	protected final Object key;
-	protected final Object value;
-	protected final Object version;
+   protected final Object session;
+   protected final Object key;
+   protected final Object value;
+   protected final Object version;
 
-	public TestSynchronization(Object session, Object key, Object value, Object version) {
-		this.session = session;
-		this.key = key;
-		this.value = value;
-		this.version = version;
-	}
+   public TestSynchronization(Object session, Object key, Object value, Object version) {
+      this.session = session;
+      this.key = key;
+      this.value = value;
+      this.version = version;
+   }
 
-	@Override
-	public void beforeCompletion() {
-	}
+   @Override
+   public void beforeCompletion() {
+   }
 
 
-	public static class AfterInsert extends TestSynchronization {
-		private final TestRegionAccessStrategy strategy;
+   public static class AfterInsert extends TestSynchronization {
+      private final TestRegionAccessStrategy strategy;
 
-		public AfterInsert(TestRegionAccessStrategy strategy, Object session, Object key, Object value, Object version) {
-			super(session, key, value, version);
-			this.strategy = strategy;
-		}
+      public AfterInsert(TestRegionAccessStrategy strategy, Object session, Object key, Object value, Object version) {
+         super(session, key, value, version);
+         this.strategy = strategy;
+      }
 
-		@Override
-		public void afterCompletion(int status) {
-			strategy.afterInsert(session, key, value, version);
-		}
-	}
+      @Override
+      public void afterCompletion(int status) {
+         strategy.afterInsert(session, key, value, version);
+      }
+   }
 
-	public static class AfterUpdate extends TestSynchronization {
-		private final TestRegionAccessStrategy strategy;
-		private final SoftLock lock;
+   public static class AfterUpdate extends TestSynchronization {
+      private final TestRegionAccessStrategy strategy;
+      private final SoftLock lock;
 
-		public AfterUpdate(TestRegionAccessStrategy strategy, Object session, Object key, Object value, Object version, SoftLock lock) {
-			super(session, key, value, version);
-			this.strategy = strategy;
-			this.lock = lock;
-		}
+      public AfterUpdate(TestRegionAccessStrategy strategy, Object session, Object key, Object value, Object version, SoftLock lock) {
+         super(session, key, value, version);
+         this.strategy = strategy;
+         this.lock = lock;
+      }
 
-		@Override
-		public void afterCompletion(int status) {
-			strategy.afterUpdate(session, key, value, version, null, lock);
-		}
-	}
+      @Override
+      public void afterCompletion(int status) {
+         strategy.afterUpdate(session, key, value, version, null, lock);
+      }
+   }
 
-	public static class UnlockItem extends TestSynchronization {
-		private final TestRegionAccessStrategy strategy;
-		private final SoftLock lock;
+   public static class UnlockItem extends TestSynchronization {
+      private final TestRegionAccessStrategy strategy;
+      private final SoftLock lock;
 
-		public UnlockItem(TestRegionAccessStrategy strategy, Object session, Object key, SoftLock lock) {
-			super(session, key, null, null);
-			this.strategy = strategy;
-			this.lock = lock;
-		}
+      public UnlockItem(TestRegionAccessStrategy strategy, Object session, Object key, SoftLock lock) {
+         super(session, key, null, null);
+         this.strategy = strategy;
+         this.lock = lock;
+      }
 
-		@Override
-		public void afterCompletion(int status) {
-			strategy.unlockItem(session, key, lock);
-		}
-	}
+      @Override
+      public void afterCompletion(int status) {
+         strategy.unlockItem(session, key, lock);
+      }
+   }
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestingKeyFactory.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestingKeyFactory.java
@@ -4,57 +4,57 @@ import java.io.Serializable;
 
 public class TestingKeyFactory {
 
-	private TestingKeyFactory() {
-		//Not to be constructed
-	}
+   private TestingKeyFactory() {
+      //Not to be constructed
+   }
 
-	public static Object generateEntityCacheKey(String id) {
-		return new TestingEntityCacheKey( id );
-	}
+   public static Object generateEntityCacheKey(String id) {
+      return new TestingEntityCacheKey(id);
+   }
 
-	public static Object generateCollectionCacheKey(String id) {
-		return new TestingEntityCacheKey( id );
-	}
+   public static Object generateCollectionCacheKey(String id) {
+      return new TestingEntityCacheKey(id);
+   }
 
-	//For convenience implement both interfaces.
-	private static class TestingEntityCacheKey implements Serializable {
+   //For convenience implement both interfaces.
+   private static class TestingEntityCacheKey implements Serializable {
 
-		private final String id;
+      private final String id;
 
-		public TestingEntityCacheKey(String id) {
-			this.id = id;
-		}
+      public TestingEntityCacheKey(String id) {
+         this.id = id;
+      }
 
-		@Override
-		public String toString() {
-			return id;
-		}
+      @Override
+      public String toString() {
+         return id;
+      }
 
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((id == null) ? 0 : id.hashCode());
-			return result;
-		}
+      @Override
+      public int hashCode() {
+         final int prime = 31;
+         int result = 1;
+         result = prime * result + ((id == null) ? 0 : id.hashCode());
+         return result;
+      }
 
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			TestingEntityCacheKey other = (TestingEntityCacheKey) obj;
-			if (id == null) {
-				if (other.id != null)
-					return false;
-			} else if (!id.equals(other.id))
-				return false;
-			return true;
-		}
+      @Override
+      public boolean equals(Object obj) {
+         if (this == obj)
+            return true;
+         if (obj == null)
+            return false;
+         if (getClass() != obj.getClass())
+            return false;
+         TestingEntityCacheKey other = (TestingEntityCacheKey) obj;
+         if (id == null) {
+            if (other.id != null)
+               return false;
+         } else if (!id.equals(other.id))
+            return false;
+         return true;
+      }
 
-	}
+   }
 
 }

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestingUtil.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TestingUtil.java
@@ -19,8 +19,8 @@ public class TestingUtil {
     * right pattern is used to make sure that the transaction is always either
     * committed or rollbacked.
     *
-    * @param tm transaction manager
-    * @param c callable instance to run within a transaction
+    * @param tm  transaction manager
+    * @param c   callable instance to run within a transaction
     * @param <T> type returned from the callable
     * @return returns whatever the callable returns
     */
@@ -33,8 +33,8 @@ public class TestingUtil {
     * right pattern is used to make sure that the transaction is always either committed or rollbacked around
     * the callable.
     *
-    * @param tm transaction manager
-    * @param c callable instance to run within a transaction
+    * @param tm  transaction manager
+    * @param c   callable instance to run within a transaction
     * @param <T> tyep of callable to return
     * @return The callable to invoke.  Note as long as the provided callable is thread safe this callable will be as well
     */

--- a/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TxUtil.java
+++ b/hibernate/cache-commons/src/test/java/org/infinispan/test/hibernate/cache/commons/util/TxUtil.java
@@ -17,131 +17,131 @@ import jakarta.transaction.TransactionManager;
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 public final class TxUtil {
-	public static void withTxSession(boolean useJta, SessionFactory sessionFactory, ThrowingConsumer<Session, Exception> consumer) throws Exception {
-		JtaPlatform jtaPlatform = useJta ? sessionFactory.getSessionFactoryOptions().getServiceRegistry().getService(JtaPlatform.class) : null;
-		withTxSession(jtaPlatform, sessionFactory.withOptions(), consumer);
-	}
+   public static void withTxSession(boolean useJta, SessionFactory sessionFactory, ThrowingConsumer<Session, Exception> consumer) throws Exception {
+      JtaPlatform jtaPlatform = useJta ? sessionFactory.getSessionFactoryOptions().getServiceRegistry().getService(JtaPlatform.class) : null;
+      withTxSession(jtaPlatform, sessionFactory.withOptions(), consumer);
+   }
 
-	public static void withTxSession(JtaPlatform jtaPlatform, SessionBuilder sessionBuilder, ThrowingConsumer<Session, Exception> consumer) throws Exception {
-		if (jtaPlatform != null) {
-			TransactionManager tm = jtaPlatform.retrieveTransactionManager();
-			final SessionBuilder sb = sessionBuilder;
-			Caches.withinTx(tm, () -> {
-				withSession(sb, s -> {
-					consumer.accept(s);
-					// we need to flush the session before close when running with JTA transactions
-					s.flush();
-				});
-				return null;
-			});
-		} else {
-			withSession(sessionBuilder, s -> withResourceLocalTx(s, consumer));
-		}
-	}
+   public static void withTxSession(JtaPlatform jtaPlatform, SessionBuilder sessionBuilder, ThrowingConsumer<Session, Exception> consumer) throws Exception {
+      if (jtaPlatform != null) {
+         TransactionManager tm = jtaPlatform.retrieveTransactionManager();
+         final SessionBuilder sb = sessionBuilder;
+         Caches.withinTx(tm, () -> {
+            withSession(sb, s -> {
+               consumer.accept(s);
+               // we need to flush the session before close when running with JTA transactions
+               s.flush();
+            });
+            return null;
+         });
+      } else {
+         withSession(sessionBuilder, s -> withResourceLocalTx(s, consumer));
+      }
+   }
 
-	public static <T> T withTxSessionApply(boolean useJta, SessionFactory sessionFactory, ThrowingFunction<Session, T, Exception> function) throws Exception {
-		JtaPlatform jtaPlatform = useJta ? sessionFactory.getSessionFactoryOptions().getServiceRegistry().getService(JtaPlatform.class) : null;
-		return withTxSessionApply(jtaPlatform, sessionFactory.withOptions(), function);
-	}
+   public static <T> T withTxSessionApply(boolean useJta, SessionFactory sessionFactory, ThrowingFunction<Session, T, Exception> function) throws Exception {
+      JtaPlatform jtaPlatform = useJta ? sessionFactory.getSessionFactoryOptions().getServiceRegistry().getService(JtaPlatform.class) : null;
+      return withTxSessionApply(jtaPlatform, sessionFactory.withOptions(), function);
+   }
 
-	public static <T> T withTxSessionApply(JtaPlatform jtaPlatform, SessionBuilder sessionBuilder, ThrowingFunction<Session, T, Exception> function) throws Exception {
-		if (jtaPlatform != null) {
-			TransactionManager tm = jtaPlatform.retrieveTransactionManager();
-			Callable<T> callable = () -> withSessionApply(sessionBuilder, s -> {
-				T t = function.apply(s);
-				s.flush();
-				return t;
-			});
-			return Caches.withinTx(tm, callable);
-		} else {
-			return withSessionApply(sessionBuilder, s -> withResourceLocalTx(s, function));
-		}
-	}
+   public static <T> T withTxSessionApply(JtaPlatform jtaPlatform, SessionBuilder sessionBuilder, ThrowingFunction<Session, T, Exception> function) throws Exception {
+      if (jtaPlatform != null) {
+         TransactionManager tm = jtaPlatform.retrieveTransactionManager();
+         Callable<T> callable = () -> withSessionApply(sessionBuilder, s -> {
+            T t = function.apply(s);
+            s.flush();
+            return t;
+         });
+         return Caches.withinTx(tm, callable);
+      } else {
+         return withSessionApply(sessionBuilder, s -> withResourceLocalTx(s, function));
+      }
+   }
 
-	public static <E extends Throwable> void withSession(SessionBuilder sessionBuilder, ThrowingConsumer<Session, E> consumer) throws E {
-		Session s = sessionBuilder.openSession();
-		try {
-			consumer.accept(s);
-		} finally {
-			s.close();
-		}
-	}
+   public static <E extends Throwable> void withSession(SessionBuilder sessionBuilder, ThrowingConsumer<Session, E> consumer) throws E {
+      Session s = sessionBuilder.openSession();
+      try {
+         consumer.accept(s);
+      } finally {
+         s.close();
+      }
+   }
 
-	public static <R, E extends Throwable> R withSessionApply(SessionBuilder sessionBuilder, ThrowingFunction<Session, R, E> function) throws E {
-		Session s = sessionBuilder.openSession();
-		try {
-			return function.apply(s);
-		} finally {
-			s.close();
-		}
-	}
+   public static <R, E extends Throwable> R withSessionApply(SessionBuilder sessionBuilder, ThrowingFunction<Session, R, E> function) throws E {
+      Session s = sessionBuilder.openSession();
+      try {
+         return function.apply(s);
+      } finally {
+         s.close();
+      }
+   }
 
-	public static void withResourceLocalTx(Session session, ThrowingConsumer<Session, Exception> consumer) throws Exception {
-		Transaction transaction = session.beginTransaction();
-		boolean rollingBack = false;
-		try {
-			consumer.accept(session);
-			if (transaction.getStatus() == TransactionStatus.ACTIVE) {
-				transaction.commit();
-			} else {
-				rollingBack = true;
-				transaction.rollback();
-			}
-		} catch (Exception e) {
-			if (!rollingBack) {
-				try {
-					transaction.rollback();
-				} catch (Exception suppressed) {
-					e.addSuppressed(suppressed);
-				}
-			}
-			throw e;
-		}
-	}
+   public static void withResourceLocalTx(Session session, ThrowingConsumer<Session, Exception> consumer) throws Exception {
+      Transaction transaction = session.beginTransaction();
+      boolean rollingBack = false;
+      try {
+         consumer.accept(session);
+         if (transaction.getStatus() == TransactionStatus.ACTIVE) {
+            transaction.commit();
+         } else {
+            rollingBack = true;
+            transaction.rollback();
+         }
+      } catch (Exception e) {
+         if (!rollingBack) {
+            try {
+               transaction.rollback();
+            } catch (Exception suppressed) {
+               e.addSuppressed(suppressed);
+            }
+         }
+         throw e;
+      }
+   }
 
-	public static <T> T withResourceLocalTx(Session session, ThrowingFunction<Session, T, Exception> consumer) throws Exception {
-		Transaction transaction = session.beginTransaction();
-		boolean rollingBack = false;
-		try {
-			T t = consumer.apply(session);
-			if (transaction.getStatus() == TransactionStatus.ACTIVE) {
-				transaction.commit();
-			} else {
-				rollingBack = true;
-				transaction.rollback();
-			}
-			return t;
-		} catch (Exception e) {
-			if (!rollingBack) {
-				try {
-					transaction.rollback();
-				} catch (Exception suppressed) {
-					e.addSuppressed(suppressed);
-				}
-			}
-			throw e;
-		}
-	}
+   public static <T> T withResourceLocalTx(Session session, ThrowingFunction<Session, T, Exception> consumer) throws Exception {
+      Transaction transaction = session.beginTransaction();
+      boolean rollingBack = false;
+      try {
+         T t = consumer.apply(session);
+         if (transaction.getStatus() == TransactionStatus.ACTIVE) {
+            transaction.commit();
+         } else {
+            rollingBack = true;
+            transaction.rollback();
+         }
+         return t;
+      } catch (Exception e) {
+         if (!rollingBack) {
+            try {
+               transaction.rollback();
+            } catch (Exception suppressed) {
+               e.addSuppressed(suppressed);
+            }
+         }
+         throw e;
+      }
+   }
 
-	public static void markRollbackOnly(boolean useJta, Session s) {
-		if (useJta) {
-			JtaPlatform jtaPlatform = s.getSessionFactory().getSessionFactoryOptions().getServiceRegistry().getService(JtaPlatform.class);
-			TransactionManager tm = jtaPlatform.retrieveTransactionManager();
-			try {
-				tm.setRollbackOnly();
-			} catch (SystemException e) {
-				throw new RuntimeException(e);
-			}
-		} else {
-			s.getTransaction().markRollbackOnly();
-		}
-	}
+   public static void markRollbackOnly(boolean useJta, Session s) {
+      if (useJta) {
+         JtaPlatform jtaPlatform = s.getSessionFactory().getSessionFactoryOptions().getServiceRegistry().getService(JtaPlatform.class);
+         TransactionManager tm = jtaPlatform.retrieveTransactionManager();
+         try {
+            tm.setRollbackOnly();
+         } catch (SystemException e) {
+            throw new RuntimeException(e);
+         }
+      } else {
+         s.getTransaction().markRollbackOnly();
+      }
+   }
 
-	public interface ThrowingConsumer<T, E extends Throwable> {
-		void accept(T t) throws E;
-	}
+   public interface ThrowingConsumer<T, E extends Throwable> {
+      void accept(T t) throws E;
+   }
 
-	public interface ThrowingFunction<T, R, E extends Throwable> {
-		R apply(T t) throws E;
-	}
+   public interface ThrowingFunction<T, R, E extends Throwable> {
+      R apply(T t) throws E;
+   }
 }

--- a/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
+++ b/hibernate/cache-commons/src/test/resources/2lc-test-tcp.xml
@@ -42,15 +42,15 @@
                max_join_attempts="3"
    />
 
-    <!-- At this place we can react on DISCONNECTs immediatelly -->
-    <!-- It deadlocks with JGroups 4.0.6, enable only after making sure it works -->
-    <!--<org.infinispan.test.hibernate.cache.util.TestDisconnectHandler />-->
+   <!-- At this place we can react on DISCONNECTs immediatelly -->
+   <!-- It deadlocks with JGroups 4.0.6, enable only after making sure it works -->
+   <!--<org.infinispan.test.hibernate.cache.util.TestDisconnectHandler />-->
 
    <UFC max_credits="4m"
         min_threshold="0.40"
    />
    <MFC max_credits="4m"
         min_threshold="0.40"
-    />
-   <FRAG4 frag_size="6k" />
+   />
+   <FRAG4 frag_size="6k"/>
 </config>

--- a/hibernate/cache-commons/src/test/resources/alternative-infinispan-configs.xml
+++ b/hibernate/cache-commons/src/test/resources/alternative-infinispan-configs.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd"
-        xmlns="urn:infinispan:config:${infinispan.core.schema.version}">
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:${infinispan.core.schema.version} https://infinispan.org/schemas/infinispan-config-${infinispan.core.schema.version}.xsd"
+      xmlns="urn:infinispan:config:${infinispan.core.schema.version}">
 
    <jgroups>
       <stack-file name="2lc-test-tcp" path="2lc-test-tcp.xml"/>
    </jgroups>
 
-   <cache-container name="SampleCacheManager" statistics="false" default-cache="the-default-cache" shutdown-hook="DEFAULT">
+   <cache-container name="SampleCacheManager" statistics="false" default-cache="the-default-cache"
+                    shutdown-hook="DEFAULT">
       <transport stack="2lc-test-tcp" cluster="infinispan-hibernate-cluster"/>
 
-      <local-cache name="the-default-cache" statistics="false" />
+      <local-cache name="the-default-cache" statistics="false"/>
 
       <!-- Default configuration is appropriate for entity/collection caching. -->
       <invalidation-cache name="entity" mode="SYNC" remote-timeout="20000">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
-         <transaction mode="NONE" />
+         <transaction mode="NONE"/>
          <expiration max-idle="100000" interval="5000"/>
          <memory storage="OBJECT" max-count="10000"/>
       </invalidation-cache>
@@ -32,7 +33,7 @@
       <!-- A config appropriate for query caching. Does not replicate queries. -->
       <local-cache name="local-query">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
-         <transaction mode="NONE" />
+         <transaction mode="NONE"/>
          <expiration max-idle="100000" interval="5000"/>
          <memory storage="OBJECT" max-count="10000"/>
       </local-cache>
@@ -40,7 +41,7 @@
       <!-- A query cache that replicates queries. Replication is asynchronous. -->
       <replicated-cache name="replicated-query" mode="ASYNC">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
-         <transaction mode="NONE" />
+         <transaction mode="NONE"/>
          <expiration max-idle="100000" interval="5000"/>
          <memory storage="OBJECT" max-count="10000"/>
       </replicated-cache>
@@ -60,19 +61,19 @@
       <!-- This configuration should match to InfinispanRegionFactory.DEFAULT_PENDING_PUTS_CACHE_CONFIGURATION -->
       <local-cache name="pending-puts" statistics="false">
          <transaction mode="NONE"/>
-         <expiration max-idle="120000" />
+         <expiration max-idle="120000"/>
       </local-cache>
 
       <!-- ISPN-8836 check what happens when custom region name matches cache name -->
       <invalidation-cache-configuration name="myregion" remote-timeout="20000" statistics="false">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
-         <transaction mode="NONE" />
+         <transaction mode="NONE"/>
          <expiration max-idle="100000" interval="5000"/>
          <memory storage="OBJECT" max-count="10000"/>
       </invalidation-cache-configuration>
       <invalidation-cache-configuration name="otherregion" remote-timeout="20000" statistics="false">
          <locking concurrency-level="1000" acquire-timeout="15000"/>
-         <transaction mode="NONE" />
+         <transaction mode="NONE"/>
          <expiration max-idle="100000" interval="5000"/>
          <memory storage="OBJECT" max-count="10000"/>
       </invalidation-cache-configuration>

--- a/hibernate/cache-commons/src/test/resources/hibernate.properties
+++ b/hibernate/cache-commons/src/test/resources/hibernate.properties
@@ -4,13 +4,8 @@ hibernate.connection.driver_class org.h2.Driver
 hibernate.connection.url jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;LOCK_TIMEOUT=10000
 hibernate.connection.username sa
 hibernate.connection.password
-
 hibernate.connection.pool_size 5
-
 hibernate.format_sql true
-
 hibernate.max_fetch_depth 5
-
 hibernate.generate_statistics true
-
 hibernate.service.allow_crawling=false

--- a/hibernate/cache-commons/src/test/resources/log4j.properties
+++ b/hibernate/cache-commons/src/test/resources/log4j.properties
@@ -2,11 +2,8 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p [%t] %c{1}:%L - %m%n
-
 log4j.rootLogger=info, stdout
-
 log4j.logger.org.hibernate.test=info
 log4j.logger.org.hibernate.cache=info
-
 # SQL Logging - HHH-6833
 log4j.logger.org.hibernate.SQL=warn

--- a/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Account.hbm.xml
+++ b/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Account.hbm.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
-	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+      "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+      "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping package="org.infinispan.test.hibernate.cache.commons.functional.entities">
 
-	<class name="Account" table="Accounts">
-		<id name="id">
-			<generator class="assigned"/>
-		</id>
-		
-		<property name="branch" not-null="true"/>
-		<property name="balance" not-null="true"/>		
+   <class name="Account" table="Accounts">
+      <id name="id">
+         <generator class="assigned"/>
+      </id>
+
+      <property name="branch" not-null="true"/>
+      <property name="balance" not-null="true"/>
       <property name="accountHolder" type="serializable" not-null="true"/>
-      
-	</class>
+
+   </class>
 
 </hibernate-mapping>

--- a/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Contact.hbm.xml
+++ b/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Contact.hbm.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
-	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+      "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+      "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
-   <hibernate-mapping
-   package="org.infinispan.test.hibernate.cache.commons.functional.entities">
+<hibernate-mapping
+      package="org.infinispan.test.hibernate.cache.commons.functional.entities">
 
    <class name="Contact" table="Contacts">
       <id name="id">
-         <generator class="increment" />
+         <generator class="increment"/>
       </id>
-      <property name="name" not-null="true" />
-      <property name="tlf" not-null="true" />
-      <many-to-one name="customer" column="cust_id" class="Customer" />
+      <property name="name" not-null="true"/>
+      <property name="tlf" not-null="true"/>
+      <many-to-one name="customer" column="cust_id" class="Customer"/>
    </class>
 
 </hibernate-mapping>

--- a/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Customer.hbm.xml
+++ b/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Customer.hbm.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
-   "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-   "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+      "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+      "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
-   <hibernate-mapping
-   package="org.infinispan.test.hibernate.cache.commons.functional.entities">
+<hibernate-mapping
+      package="org.infinispan.test.hibernate.cache.commons.functional.entities">
 
    <class name="Customer" table="Customers">
       <id name="id">
-         <generator class="increment" />
+         <generator class="increment"/>
       </id>
-      <property name="name" not-null="true" />
+      <property name="name" not-null="true"/>
       <set name="contacts" inverse="true" cascade="persist">
-         <key column="cust_id" />
-         <one-to-many class="Contact" />
+         <key column="cust_id"/>
+         <one-to-many class="Contact"/>
       </set>
 
    </class>

--- a/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Item.hbm.xml
+++ b/hibernate/cache-commons/src/test/resources/org/infinispan/test/hibernate/cache/commons/functional/entities/Item.hbm.xml
@@ -1,53 +1,53 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
-	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+      "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+      "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
-   <hibernate-mapping package="org.infinispan.test.hibernate.cache.commons.functional.entities">
+<hibernate-mapping package="org.infinispan.test.hibernate.cache.commons.functional.entities">
 
    <class name="Item" table="Items">
       <id name="id">
-         <generator class="increment" />
+         <generator class="increment"/>
       </id>
       <property name="name" not-null="true" column="item_name" unique="true"/>
-      <property name="description" not-null="true" />
-      <many-to-one name="owner" column="owner_id" class="Item" />
-      <many-to-one name="bagOwner" column="bagowner_id" class="Item" />
+      <property name="description" not-null="true"/>
+      <many-to-one name="owner" column="owner_id" class="Item"/>
+      <many-to-one name="bagOwner" column="bagowner_id" class="Item"/>
       <set name="items" inverse="true">
-         <key column="owner_id" />
-         <one-to-many class="Item" />
+         <key column="owner_id"/>
+         <one-to-many class="Item"/>
       </set>
-       <bag name="bagOfItems" inverse="true">
-           <key column="bagowner_id" />
-           <one-to-many class="Item" />
-       </bag>
-       <set name="otherItems" table="items_otheritems">
-           <key property-ref="name" column="item_name"/>
-           <many-to-many class="OtherItem" column="other_item_id"/>
-       </set>
+      <bag name="bagOfItems" inverse="true">
+         <key column="bagowner_id"/>
+         <one-to-many class="Item"/>
+      </bag>
+      <set name="otherItems" table="items_otheritems">
+         <key property-ref="name" column="item_name"/>
+         <many-to-many class="OtherItem" column="other_item_id"/>
+      </set>
    </class>
 
 
-    <class name="OtherItem" table="OtherItems">
-        <id name="id">
-            <generator class="increment" />
-        </id>
-        <many-to-one name="favoriteItem" property-ref="name"/>
-        <property name="name" not-null="true" column="other_item_name" unique="true" />
-        <bag name="bagOfItems" inverse="true" table="items_otheritems">
-            <key column="other_item_id"/>
-            <many-to-many class="Item" property-ref="name" column="item_name" />
-        </bag>
-    </class>
-
-
-    <class name="VersionedItem" table="VersionedItems">
+   <class name="OtherItem" table="OtherItems">
       <id name="id">
-         <generator class="increment" />
+         <generator class="increment"/>
       </id>
-      <version name="version" type="long" />
-      <property name="name" not-null="true" />
-      <property name="description" not-null="true" />
+      <many-to-one name="favoriteItem" property-ref="name"/>
+      <property name="name" not-null="true" column="other_item_name" unique="true"/>
+      <bag name="bagOfItems" inverse="true" table="items_otheritems">
+         <key column="other_item_id"/>
+         <many-to-many class="Item" property-ref="name" column="item_name"/>
+      </bag>
+   </class>
+
+
+   <class name="VersionedItem" table="VersionedItems">
+      <id name="id">
+         <generator class="increment"/>
+      </id>
+      <version name="version" type="long"/>
+      <property name="name" not-null="true"/>
+      <property name="description" not-null="true"/>
    </class>
 
 </hibernate-mapping>

--- a/hibernate/cache-commons/src/test/resources/stress-local-infinispan.xml
+++ b/hibernate/cache-commons/src/test/resources/stress-local-infinispan.xml
@@ -34,7 +34,7 @@
          <object size="140000"/>
       </memory>
       <expiration maxIdle="1200000" wakeUpInterval="60000"/>
-      <transaction transactionMode="NON_TRANSACTIONAL" autoCommit="false" />
+      <transaction transactionMode="NON_TRANSACTIONAL" autoCommit="false"/>
    </local-cache>
 
    <!-- Optimized for timestamp caching. -->

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/JdbcConfigurationUtil.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/JdbcConfigurationUtil.java
@@ -11,59 +11,59 @@ import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigu
 
 public class JdbcConfigurationUtil {
 
-    private PooledConnectionFactoryConfigurationBuilder<?> persistenceConfiguration;
-    private final ConfigurationBuilder configurationBuilder;
-    public static final String CACHE_NAME = "jdbc";
-    public String driverClass;
+   private PooledConnectionFactoryConfigurationBuilder<?> persistenceConfiguration;
+   private final ConfigurationBuilder configurationBuilder;
+   public static final String CACHE_NAME = "jdbc";
+   public String driverClass;
 
-    public JdbcConfigurationUtil(boolean passivation, boolean preload) {
-        configurationBuilder = new ConfigurationBuilder();
-        createPersistenceConfiguration(passivation, preload);
-    }
+   public JdbcConfigurationUtil(boolean passivation, boolean preload) {
+      configurationBuilder = new ConfigurationBuilder();
+      createPersistenceConfiguration(passivation, preload);
+   }
 
-    private void createPersistenceConfiguration(boolean passivation, boolean preload) {
-        Properties props = loadDBProperties();
-        driverClass = props.getProperty("driver.class");
-        configurationBuilder.memory().maxCount(2);
-        persistenceConfiguration = configurationBuilder
-                .persistence()
-                .passivation(passivation)
-                .addStore(JdbcStringBasedStoreConfigurationBuilder.class)
-                .segmented(false)
-                .preload(preload)
-                .table()
-                .createOnStart(true)
-                .tableNamePrefix("tbl")
-                .idColumnName("ID_COLUMN").idColumnType(props.getProperty("id.column.type"))
-                .dataColumnName("DATA_COLUMN").dataColumnType(props.getProperty("data.column.type"))
-                .timestampColumnName("TIMESTAMP_COLUMN").timestampColumnType(props.getProperty("timestamp.column.type"))
-                .connectionPool()
-                .driverClass(driverClass)
-                .connectionUrl(props.getProperty("connection.url"))
-                .username(props.getProperty("db.username"))
-                .password(props.getProperty("db.password"));
-        persistenceConfiguration.addProperty("infinispan.jdbc.upsert.disabled", props.getProperty("database.upsert.disabled"));
-    }
+   private void createPersistenceConfiguration(boolean passivation, boolean preload) {
+      Properties props = loadDBProperties();
+      driverClass = props.getProperty("driver.class");
+      configurationBuilder.memory().maxCount(2);
+      persistenceConfiguration = configurationBuilder
+            .persistence()
+            .passivation(passivation)
+            .addStore(JdbcStringBasedStoreConfigurationBuilder.class)
+            .segmented(false)
+            .preload(preload)
+            .table()
+            .createOnStart(true)
+            .tableNamePrefix("tbl")
+            .idColumnName("ID_COLUMN").idColumnType(props.getProperty("id.column.type"))
+            .dataColumnName("DATA_COLUMN").dataColumnType(props.getProperty("data.column.type"))
+            .timestampColumnName("TIMESTAMP_COLUMN").timestampColumnType(props.getProperty("timestamp.column.type"))
+            .connectionPool()
+            .driverClass(driverClass)
+            .connectionUrl(props.getProperty("connection.url"))
+            .username(props.getProperty("db.username"))
+            .password(props.getProperty("db.password"));
+      persistenceConfiguration.addProperty("infinispan.jdbc.upsert.disabled", props.getProperty("database.upsert.disabled"));
+   }
 
-    public PooledConnectionFactoryConfigurationBuilder<?> getPersistenceConfiguration() {
-        return this.persistenceConfiguration;
-    }
+   public PooledConnectionFactoryConfigurationBuilder<?> getPersistenceConfiguration() {
+      return this.persistenceConfiguration;
+   }
 
-    public DefaultCacheManager getCacheManager() {
-        ConfigurationBuilderHolder holder = new ConfigurationBuilderHolder();
-        holder.global().nonClusteredDefault().defaultCacheName(CACHE_NAME);
-        holder.newConfigurationBuilder(CACHE_NAME).read(configurationBuilder.build());
-        return new DefaultCacheManager(holder);
-    }
+   public DefaultCacheManager getCacheManager() {
+      ConfigurationBuilderHolder holder = new ConfigurationBuilderHolder();
+      holder.global().nonClusteredDefault().defaultCacheName(CACHE_NAME);
+      holder.newConfigurationBuilder(CACHE_NAME).read(configurationBuilder.build());
+      return new DefaultCacheManager(holder);
+   }
 
-    private static Properties loadDBProperties() {
-        Properties props = new Properties();
-        try {
-            props.load(JdbcConfigurationUtil.class.getResourceAsStream("/connection.properties"));
-        } catch (IOException ioe) {
-            throw new RuntimeException("Unable to read DB properties");
-        }
-        return props;
-    }
+   private static Properties loadDBProperties() {
+      Properties props = new Properties();
+      try {
+         props.load(JdbcConfigurationUtil.class.getResourceAsStream("/connection.properties"));
+      } catch (IOException ioe) {
+         throw new RuntimeException("Unable to read DB properties");
+      }
+      return props;
+   }
 
 }

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/LegacyRestMetricsResourceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/LegacyRestMetricsResourceIT.java
@@ -26,8 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
-import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractDoubleAssert;
 import org.assertj.core.api.AbstractStringAssert;
@@ -44,6 +42,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
 
 
 /**
@@ -389,7 +390,7 @@ public class LegacyRestMetricsResourceIT {
          return addDescription(assertThat(value));
       }
 
-      private <T extends AbstractAssert<?,?>> T addDescription(T abstractAssert) {
+      private <T extends AbstractAssert<?, ?>> T addDescription(T abstractAssert) {
          abstractAssert.getWritableAssertionInfo().description("metric=%s, tags=%s", name, rawTags);
          return abstractAssert;
       }

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestMetricsResourceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestMetricsResourceIT.java
@@ -26,8 +26,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
-import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractDoubleAssert;
 import org.assertj.core.api.AbstractStringAssert;
@@ -43,6 +41,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.prometheus.metrics.expositionformats.OpenMetricsTextFormatWriter;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
 
 
 /**
@@ -388,7 +389,7 @@ public class RestMetricsResourceIT {
          return addDescription(assertThat(value));
       }
 
-      private <T extends AbstractAssert<?,?>> T addDescription(T abstractAssert) {
+      private <T extends AbstractAssert<?, ?>> T addDescription(T abstractAssert) {
          abstractAssert.getWritableAssertionInfo().description("metric=%s, tags=%s", name, rawTags);
          return abstractAssert;
       }

--- a/server/tests/src/test/java/org/infinispan/server/persistence/CustomNonBlockingStore.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/CustomNonBlockingStore.java
@@ -8,12 +8,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.encoding.DataConversion;
 import org.infinispan.persistence.spi.InitializationContext;
 import org.infinispan.persistence.spi.MarshallableEntry;
 import org.infinispan.persistence.spi.MarshallableEntryFactory;
 import org.infinispan.persistence.spi.NonBlockingStore;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 
 public class CustomNonBlockingStore implements NonBlockingStore<String, String> {
    private MarshallableEntryFactory<String, String> marshallableEntryFactory;

--- a/server/tests/src/test/java/org/infinispan/server/persistence/JdbcConfigurationUtil.java
+++ b/server/tests/src/test/java/org/infinispan/server/persistence/JdbcConfigurationUtil.java
@@ -2,63 +2,63 @@ package org.infinispan.server.persistence;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.IsolationLevel;
 import org.infinispan.persistence.jdbc.common.configuration.PooledConnectionFactoryConfigurationBuilder;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.server.test.core.persistence.Database;
-import org.infinispan.configuration.cache.IsolationLevel;
 
 public class JdbcConfigurationUtil {
 
-    private PooledConnectionFactoryConfigurationBuilder<?> persistenceConfiguration;
-    private final ConfigurationBuilder configurationBuilder;
-    private final CacheMode cacheMode;
+   private PooledConnectionFactoryConfigurationBuilder<?> persistenceConfiguration;
+   private final ConfigurationBuilder configurationBuilder;
+   private final CacheMode cacheMode;
 
-    public JdbcConfigurationUtil(CacheMode cacheMode, Database database, boolean passivation, boolean preload) {
-        configurationBuilder = new ConfigurationBuilder();
-        this.cacheMode = cacheMode;
-        createPersistenceConfiguration(database, passivation, preload);
-    }
+   public JdbcConfigurationUtil(CacheMode cacheMode, Database database, boolean passivation, boolean preload) {
+      configurationBuilder = new ConfigurationBuilder();
+      this.cacheMode = cacheMode;
+      createPersistenceConfiguration(database, passivation, preload);
+   }
 
-    private JdbcConfigurationUtil createPersistenceConfiguration(Database database, boolean passivation, boolean preload) {
-        persistenceConfiguration = configurationBuilder.clustering().cacheMode(cacheMode).hash().numOwners(1)
-                .persistence()
-                .passivation(passivation)
-                .addStore(JdbcStringBasedStoreConfigurationBuilder.class)
-                .shared(false)
-                .preload(preload)
-                .fetchPersistentState(true)
-                .table()
-                .dropOnExit(false)
-                .createOnStart(true)
-                .tableNamePrefix("tbl")
-                .idColumnName("id").idColumnType(database.getIdColumType())
-                .dataColumnName("data").dataColumnType(database.getDataColumnType())
-                .timestampColumnName("ts").timestampColumnType(database.getTimeStampColumnType())
-                .segmentColumnName("s").segmentColumnType(database.getSegmentColumnType())
-                .connectionPool()
-                .connectionUrl(database.jdbcUrl())
-                .username(database.username())
-                .password(database.password())
-                .driverClass(database.driverClassName());
-        return this;
-    }
+   private JdbcConfigurationUtil createPersistenceConfiguration(Database database, boolean passivation, boolean preload) {
+      persistenceConfiguration = configurationBuilder.clustering().cacheMode(cacheMode).hash().numOwners(1)
+            .persistence()
+            .passivation(passivation)
+            .addStore(JdbcStringBasedStoreConfigurationBuilder.class)
+            .shared(false)
+            .preload(preload)
+            .fetchPersistentState(true)
+            .table()
+            .dropOnExit(false)
+            .createOnStart(true)
+            .tableNamePrefix("tbl")
+            .idColumnName("id").idColumnType(database.getIdColumType())
+            .dataColumnName("data").dataColumnType(database.getDataColumnType())
+            .timestampColumnName("ts").timestampColumnType(database.getTimeStampColumnType())
+            .segmentColumnName("s").segmentColumnType(database.getSegmentColumnType())
+            .connectionPool()
+            .connectionUrl(database.jdbcUrl())
+            .username(database.username())
+            .password(database.password())
+            .driverClass(database.driverClassName());
+      return this;
+   }
 
-    public JdbcConfigurationUtil setLockingConfigurations() {
-        configurationBuilder.locking().isolationLevel(IsolationLevel.READ_COMMITTED).lockAcquisitionTimeout(20000).concurrencyLevel(500).useLockStriping(false);
-        return this;
-    }
+   public JdbcConfigurationUtil setLockingConfigurations() {
+      configurationBuilder.locking().isolationLevel(IsolationLevel.READ_COMMITTED).lockAcquisitionTimeout(20000).concurrencyLevel(500).useLockStriping(false);
+      return this;
+   }
 
-    public JdbcConfigurationUtil setEviction() {
-        configurationBuilder.memory().maxCount(2);
-        return this;
-    }
+   public JdbcConfigurationUtil setEviction() {
+      configurationBuilder.memory().maxCount(2);
+      return this;
+   }
 
-    public PooledConnectionFactoryConfigurationBuilder<?> getPersistenceConfiguration() {
-        return this.persistenceConfiguration;
-    }
+   public PooledConnectionFactoryConfigurationBuilder<?> getPersistenceConfiguration() {
+      return this.persistenceConfiguration;
+   }
 
-    public ConfigurationBuilder getConfigurationBuilder() {
-        return configurationBuilder;
-    }
+   public ConfigurationBuilder getConfigurationBuilder() {
+      return configurationBuilder;
+   }
 
 }

--- a/spring/spring-boot-3/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanJmxConfiguration.java
+++ b/spring/spring-boot-3/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanJmxConfiguration.java
@@ -1,11 +1,11 @@
 package org.infinispan.spring.starter.remote;
 
-import jakarta.annotation.PostConstruct;
-
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jmx.export.MBeanExporter;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * Spring and Infinispan register the same bean. Avoid an exception telling Spring not to export Infinispan's

--- a/spring/spring-boot-3/remote/src/test/java/test/org/infinispan/spring/starter/remote/ApplicationYamlTest.java
+++ b/spring/spring-boot-3/remote/src/test/java/test/org/infinispan/spring/starter/remote/ApplicationYamlTest.java
@@ -1,5 +1,16 @@
 package test.org.infinispan.spring.starter.remote;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.RealmCallback;
+
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ClientIntelligence;
@@ -20,16 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.sasl.RealmCallback;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
 
 @SpringBootTest(
       classes = {

--- a/spring/spring-boot-3/remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
+++ b/spring/spring-boot-3/remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
@@ -9,6 +9,7 @@ import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConf
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import test.org.infinispan.spring.starter.remote.testconfiguration.InfinispanCacheTestConfiguration;
 
 @SpringBootTest(

--- a/spring/spring-boot-3/remote/src/test/java/test/org/infinispan/spring/starter/remote/actuator/RemoteCacheMeterBinderProviderTest.java
+++ b/spring/spring-boot-3/remote/src/test/java/test/org/infinispan/spring/starter/remote/actuator/RemoteCacheMeterBinderProviderTest.java
@@ -1,6 +1,8 @@
 package test.org.infinispan.spring.starter.remote.actuator;
 
-import io.micrometer.core.instrument.binder.MeterBinder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.commons.api.BasicCache;
@@ -8,9 +10,7 @@ import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.spring.starter.remote.actuator.RemoteInfinispanCacheMeterBinderProvider;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import io.micrometer.core.instrument.binder.MeterBinder;
 
 public class RemoteCacheMeterBinderProviderTest {
 

--- a/spring/spring-boot-4/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanJmxConfiguration.java
+++ b/spring/spring-boot-4/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanJmxConfiguration.java
@@ -1,11 +1,11 @@
 package org.infinispan.spring.starter.remote;
 
-import jakarta.annotation.PostConstruct;
-
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jmx.export.MBeanExporter;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * Spring and Infinispan register the same bean. Avoid an exception telling Spring not to export Infinispan's

--- a/spring/spring-boot-4/remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
+++ b/spring/spring-boot-4/remote/src/test/java/test/org/infinispan/spring/starter/remote/IntegrationTest.java
@@ -9,6 +9,7 @@ import org.infinispan.spring.starter.remote.InfinispanRemoteCacheManagerAutoConf
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
 import test.org.infinispan.spring.starter.remote.testconfiguration.InfinispanCacheTestConfiguration;
 
 @SpringBootTest(


### PR DESCRIPTION
## Summary
- Adds `spotless-maven-plugin` 2.44.4 to `<pluginManagement>` and `<build><plugins>`, configured with:
  - Import ordering matching checkstyle rules (static first, then `java`, `javax`, `org`, `com`, then everything else)
  - Indentation enforcement (3 spaces, no tabs) matching `.editorconfig`
  - Unused import removal
  - Trailing whitespace trimming
  - End-with-newline enforcement
  - `@formatter:off` / `@formatter:on` support via `toggleOffOn`
- Adds `spotless.skip` property so modules can opt out

Closes #16793