### PR TITLE
[#15890] Fix flaky access logging tests across all protocols

### DIFF
--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAccessLoggingTest.java
@@ -40,6 +40,11 @@ public class HotRodAccessLoggingTest extends HotRodSingleNodeTest {
 
       server().getTransport().stop();
 
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      eventually(() -> "Expected 2 log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= 2);
+
       String logline = logAppender.get(1);
       assertTrue(logline, logline.matches(
             "^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"PUT /" +

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAuthAccessLoggingTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/logging/HotRodAuthAccessLoggingTest.java
@@ -58,6 +58,12 @@ public class HotRodAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
          }
       }
 
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      int expectedLogs = 17;
+      eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= expectedLogs);
+
       int i = 0;
       // Initial client PING
       assertThat(parseAccessLog(i++)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HOTROD/2.1", "METHOD", "PING", "STATUS", "OK", "WHO", "-"));

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/logging/MemcachedAccessLoggingTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/logging/MemcachedAccessLoggingTest.java
@@ -42,6 +42,11 @@ public class MemcachedAccessLoggingTest extends MemcachedSingleNodeTest {
 
       server.getTransport().stop();
 
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      eventually(() -> "Expected 1 log entry, got " + logAppender.size(),
+            () -> logAppender.size() >= 1);
+
       String logline = logAppender.get(0);
       assertTrue(logline, logline.matches(
             "^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"set /key MCTXT\" OK \\d+ \\d+ \\d+$"));

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/logging/MemcachedBinaryAuthAccessLoggingTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/logging/MemcachedBinaryAuthAccessLoggingTest.java
@@ -18,6 +18,12 @@ public class MemcachedBinaryAuthAccessLoggingTest extends MemcachedBaseAuthAcces
 
    @Override
    protected void verifyLogs() {
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      int expectedLogs = 11;
+      eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= expectedLogs);
+
       int i = 0;
       // Unauthenticated SET
       assertThat(parseAccessLog(i++)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "MCBIN", "METHOD", "SET", "STATUS", "\"Forbidden\"", "WHO", "-"));

--- a/server/memcached/src/test/java/org/infinispan/server/memcached/logging/MemcachedTextAuthAccessLoggingTest.java
+++ b/server/memcached/src/test/java/org/infinispan/server/memcached/logging/MemcachedTextAuthAccessLoggingTest.java
@@ -18,6 +18,12 @@ public class MemcachedTextAuthAccessLoggingTest extends MemcachedBaseAuthAccessL
 
    @Override
    protected void verifyLogs() {
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      int expectedLogs = 11;
+      eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= expectedLogs);
+
       int i = 0;
       assertThat(parseAccessLog(i++)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "MCTXT", "METHOD", "auth", "STATUS", "\"CLIENT_ERROR authentication failed: Wrong credentials\"", "WHO", "-"));
       assertThat(parseAccessLog(i++)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "MCTXT", "METHOD", "get", "STATUS", "\"CLIENT_ERROR authentication failed: Forbidden\"", "WHO", "-"));

--- a/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAuthAccessLoggingTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAuthAccessLoggingTest.java
@@ -89,6 +89,12 @@ public class RespAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
          }
       }
 
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      int expectedLogs = 12;
+      eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= expectedLogs);
+
       int i = 0;
 
       assertThat(parseAccessLog(i++)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "RESP", "METHOD", "HELLO", "STATUS", "\"" + Messages.MESSAGES.noAuthHello() + "\"", "WHO", "-"));

--- a/server/rest/src/test/java/org/infinispan/rest/logging/RestAccessLoggingTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/logging/RestAccessLoggingTest.java
@@ -67,6 +67,11 @@ public class RestAccessLoggingTest extends SingleCacheManagerTest {
 
       restServer.stop();
 
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      eventually(() -> "Expected 1 log entry, got " + logAppender.size(),
+            () -> logAppender.size() >= 1);
+
       String logline = logAppender.get(0);
 
       String regex = String.format("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d+] \"PUT /rest/v2/caches/default/key HTTP/1\\.1\" 404 \\d+ \\d+ \\d+ %s/\\p{Graph}+$", System.getProperty("infinispan.brand.name"));

--- a/server/rest/src/test/java/org/infinispan/rest/logging/RestAuthAccessLoggingTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/logging/RestAuthAccessLoggingTest.java
@@ -56,7 +56,13 @@ public class RestAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
       }
       restServer.stop();
 
-      assertEquals(14, logAppender.size());
+      // Access log entries are written asynchronously via ChannelFuture listeners.
+      // Wait for all expected entries to arrive before asserting.
+      int expectedLogs = 14;
+      eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= expectedLogs);
+
+      assertEquals(expectedLogs, logAppender.size());
 
       // ANONYMOUS PUT
       assertThat(parseAccessLog(0)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "401", "WHO", "-"));


### PR DESCRIPTION
## Summary
- Access log entries are written asynchronously via `ChannelFuture` listeners. Tests were asserting on log entries immediately after performing operations, before all async listeners had fired.
- Added `eventually()` waits for expected log entries to arrive before asserting in all affected access logging tests.

### Tests fixed
| Test | Issue |
|------|-------|
| `HotRodAuthAccessLoggingTest` | No wait, no transport stop — immediate assertion failure |
| `RespAuthAccessLoggingTest` | No wait, no transport stop — immediate assertion failure |
| `MemcachedBinaryAuthAccessLoggingTest` | No wait, no transport stop — immediate assertion failure |
| `MemcachedTextAuthAccessLoggingTest` | No wait, no transport stop — immediate assertion failure |
| `RestAuthAccessLoggingTest` | Transport stop but no `eventually()` wait |
| `HotRodAccessLoggingTest` | Transport stop but no `eventually()` wait |
| `MemcachedAccessLoggingTest` | Transport stop but no `eventually()` wait |
| `RestAccessLoggingTest` | Transport stop but no `eventually()` wait |

## Test plan
- [ ] Run all access logging tests repeatedly to confirm flaky failures no longer reproduce