### PR TITLE
[#16855] Flaky PooledConnectionIT test

### DIFF
--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/stringbased/PooledConnectionIT.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/stringbased/PooledConnectionIT.java
@@ -1,6 +1,7 @@
 package org.infinispan.test.integration.persistence.jdbc.stringbased;
 
 import static org.infinispan.test.integration.persistence.jdbc.util.JdbcConfigurationUtil.CACHE_NAME;
+import static org.infinispan.testing.Eventually.eventually;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -42,14 +43,16 @@ public class PooledConnectionIT {
             cache.put("k3", "v3");
             //now some key is evicted and stored in store
             assertEquals(2, getNumberOfEntriesInMemory(cache));
-            // TODO: need to fix this later, for some reason this fails on Oracle but passes on other DBs
-//            assertEquals(1, table.countAllRows());
+            // Passivation will happen asynchronously.
+            eventually(() -> table.countAllRows() == 1);
 
             cache.stop();
             cache.start();
 
             assertEquals(3, cache.size());
             assertEquals("v1", cache.get("k1"));
+            assertEquals(2, getNumberOfEntriesInMemory(cache));
+            assertEquals(3, table.countAllRows());
             assertCleanCacheAndStore(cache);
         }
     }

--- a/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/TableManipulation.java
+++ b/integrationtests/server-integration/server-integration-commons/src/test/java/org/infinispan/test/integration/persistence/jdbc/util/TableManipulation.java
@@ -66,6 +66,20 @@ public class TableManipulation implements AutoCloseable {
       }
    }
 
+   public int countAllRows() {
+      connection = getConnection();
+      try (PreparedStatement ps = connection.prepareStatement(countRowsSql);
+           ResultSet rs = ps.executeQuery()) {
+         if (rs.next()) {
+            return rs.getInt(1);
+         } else {
+            throw new IllegalStateException(countRowsSql + " returned no rows");
+         }
+      } catch (SQLException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
    public String getEncodedKey(String key) throws Exception {
       ProtoStreamMarshaller protoStreamMarshaller = new ProtoStreamMarshaller();
       byte[] marshalled = protoStreamMarshaller.objectToByteBuffer(key);

--- a/integrationtests/server-integration/third-party-server/pom.xml
+++ b/integrationtests/server-integration/third-party-server/pom.xml
@@ -56,6 +56,16 @@
       </repository>
    </repositories>
 
+   <dependencyManagement>
+      <dependencies>
+         <dependency>
+            <groupId>org.jboss.weld.servlet</groupId>
+            <artifactId>weld-servlet-core</artifactId>
+            <version>${version.weld-servlet}</version>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
    <dependencies>
       <dependency>
          <groupId>org.infinispan</groupId>

--- a/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/persistence/jdbc/stringbased/PooledConnectionDeployIT.java
+++ b/integrationtests/server-integration/third-party-server/src/test/java/org/infinispan/test/integration/thirdparty/persistence/jdbc/stringbased/PooledConnectionDeployIT.java
@@ -6,6 +6,7 @@ import org.infinispan.test.integration.persistence.jdbc.stringbased.PooledConnec
 import org.infinispan.test.integration.persistence.jdbc.util.JdbcConfigurationUtil;
 import org.infinispan.test.integration.persistence.jdbc.util.TableManipulation;
 import org.infinispan.test.integration.thirdparty.DeploymentHelper;
+import org.infinispan.testing.Eventually;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
@@ -23,6 +24,8 @@ public class PooledConnectionDeployIT extends PooledConnectionIT {
         war.addClass(PooledConnectionIT.class);
         war.addClass(TableManipulation.class);
         war.addClass(JdbcConfigurationUtil.class);
+        war.addClass(Eventually.class);
+        war.addClass(Eventually.Condition.class);
         addJdbcLibraries(war);
         return war;
     }

--- a/integrationtests/server-integration/third-party-server/src/test/resources/arquillian.xml
+++ b/integrationtests/server-integration/third-party-server/src/test/resources/arquillian.xml
@@ -20,6 +20,7 @@
                 <property name="javaVmArguments">
                     --add-opens=java.base/java.util=ALL-UNNAMED
                     --add-opens=java.base/java.lang=ALL-UNNAMED
+                    --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
                     -Dinfinispan.server.integration.data-source=${infinispan.server.integration.data-source}
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind.address=localhost
@@ -41,6 +42,7 @@
                 <property name="javaVmArguments">
                     --add-opens=java.base/java.util=ALL-UNNAMED
                     --add-opens=java.base/java.lang=ALL-UNNAMED
+                    --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED
                     -Dinfinispan.server.integration.data-source=${infinispan.server.integration.data-source}
                     -Djava.net.preferIPv4Stack=true
                     -Djgroups.bind.address=localhost


### PR DESCRIPTION
* Passivation happens asynchronously, so the row is written in the database after some time.
* Assert all data is in the store after restart.

I've also included some fixes for when deploying with Tomcat.

Close #16855.