### PR TITLE
[#16154] Implement LOCALUSER HTTP authentication mechanism

### DIFF
--- a/cli/src/main/java/org/infinispan/cli/connection/rest/RestConnector.java
+++ b/cli/src/main/java/org/infinispan/cli/connection/rest/RestConnector.java
@@ -21,14 +21,14 @@ import org.kohsuke.MetaInfServices;
  **/
 @MetaInfServices
 public class RestConnector implements Connector {
-   private final Pattern HOST_PORT = Pattern.compile("(\\[[0-9A-Fa-f:]+\\]|[^:/?#]*)(?::(\\d*))");
+   private final Pattern HOST_PORT = Pattern.compile("(\\[[0-9A-Fa-f:]+]|[^:/?#]*):(\\d*)");
 
    @Override
    public Connection getConnection(Properties properties, String connectionString, SSLContextSettings sslContextSettings) {
       try {
          RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder().withProperties(properties);
          if (connectionString == null || connectionString.isEmpty() || "-".equals(connectionString)) {
-            builder.addServer().host("localhost").port(11222);
+            builder.addServer().host("localhost").port(11222).security().authentication().enable();
          } else {
             Matcher matcher = HOST_PORT.matcher(connectionString);
             if (matcher.matches()) {

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/AutoDetectAuthenticator.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/AutoDetectAuthenticator.java
@@ -1,24 +1,47 @@
 package org.infinispan.client.rest.impl.jdk.auth;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.client.rest.configuration.AuthenticationConfiguration;
 
 public class AutoDetectAuthenticator extends HttpAuthenticator {
-   private final BasicAuthenticator basic;
-   private final BearerAuthenticator bearer;
-   private final DigestAuthenticator digest;
-   private final NegotiateAuthenticator negotiate;
+   private final Map<String, HttpAuthenticator> authenticatorMap;
+   // Tracks the authenticator that completed a successful exchange, so we only
+   // preauthenticate with the mechanism the server actually supports.
+   private volatile HttpAuthenticator activeAuthenticator;
 
    public AutoDetectAuthenticator(HttpClient client, AuthenticationConfiguration configuration) {
       super(client, configuration);
-      basic = new BasicAuthenticator(client, configuration);
-      bearer = new BearerAuthenticator(client, configuration);
-      digest = new DigestAuthenticator(client, configuration);
-      negotiate = new NegotiateAuthenticator(client, configuration);
+      authenticatorMap = new LinkedHashMap<>();
+      if (configuration.username() != null && configuration.password() != null) {
+         authenticatorMap.put("Digest", new DigestAuthenticator(client, configuration));
+         authenticatorMap.put("Basic", new BasicAuthenticator(client, configuration));
+      }
+      if (configuration.username() != null) {
+         authenticatorMap.put("Bearer", new BearerAuthenticator(client, configuration));
+      }
+      authenticatorMap.put("Negotiate", new NegotiateAuthenticator(client, configuration));
+      authenticatorMap.put("Localuser", new LocalUserAuthenticator(client, configuration));
+   }
+
+   @Override
+   public boolean supportsPreauthentication() {
+      HttpAuthenticator active = activeAuthenticator;
+      return active != null && active.supportsPreauthentication();
+   }
+
+   @Override
+   public HttpRequest.Builder preauthenticate(HttpRequest.Builder request) {
+      if (supportsPreauthentication()) {
+         return activeAuthenticator.preauthenticate(request);
+      }
+      return request;
    }
 
    @Override
@@ -26,16 +49,11 @@ public class AutoDetectAuthenticator extends HttpAuthenticator {
       List<String> headers = response.headers().allValues(WWW_AUTH);
       for (String header : headers) {
          int space = header.indexOf(' ');
-         String mech = header.substring(0, space);
-         switch (mech) {
-            case "Digest":
-               return digest.authenticate(response, bodyHandler);
-            case "Basic":
-               return basic.authenticate(response, bodyHandler);
-            case "Bearer":
-               return bearer.authenticate(response, bodyHandler);
-            case "Negotiate":
-               return negotiate.authenticate(response, bodyHandler);
+         String mech = space >= 0 ? header.substring(0, space) : header;
+         HttpAuthenticator authenticator = authenticatorMap.get(mech);
+         if (authenticator != null) {
+            activeAuthenticator = authenticator;
+            return authenticator.authenticate(response, bodyHandler);
          }
       }
       return null;

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/AutoDetectAuthenticator.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/AutoDetectAuthenticator.java
@@ -1,24 +1,47 @@
 package org.infinispan.client.rest.impl.jdk.auth;
 
 import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
 import org.infinispan.client.rest.configuration.AuthenticationConfiguration;
 
 public class AutoDetectAuthenticator extends HttpAuthenticator {
-   private final BasicAuthenticator basic;
-   private final BearerAuthenticator bearer;
-   private final DigestAuthenticator digest;
-   private final NegotiateAuthenticator negotiate;
+   private final Map<String, HttpAuthenticator> authenticatorMap;
+   // Tracks the authenticator that completed a successful exchange, so we only
+   // preauthenticate with the mechanism the server actually supports.
+   private volatile HttpAuthenticator activeAuthenticator;
 
    public AutoDetectAuthenticator(HttpClient client, AuthenticationConfiguration configuration) {
       super(client, configuration);
-      basic = new BasicAuthenticator(client, configuration);
-      bearer = new BearerAuthenticator(client, configuration);
-      digest = new DigestAuthenticator(client, configuration);
-      negotiate = new NegotiateAuthenticator(client, configuration);
+      authenticatorMap = new LinkedHashMap<>();
+      if (configuration.username() != null && configuration.password() != null) {
+         authenticatorMap.put("Digest", new DigestAuthenticator(client, configuration));
+         authenticatorMap.put("Basic", new BasicAuthenticator(client, configuration));
+      }
+      if (configuration.username() != null) {
+         authenticatorMap.put("Bearer", new BearerAuthenticator(client, configuration));
+      }
+      authenticatorMap.put("Negotiate", new NegotiateAuthenticator(client, configuration));
+      authenticatorMap.put("Localuser", new LocalUserAuthenticator(client, configuration));
+   }
+
+   @Override
+   public boolean supportsPreauthentication() {
+      HttpAuthenticator active = activeAuthenticator;
+      return active != null && active.supportsPreauthentication();
+   }
+
+   @Override
+   public HttpRequest.Builder preauthenticate(HttpRequest.Builder request) {
+      if (supportsPreauthentication()) {
+         return activeAuthenticator.preauthenticate(request);
+      }
+      return request;
    }
 
    @Override
@@ -26,16 +49,16 @@ public class AutoDetectAuthenticator extends HttpAuthenticator {
       List<String> headers = response.headers().allValues(WWW_AUTH);
       for (String header : headers) {
          int space = header.indexOf(' ');
-         String mech = header.substring(0, space);
-         switch (mech) {
-            case "Digest":
-               return digest.authenticate(response, bodyHandler);
-            case "Basic":
-               return basic.authenticate(response, bodyHandler);
-            case "Bearer":
-               return bearer.authenticate(response, bodyHandler);
-            case "Negotiate":
-               return negotiate.authenticate(response, bodyHandler);
+         String mech = space >= 0 ? header.substring(0, space) : header;
+         HttpAuthenticator authenticator = authenticatorMap.get(mech);
+         if (authenticator != null) {
+            return authenticator.authenticate(response, bodyHandler)
+                  .thenApply(r -> {
+                     if (r.statusCode() != 401) {
+                        activeAuthenticator = authenticator;
+                     }
+                     return r;
+                  });
          }
       }
       return null;

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/BasicAuthenticator.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/BasicAuthenticator.java
@@ -15,12 +15,12 @@ public class BasicAuthenticator extends HttpAuthenticator {
 
    public BasicAuthenticator(HttpClient client, AuthenticationConfiguration configuration) {
       super(client, configuration);
-      authzValue = basic(configuration.username(), new String(configuration.password()));
+      authzValue = (configuration.username() != null && configuration.password() != null) ? basic(configuration.username(), new String(configuration.password())) : null;
    }
 
    @Override
    public boolean supportsPreauthentication() {
-      return true;
+      return authzValue != null;
    }
 
    @Override
@@ -32,7 +32,7 @@ public class BasicAuthenticator extends HttpAuthenticator {
    public <T> CompletionStage<HttpResponse<T>> authenticate(HttpResponse<T> response, HttpResponse.BodyHandler<?> bodyHandler) {
       HttpRequest request = response.request();
       List<String> authorization = request.headers().allValues(WWW_AUTH_RESP);
-      if (!authorization.isEmpty() && authorization.get(0).startsWith("Basic")) {
+      if (authzValue == null || !authorization.isEmpty() && authorization.get(0).startsWith("Basic")) {
          // We have already attempted to authenticate, fail
          return null;
       }

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/LocalUserAuthenticator.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/LocalUserAuthenticator.java
@@ -1,0 +1,120 @@
+package org.infinispan.client.rest.impl.jdk.auth;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.client.rest.configuration.AuthenticationConfiguration;
+import org.infinispan.commons.util.Util;
+
+/**
+ * Client-side authenticator for the LOCALUSER HTTP authentication mechanism.
+ * Performs a multi-round challenge-response flow:
+ * <ol>
+ *   <li>On 401 with {@code WWW-Authenticate: Localuser} (no filepath): send {@code Authorization: Localuser} to trigger challenge creation</li>
+ *   <li>On 401 with {@code WWW-Authenticate: Localuser <filepath>}: read the file, hex-encode the bytes, send {@code Authorization: Localuser <filepath> <hex_bytes>}</li>
+ * </ol>
+ *
+ * @since 16.2
+ */
+public class LocalUserAuthenticator extends HttpAuthenticator {
+   private static final String LOCALUSER_PREFIX = "Localuser";
+   private static final String SESSION_TOKEN_PREFIX = "token:";
+   private static final String SESSION_TOKEN_HEADER = "X-Localuser-Token";
+   private static final long MAX_CHALLENGE_FILE_SIZE = 1024;
+
+   // Guard against infinite retry loops
+   private int retryCount = 0;
+   private static final int MAX_RETRIES = 3;
+
+   private volatile String cachedToken;
+
+   public LocalUserAuthenticator(HttpClient client, AuthenticationConfiguration configuration) {
+      super(client, configuration);
+   }
+
+   @Override
+   public boolean supportsPreauthentication() {
+      return cachedToken != null;
+   }
+
+   @Override
+   public HttpRequest.Builder preauthenticate(HttpRequest.Builder request) {
+      String token = cachedToken;
+      if (token != null) {
+         request.header(WWW_AUTH_RESP, LOCALUSER_PREFIX + " " + SESSION_TOKEN_PREFIX + token);
+      }
+      return request;
+   }
+
+   @Override
+   public <T> CompletionStage<HttpResponse<T>> authenticate(HttpResponse<T> response, HttpResponse.BodyHandler<?> bodyHandler) {
+      // If the rejected request used a session token, invalidate it and restart
+      HttpRequest originalRequest = response.request();
+      String authHeader = originalRequest.headers().firstValue(WWW_AUTH_RESP).orElse(null);
+      if (authHeader != null && authHeader.contains(SESSION_TOKEN_PREFIX)) {
+         cachedToken = null;
+         retryCount = 0;
+      }
+
+      if (retryCount >= MAX_RETRIES) {
+         return null;
+      }
+      retryCount++;
+
+      List<String> wwwAuthHeaders = response.headers().allValues(WWW_AUTH);
+      String localuserHeader = null;
+      for (String header : wwwAuthHeaders) {
+         if (header.startsWith(LOCALUSER_PREFIX)) {
+            localuserHeader = header;
+            break;
+         }
+      }
+
+      if (localuserHeader == null) {
+         return null;
+      }
+
+      String token = localuserHeader.substring(LOCALUSER_PREFIX.length()).trim();
+
+      HttpRequest.Builder newRequest = copyRequest(originalRequest, (n, v) -> !n.equalsIgnoreCase(WWW_AUTH_RESP));
+
+      if (token.isEmpty()) {
+         // Round 1: send empty Localuser authorization to trigger challenge creation
+         newRequest.header(WWW_AUTH_RESP, LOCALUSER_PREFIX);
+      } else {
+         // Round 2: read challenge file and send back the bytes
+         try {
+            Path challengeFile = Path.of(token).toRealPath();
+            Path tempDir = Path.of(System.getProperty("java.io.tmpdir")).toRealPath();
+            if (!challengeFile.startsWith(tempDir)) {
+               throw new AuthenticationException("LOCALUSER challenge file is not in the temp directory: " + challengeFile);
+            }
+            long size = Files.size(challengeFile);
+            if (size > MAX_CHALLENGE_FILE_SIZE) {
+               throw new AuthenticationException("LOCALUSER challenge file exceeds maximum size: " + size);
+            }
+            byte[] challengeBytes = Files.readAllBytes(challengeFile);
+            String hexEncoded = Util.toHexString(challengeBytes);
+            newRequest.header(WWW_AUTH_RESP, LOCALUSER_PREFIX + " " + token + " " + hexEncoded);
+         } catch (IOException e) {
+            throw new AuthenticationException("Failed to read LOCALUSER challenge file: " + token, e);
+         }
+      }
+
+      return client.sendAsync(newRequest.build(), (HttpResponse.BodyHandler<T>) bodyHandler)
+            .thenApply(r -> {
+               if (r.statusCode() != 401) {
+                  retryCount = 0;
+                  r.headers().firstValue(SESSION_TOKEN_HEADER).ifPresent(t -> cachedToken = t);
+               }
+               return r;
+            });
+   }
+
+}

--- a/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/LocalUserAuthenticator.java
+++ b/client/rest-client/src/main/java/org/infinispan/client/rest/impl/jdk/auth/LocalUserAuthenticator.java
@@ -1,0 +1,120 @@
+package org.infinispan.client.rest.impl.jdk.auth;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.infinispan.client.rest.configuration.AuthenticationConfiguration;
+import org.infinispan.commons.util.Util;
+
+/**
+ * Client-side authenticator for the LOCALUSER HTTP authentication mechanism.
+ * Performs a multi-round challenge-response flow:
+ * <ol>
+ *   <li>On 401 with {@code WWW-Authenticate: Localuser} (no filepath): send {@code Authorization: Localuser} to trigger challenge creation</li>
+ *   <li>On 401 with {@code WWW-Authenticate: Localuser <filepath>}: read the file, hex-encode the bytes, send {@code Authorization: Localuser <filepath> <hex_bytes>}</li>
+ * </ol>
+ *
+ * @since 16.2
+ */
+public class LocalUserAuthenticator extends HttpAuthenticator {
+   private static final String LOCALUSER_PREFIX = "Localuser";
+   private static final String SESSION_TOKEN_PREFIX = "token:";
+   private static final String SESSION_TOKEN_HEADER = "X-Localuser-Token";
+   private static final long MAX_CHALLENGE_FILE_SIZE = 1024;
+
+   // Guard against infinite retry loops
+   private volatile int retryCount = 0;
+   private static final int MAX_RETRIES = 3;
+
+   private volatile String cachedToken;
+
+   public LocalUserAuthenticator(HttpClient client, AuthenticationConfiguration configuration) {
+      super(client, configuration);
+   }
+
+   @Override
+   public boolean supportsPreauthentication() {
+      return cachedToken != null;
+   }
+
+   @Override
+   public HttpRequest.Builder preauthenticate(HttpRequest.Builder request) {
+      String token = cachedToken;
+      if (token != null) {
+         request.header(WWW_AUTH_RESP, LOCALUSER_PREFIX + " " + SESSION_TOKEN_PREFIX + token);
+      }
+      return request;
+   }
+
+   @Override
+   public <T> CompletionStage<HttpResponse<T>> authenticate(HttpResponse<T> response, HttpResponse.BodyHandler<?> bodyHandler) {
+      // If the rejected request used a session token, invalidate it and restart
+      HttpRequest originalRequest = response.request();
+      String authHeader = originalRequest.headers().firstValue(WWW_AUTH_RESP).orElse(null);
+      if (authHeader != null && authHeader.contains(SESSION_TOKEN_PREFIX)) {
+         cachedToken = null;
+         retryCount = 0;
+      }
+
+      if (retryCount >= MAX_RETRIES) {
+         return null;
+      }
+      retryCount++;
+
+      List<String> wwwAuthHeaders = response.headers().allValues(WWW_AUTH);
+      String localuserHeader = null;
+      for (String header : wwwAuthHeaders) {
+         if (header.startsWith(LOCALUSER_PREFIX)) {
+            localuserHeader = header;
+            break;
+         }
+      }
+
+      if (localuserHeader == null) {
+         return null;
+      }
+
+      String token = localuserHeader.substring(LOCALUSER_PREFIX.length()).trim();
+
+      HttpRequest.Builder newRequest = copyRequest(originalRequest, (n, v) -> !n.equalsIgnoreCase(WWW_AUTH_RESP));
+
+      if (token.isEmpty()) {
+         // Round 1: send empty Localuser authorization to trigger challenge creation
+         newRequest.header(WWW_AUTH_RESP, LOCALUSER_PREFIX);
+      } else {
+         // Round 2: read challenge file and send back the bytes
+         try {
+            Path challengeFile = Path.of(token).toRealPath();
+            Path tempDir = Path.of(System.getProperty("java.io.tmpdir")).toRealPath();
+            if (!challengeFile.startsWith(tempDir)) {
+               throw new AuthenticationException("LOCALUSER challenge file is not in the temp directory: " + challengeFile);
+            }
+            long size = Files.size(challengeFile);
+            if (size > MAX_CHALLENGE_FILE_SIZE) {
+               throw new AuthenticationException("LOCALUSER challenge file exceeds maximum size: " + size);
+            }
+            byte[] challengeBytes = Files.readAllBytes(challengeFile);
+            String hexEncoded = Util.toHexString(challengeBytes);
+            newRequest.header(WWW_AUTH_RESP, LOCALUSER_PREFIX + " " + token + " " + hexEncoded);
+         } catch (IOException e) {
+            throw new AuthenticationException("Failed to read LOCALUSER challenge file: " + token, e);
+         }
+      }
+
+      return client.sendAsync(newRequest.build(), (HttpResponse.BodyHandler<T>) bodyHandler)
+            .thenApply(r -> {
+               if (r.statusCode() != 401) {
+                  retryCount = 0;
+                  r.headers().firstValue(SESSION_TOKEN_HEADER).ifPresent(t -> cachedToken = t);
+               }
+               return r;
+            });
+   }
+
+}

--- a/commons/all/src/main/java/org/infinispan/commons/util/NetworkAddress.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/NetworkAddress.java
@@ -113,7 +113,7 @@ public class NetworkAddress {
    }
 
    public static NetworkAddress nonLoopback(String name) throws IOException {
-      return new NetworkAddress(name, findAddress(a -> !a.getAddress().isLoopbackAddress()));
+      return new NetworkAddress(name, findAddress(a -> !a.getAddress().isLoopbackAddress() && !a.getAddress().isLinkLocalAddress()));
    }
 
    public static NetworkAddress siteLocal(String name) throws IOException {

--- a/commons/all/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Util.java
@@ -564,6 +564,16 @@ public final class Util {
       return String.valueOf(result);
    }
 
+   public static byte[] hexToBytes(String hex) {
+      int len = hex.length();
+      byte[] data = new byte[len / 2];
+      for (int i = 0; i < len; i += 2) {
+         data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
+               + Character.digit(hex.charAt(i + 1), 16));
+      }
+      return data;
+   }
+
    public static String padString(String s, int minWidth) {
       if (s.length() < minWidth) {
          StringBuilder sb = new StringBuilder(s);

--- a/commons/all/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/all/src/main/java/org/infinispan/commons/util/Util.java
@@ -564,6 +564,23 @@ public final class Util {
       return String.valueOf(result);
    }
 
+   public static byte[] hexToBytes(String hex) {
+      int len = hex.length();
+      if ((len & 1) != 0) {
+         throw new IllegalArgumentException("Odd-length hex string");
+      }
+      byte[] data = new byte[len / 2];
+      for (int i = 0; i < len; i += 2) {
+         int hi = Character.digit(hex.charAt(i), 16);
+         int lo = Character.digit(hex.charAt(i + 1), 16);
+         if ((hi | lo) < 0) {
+            throw new IllegalArgumentException("Invalid hex character at index " + (hi < 0 ? i : i + 1));
+         }
+         data[i / 2] = (byte) ((hi << 4) + lo);
+      }
+      return data;
+   }
+
    public static String padString(String s, int minWidth) {
       if (s.length() < minWidth) {
          StringBuilder sb = new StringBuilder(s);

--- a/documentation/src/main/asciidoc/stories/assembly_server_security_realms.adoc
+++ b/documentation/src/main/asciidoc/stories/assembly_server_security_realms.adoc
@@ -14,6 +14,7 @@ include::{topics}/ref_server_realm_token.adoc[leveloffset=+1]
 include::{topics}/ref_server_realm_trust.adoc[leveloffset=+1]
 include::{topics}/ref_server_realm_distributed.adoc[leveloffset=+1]
 include::{topics}/ref_server_realm_aggregate.adoc[leveloffset=+1]
+include::{topics}/ref_server_realm_local.adoc[leveloffset=+1]
 include::{topics}/ref_server_realm_caching.adoc[leveloffset=+1]
 
 // Restore the parent context.

--- a/documentation/src/main/asciidoc/topics/changes/changes_16_3.adoc
+++ b/documentation/src/main/asciidoc/topics/changes/changes_16_3.adoc
@@ -1,5 +1,20 @@
 == Upgrading from 16.2 to 16.3
 
+=== Security
+
+==== Local user authentication enabled by default
+
+The default server configurations now include a `local-realm` that enables the `LOCALUSER` HTTP authentication mechanism.
+This allows the CLI to authenticate automatically against a local {brandname} server without prompting for credentials, as long as the user running the CLI is the same system user that started the server.
+
+Authentication is restricted to loopback connections and relies on file-system permissions to verify that the client process runs as the same operating system user as the server.
+The authenticated user receives full administrative permissions.
+
+If your deployment does not require local CLI access, you can remove the `<local-realm/>` element from your server configuration.
+
+NOTE: The `LOCALUSER` mechanism requires a POSIX-compatible file system.
+On Windows, the mechanism is automatically disabled and a warning is logged.
+
 === Deprecations
 
 ==== InvocationBatchingConfiguration

--- a/documentation/src/main/asciidoc/topics/json/server_local_realm.json
+++ b/documentation/src/main/asciidoc/topics/json/server_local_realm.json
@@ -1,0 +1,11 @@
+{
+  "server": {
+    "security": {
+      "security-realms": [{
+        "name": "default",
+        "local-realm": {},
+        "properties-realm": {}
+      }]
+    }
+  }
+}

--- a/documentation/src/main/asciidoc/topics/ref_server_realm_local.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_server_realm_local.adoc
@@ -1,0 +1,30 @@
+[id='local-security-realms_{context}']
+= Local security realms
+
+A local security realm allows the CLI to authenticate against the local {brandname} instance without prompting the user
+for a username and password. This mechanism only works if the user running the CLI has read access to the server's
+temporary directory. This realm should always be used together with another realm, such as a `properties` realm.
+If the local mechanism fails then the CLI will fall back to prompting for a username and password
+for a user configured as in Default HTTP Interface Security.
+When authenticating with this realm, the user will have all permissions.
+
+[discrete]
+== Local realm configuration
+
+.XML
+[source,xml,options="nowrap",subs=attributes+,role="primary"]
+----
+include::xml/server_local_realm.xml[]
+----
+
+.JSON
+[source,json,options="nowrap",subs=attributes+,role="secondary"]
+----
+include::json/server_local_realm.json[]
+----
+
+.YAML
+[source,yaml,options="nowrap",subs=attributes+,role="secondary"]
+----
+include::yaml/server_local_realm.yaml[]
+----

--- a/documentation/src/main/asciidoc/topics/xml/server_local_realm.xml
+++ b/documentation/src/main/asciidoc/topics/xml/server_local_realm.xml
@@ -1,0 +1,10 @@
+<server xmlns="urn:infinispan:server:{schemaversion}">
+   <security>
+      <security-realms>
+         <security-realm name="default">
+            <local-realm/>
+            <properties-realm />
+         </security-realm>
+      </security-realms>
+   </security>
+</server>

--- a/documentation/src/main/asciidoc/topics/yaml/server_local_realm.yaml
+++ b/documentation/src/main/asciidoc/topics/yaml/server_local_realm.yaml
@@ -1,0 +1,6 @@
+server:
+  security:
+    securityRealms:
+      - name: "default"
+        localRealm: ~
+        propertiesRealm: ~

--- a/server/core/src/main/java/org/infinispan/server/core/transport/ConnectionMetadata.java
+++ b/server/core/src/main/java/org/infinispan/server/core/transport/ConnectionMetadata.java
@@ -24,6 +24,10 @@ public class ConnectionMetadata {
    private String cache;
 
    public static ConnectionMetadata getInstance(Channel channel) {
+      Channel parent = channel.parent();
+      if (parent != null && parent.remoteAddress() != null) {
+         channel = parent;
+      }
       ConnectionMetadata existing = channel.attr(METADATA).get();
       if (existing == null) {
          ConnectionMetadata metadata = new ConnectionMetadata(channel);
@@ -108,5 +112,20 @@ public class ConnectionMetadata {
 
    public void cache(String cache) {
       this.cache = cache;
+   }
+
+   @Override
+   public String toString() {
+      return "ConnectionMetadata{" +
+            "channel=" + channel +
+            ", id=" + id +
+            ", subject=" + subject +
+            ", clientName='" + clientName + '\'' +
+            ", clientLibName='" + clientLibName + '\'' +
+            ", clientLibVersion='" + clientLibVersion + '\'' +
+            ", protocolVersion='" + protocolVersion + '\'' +
+            ", created=" + created +
+            ", cache='" + cache + '\'' +
+            '}';
    }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/ALPNHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/ALPNHandler.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.infinispan.rest.configuration.RestServerConfiguration;
 import org.infinispan.server.core.ProtocolServer;
 import org.infinispan.server.core.transport.AccessControlFilter;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -106,6 +107,8 @@ public class ALPNHandler extends ApplicationProtocolNegotiationHandler {
       Http2MultiplexHandler multiplexCodec = new Http2MultiplexHandler(new ChannelInitializer<>() {
          @Override
          protected void initChannel(Channel channel) {
+            ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
+            metadata.protocolVersion("HTTP/2.0");
             // Creates the HTTP/2 pipeline, where each stream is handled by a sub-channel.
             ChannelPipeline p = channel.pipeline();
             p.addLast(new Http2StreamFrameToHttpObjectCodec(true));

--- a/server/rest/src/main/java/org/infinispan/rest/NettyRestRequest.java
+++ b/server/rest/src/main/java/org/infinispan/rest/NettyRestRequest.java
@@ -16,7 +16,6 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
 
@@ -86,13 +85,13 @@ public class NettyRestRequest implements RestRequest {
       this.context = getContext(this.path);
       List<String> action = queryStringDecoder.parameters().get("action");
       if (action != null) {
-         this.action = action.iterator().next();
+         this.action = action.getFirst();
       }
       this.contentSource = new ByteBufContentSource(request.content());
    }
 
    private String getContext(String path) {
-      if (path == null || path.isEmpty() || !path.startsWith("/") || path.length() == 1) return "";
+      if (path == null || !path.startsWith("/") || path.length() == 1) return "";
       int endIndex = path.indexOf("/", 1);
       return path.substring(1, endIndex == -1 ? path.length() : endIndex);
    }
@@ -128,7 +127,7 @@ public class NettyRestRequest implements RestRequest {
 
    @Override
    public Iterable<String> headersKeys() {
-      return request.headers().entries().stream().map(headerEntry -> headerEntry.getKey()).collect(Collectors.toList());
+      return request.headers().entries().stream().map(Map.Entry::getKey).toList();
    }
 
    @Override

--- a/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
+++ b/server/rest/src/main/java/org/infinispan/rest/RestRequestHandler.java
@@ -131,7 +131,9 @@ public class RestRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
       }
 
       ConnectionMetadata metadata = ConnectionMetadata.getInstance(ctx.channel());
-      metadata.protocolVersion(request.protocolVersion().text());
+      if (metadata.protocolVersion() == null) {
+         metadata.protocolVersion(request.protocolVersion().text());
+      }
       String userAgent = request.headers().get(HttpHeaderNames.USER_AGENT);
       if (userAgent != null) {
          metadata.clientLibraryName(userAgent);
@@ -156,7 +158,7 @@ public class RestRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
       }
 
       if (authenticator == null || isAnon(invocationLookup)) {
-         handleRestRequest(ctx, restRequest, invocationLookup);
+         handleRestRequest(ctx, restRequest, invocationLookup, null);
          return;
       }
       if (subject != null) {
@@ -167,7 +169,7 @@ public class RestRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
                logger.tracef("Authorization header match, skipping authentication for %s", request);
             }
             restRequest.setSubject(subject);
-            handleRestRequest(ctx, restRequest, invocationLookup);
+            handleRestRequest(ctx, restRequest, invocationLookup, null);
             return;
          } else {
             // Invalidate and force re-authentication
@@ -185,7 +187,7 @@ public class RestRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
             authorization = restRequest.getAuthorizationHeader();
             subject = restRequest.getSubject();
             metadata.subject(subject);
-            handleRestRequest(ctx, restRequest, invocationLookup);
+            handleRestRequest(ctx, restRequest, invocationLookup, (NettyRestResponse) authResponse);
          } else {
             try {
                if (hasError) {
@@ -205,12 +207,17 @@ public class RestRequestHandler extends SimpleChannelInboundHandler<FullHttpRequ
       return lookupResult.getInvocation().anonymous();
    }
 
-   private void handleRestRequest(ChannelHandlerContext ctx, NettyRestRequest restRequest, LookupResult invocationLookup) {
+   private void handleRestRequest(ChannelHandlerContext ctx, NettyRestRequest restRequest, LookupResult invocationLookup,
+                                   NettyRestResponse authResponse) {
       restServer.getRestDispatcher().dispatch(restRequest, invocationLookup).whenComplete((restResponse, throwable) -> {
          FullHttpRequest request = restRequest.getFullHttpRequest();
          try {
             if (throwable == null) {
                NettyRestResponse nettyRestResponse = (NettyRestResponse) restResponse;
+               if (authResponse != null) {
+                  authResponse.getResponse().headers().forEach(e ->
+                        nettyRestResponse.getResponse().headers().set(e.getKey(), e.getValue()));
+               }
                sendResponse(ctx, request, nettyRestResponse);
             } else {
                handleError(ctx, request, throwable);

--- a/server/rest/src/test/java/org/infinispan/rest/logging/RestAuthAccessLoggingTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/logging/RestAuthAccessLoggingTest.java
@@ -58,7 +58,10 @@ public class RestAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
 
       // Access log entries are written asynchronously via ChannelFuture listeners.
       // Wait for all expected entries to arrive before asserting.
-      int expectedLogs = 14;
+      // After the first successful auth exchange, the client preauthenticates subsequent
+      // requests (sends the Authorization header proactively), eliminating the 401
+      // round-trip on GET requests. This reduces the count from 14 to 11.
+      int expectedLogs = 11;
       eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
             () -> logAppender.size() >= expectedLogs);
 
@@ -72,26 +75,20 @@ public class RestAuthAccessLoggingTest extends AbstractAuthAccessLoggingTest {
       assertThat(parseAccessLog(2)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "401", "WHO", "-"));
       // WRITER PUT, AFTER AUTH
       assertThat(parseAccessLog(3)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "204", "WHO", "writer"));
-      // WRITER GET, BEFORE AUTH
-      assertThat(parseAccessLog(4)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "401", "WHO", "writer"));
-      // WRITER GET, AFTER AUTH
-      assertThat(parseAccessLog(5)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "200", "WHO", "writer"));
+      // WRITER GET, PREAUTHENTICATED
+      assertThat(parseAccessLog(4)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "200", "WHO", "writer"));
       // READER PUT, BEFORE AUTH
-      assertThat(parseAccessLog(6)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "401", "WHO", "-"));
+      assertThat(parseAccessLog(5)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "401", "WHO", "-"));
       // READER PUT, AFTER AUTH
-      assertThat(parseAccessLog(7)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "403", "WHO", "reader"));
-      // READER GET, BEFORE AUTH
-      assertThat(parseAccessLog(8)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "401", "WHO", "reader"));
-      // READER GET, AFTER AUTH
-      assertThat(parseAccessLog(9)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "404", "WHO", "reader"));
+      assertThat(parseAccessLog(6)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "403", "WHO", "reader"));
+      // READER GET, PREAUTHENTICATED
+      assertThat(parseAccessLog(7)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "404", "WHO", "reader"));
       // WRONG PUT, BEFORE AUTH
-      assertThat(parseAccessLog(10)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "401", "WHO", "-"));
+      assertThat(parseAccessLog(8)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "401", "WHO", "-"));
       // WRONG PUT, AFTER AUTH
-      assertThat(parseAccessLog(11)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "403", "WHO", "-"));
-      // WRONG GET, BEFORE AUTH
-      assertThat(parseAccessLog(12)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "401", "WHO", "-"));
-      // WRONG GET, AFTER AUTH
-      assertThat(parseAccessLog(13)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "403", "WHO", "-"));
+      assertThat(parseAccessLog(9)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "PUT", "STATUS", "403", "WHO", "-"));
+      // WRONG GET, PREAUTHENTICATED
+      assertThat(parseAccessLog(10)).containsAllEntriesOf(Map.of("IP", "127.0.0.1", "PROTOCOL", "HTTP/1.1", "METHOD", "GET", "STATUS", "403", "WHO", "-"));
    }
 
    private RestClient createRestClient(String username, String password) {

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -404,6 +404,7 @@
                </properties>
                <systemPropertyVariables>
                   <server.output.dir>${server.output.dir}</server.output.dir>
+                  <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
                </systemPropertyVariables>
             </configuration>
          </plugin>

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/endpoint/EndpointConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/endpoint/EndpointConfigurationBuilder.java
@@ -260,6 +260,12 @@ public class EndpointConfigurationBuilder implements Builder<EndpointConfigurati
                Server.log.debug("Enabled BASIC for HTTP");
             }
          }
+         if (securityRealm.hasFeature(ServerSecurityRealm.Feature.LOCAL)) {
+            authentication
+                  .enable()
+                  .addMechanisms("LOCALUSER");
+            Server.log.debug("Enabled LOCALUSER for HTTP");
+         }
          authentication.authenticator(new ElytronHTTPAuthenticator(authentication.securityRealm(), serverPrincipal, authentication.mechanisms()));
       }
    }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/AggregateRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/AggregateRealmConfigurationBuilder.java
@@ -65,7 +65,7 @@ public class AggregateRealmConfigurationBuilder implements RealmProviderBuilder<
    }
 
    @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return 1; // Must be the last
+   public int sortOrder() {
+      return SORT_PENULTIMATE;
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/DistributedRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/DistributedRealmConfigurationBuilder.java
@@ -53,7 +53,7 @@ public class DistributedRealmConfigurationBuilder implements RealmProviderBuilde
    }
 
    @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return 1; // Must be the last
+   public int sortOrder() {
+      return SORT_PENULTIMATE;
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/LdapRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/LdapRealmConfigurationBuilder.java
@@ -122,10 +122,6 @@ public class LdapRealmConfigurationBuilder implements RealmProviderBuilder<LdapR
       return this;
    }
 
-   @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return 0; // Irrelevant
-   }
 
    boolean isDirectVerificationEnabled() {
       Attribute<Boolean> attribute = attributes.attribute(LdapRealmConfiguration.DIRECT_EVIDENCE_VERIFICATION);

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/LocalRealmConfiguration.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/LocalRealmConfiguration.java
@@ -1,5 +1,8 @@
 package org.infinispan.server.configuration.security;
 
+import java.security.Principal;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Properties;
 
@@ -9,8 +12,15 @@ import org.infinispan.commons.configuration.attributes.ConfigurationElement;
 import org.infinispan.server.configuration.Attribute;
 import org.infinispan.server.configuration.Element;
 import org.infinispan.server.security.ServerSecurityRealm;
+import org.wildfly.security.auth.SupportLevel;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.authz.AuthorizationIdentity;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.evidence.Evidence;
 
 /**
  * @since 10.0
@@ -33,11 +43,64 @@ public class LocalRealmConfiguration extends ConfigurationElement<LocalRealmConf
 
    @Override
    public SecurityRealm build(SecurityConfiguration securityConfiguration, RealmConfiguration realm, SecurityDomain.Builder domainBuilder, Properties properties) {
-      return null;
+      String localUser = name();
+      return new SecurityRealm() {
+         @Override
+         public RealmIdentity getRealmIdentity(Principal principal) throws RealmUnavailableException {
+            return new RealmIdentity() {
+               @Override
+               public Principal getRealmIdentityPrincipal() {
+                  return principal;
+               }
+
+               @Override
+               public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) {
+                  return SupportLevel.UNSUPPORTED;
+               }
+
+               @Override
+               public <C extends Credential> C getCredential(Class<C> credentialType) {
+                  return null;
+               }
+
+               @Override
+               public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) {
+                  return SupportLevel.UNSUPPORTED;
+               }
+
+               @Override
+               public boolean verifyEvidence(Evidence evidence) {
+                  return false;
+               }
+
+               @Override
+               public boolean exists() {
+                  return true;
+               }
+
+               @Override
+               public AuthorizationIdentity getAuthorizationIdentity() {
+                  MapAttributes attrs = new MapAttributes();
+                  attrs.addAll("Roles", Collections.singletonList("admin"));
+                  return AuthorizationIdentity.basicIdentity(attrs);
+               }
+            };
+         }
+
+         @Override
+         public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) {
+            return SupportLevel.UNSUPPORTED;
+         }
+
+         @Override
+         public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) {
+            return SupportLevel.UNSUPPORTED;
+         }
+      };
    }
 
    @Override
    public void applyFeatures(EnumSet<ServerSecurityRealm.Feature> features) {
-      // Nothing to do
+      features.add(ServerSecurityRealm.Feature.LOCAL);
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/LocalRealmConfiguration.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/LocalRealmConfiguration.java
@@ -1,5 +1,8 @@
 package org.infinispan.server.configuration.security;
 
+import java.security.Principal;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Properties;
 
@@ -9,8 +12,15 @@ import org.infinispan.commons.configuration.attributes.ConfigurationElement;
 import org.infinispan.server.configuration.Attribute;
 import org.infinispan.server.configuration.Element;
 import org.infinispan.server.security.ServerSecurityRealm;
+import org.wildfly.security.auth.SupportLevel;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.authz.AuthorizationIdentity;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.evidence.Evidence;
 
 /**
  * @since 10.0
@@ -33,11 +43,64 @@ public class LocalRealmConfiguration extends ConfigurationElement<LocalRealmConf
 
    @Override
    public SecurityRealm build(SecurityConfiguration securityConfiguration, RealmConfiguration realm, SecurityDomain.Builder domainBuilder, Properties properties) {
-      return null;
+      String localUser = name();
+      return new SecurityRealm() {
+         @Override
+         public RealmIdentity getRealmIdentity(Principal principal) throws RealmUnavailableException {
+            return new RealmIdentity() {
+               @Override
+               public Principal getRealmIdentityPrincipal() {
+                  return principal;
+               }
+
+               @Override
+               public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) {
+                  return SupportLevel.UNSUPPORTED;
+               }
+
+               @Override
+               public <C extends Credential> C getCredential(Class<C> credentialType) {
+                  return null;
+               }
+
+               @Override
+               public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) {
+                  return SupportLevel.UNSUPPORTED;
+               }
+
+               @Override
+               public boolean verifyEvidence(Evidence evidence) {
+                  return false;
+               }
+
+               @Override
+               public boolean exists() {
+                  return "$local".equals(principal.getName());
+               }
+
+               @Override
+               public AuthorizationIdentity getAuthorizationIdentity() {
+                  MapAttributes attrs = new MapAttributes();
+                  attrs.addAll("Roles", Collections.singletonList("admin"));
+                  return AuthorizationIdentity.basicIdentity(attrs);
+               }
+            };
+         }
+
+         @Override
+         public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) {
+            return SupportLevel.UNSUPPORTED;
+         }
+
+         @Override
+         public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) {
+            return SupportLevel.UNSUPPORTED;
+         }
+      };
    }
 
    @Override
    public void applyFeatures(EnumSet<ServerSecurityRealm.Feature> features) {
-      // Nothing to do
+      features.add(ServerSecurityRealm.Feature.LOCAL);
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/LocalRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/LocalRealmConfigurationBuilder.java
@@ -42,7 +42,7 @@ public class LocalRealmConfigurationBuilder implements RealmProviderBuilder<Loca
    }
 
    @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return 0; // Irrelevant
+   public int sortOrder() {
+      return SORT_LAST;
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/PropertiesRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/PropertiesRealmConfigurationBuilder.java
@@ -64,7 +64,7 @@ public class PropertiesRealmConfigurationBuilder implements RealmProviderBuilder
    }
 
    @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return 0; // Irrelevant
+   public int sortOrder() {
+      return SORT_PENULTIMATE;
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/RealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/RealmConfigurationBuilder.java
@@ -112,7 +112,7 @@ public class RealmConfigurationBuilder implements Builder<RealmConfiguration> {
       serverIdentitiesConfiguration.validate();
       Set<String> names = new HashSet<>();
       for(RealmProviderBuilder<?> builder : builders) {
-         if (names.contains(builder.name())) {
+         if (!names.add(builder.name())) {
             throw Server.log.duplicateRealm(builder.name());
          }
          builder.validate();

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/RealmProviderBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/RealmProviderBuilder.java
@@ -7,5 +7,19 @@ import org.infinispan.commons.configuration.Builder;
  * @since 13.0
  **/
 public interface RealmProviderBuilder<T extends RealmProvider> extends Builder<T>, Comparable<RealmProviderBuilder> {
+   int SORT_FIRST = -10;
+   int SORT_DEFAULT = 0;
+   int SORT_PENULTIMATE = 10;
+   int SORT_LAST = 20;
+
    String name();
+
+   default int sortOrder() {
+      return SORT_DEFAULT;
+   }
+
+   @Override
+   default int compareTo(RealmProviderBuilder o) {
+      return Integer.compare(sortOrder(), o.sortOrder());
+   }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/TokenRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/TokenRealmConfigurationBuilder.java
@@ -83,8 +83,4 @@ public class TokenRealmConfigurationBuilder implements RealmProviderBuilder<Toke
       return this;
    }
 
-   @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return 0; // Irrelevant
-   }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/configuration/security/TrustStoreRealmConfigurationBuilder.java
+++ b/server/runtime/src/main/java/org/infinispan/server/configuration/security/TrustStoreRealmConfigurationBuilder.java
@@ -42,7 +42,7 @@ public class TrustStoreRealmConfigurationBuilder implements RealmProviderBuilder
    }
 
    @Override
-   public int compareTo(RealmProviderBuilder o) {
-      return -1; // Must be the first
+   public int sortOrder() {
+      return SORT_FIRST;
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/logging/Log.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/Log.java
@@ -291,4 +291,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Malformed entry in user properties file at line %d", id = 80076)
    IllegalStateException malformedUserProperties(int line);
+
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(value = "LOCALUSER authentication mechanism disabled: the filesystem does not support POSIX file permissions", id = 80077)
+   void localUserDisabledNoPosix();
 }

--- a/server/runtime/src/main/java/org/infinispan/server/security/ElytronHTTPAuthenticator.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/ElytronHTTPAuthenticator.java
@@ -19,6 +19,8 @@ import org.infinispan.rest.framework.RestResponse;
 import org.infinispan.security.GroupPrincipal;
 import org.infinispan.server.Server;
 import org.infinispan.server.configuration.ServerConfiguration;
+import org.infinispan.server.security.http.localuser.LocalUserMechanismFactory;
+import org.infinispan.server.security.http.localuser.WildFlyElytronHttpLocalUserProvider;
 import org.infinispan.util.concurrent.BlockingManager;
 import org.wildfly.security.auth.server.MechanismConfiguration;
 import org.wildfly.security.auth.server.MechanismConfigurationSelector;
@@ -66,6 +68,7 @@ public class ElytronHTTPAuthenticator implements RestAuthenticator {
             WildFlyElytronHttpDigestProvider.getInstance(),
             WildFlyElytronHttpClientCertProvider.getInstance(),
             WildFlyElytronHttpSpnegoProvider.getInstance(),
+            WildFlyElytronHttpLocalUserProvider.getInstance(),
       };
       Map<String, String> prefixes = new HashMap<>();
       for (String m : mechanisms) {
@@ -88,6 +91,9 @@ public class ElytronHTTPAuthenticator implements RestAuthenticator {
             case "DIGEST-SHA-512-256":
                prefixes.put("DIGEST", "DIGEST-SHA-512-256");
                break;
+            case "LOCALUSER":
+               prefixes.put("LOCALUSER", "LOCALUSER");
+               break;
             default:
                prefixes.put(m, m);
          }
@@ -100,6 +106,14 @@ public class ElytronHTTPAuthenticator implements RestAuthenticator {
       if (authenticator != null) {
          authenticator.init(serverConfiguration);
       }
+   }
+
+   public Provider[] getProviders() {
+      return providers;
+   }
+
+   public void setFactory(HttpAuthenticationFactory factory) {
+      this.factory = factory;
    }
 
    public void init(ServerConfiguration serverConfiguration) {
@@ -127,26 +141,37 @@ public class ElytronHTTPAuthenticator implements RestAuthenticator {
          try {
             String authorizationHeader = request.getAuthorizationHeader();
             if (authorizationHeader == null) {
-               for (String name : configuration.authentication().mechanisms()) {
-                  HttpServerAuthenticationMechanism mechanism = factory.createMechanism(name);
+               challengeClient(request, requestAdapter);
+            } else {
+               int spaceIdx = authorizationHeader.indexOf(' ');
+               String headerMechName = (spaceIdx >= 0 ? authorizationHeader.substring(0, spaceIdx) : authorizationHeader).toUpperCase();
+               String mechName = challengePrefixMechanisms.get(headerMechName);
+               if (mechName == null) {
+                  // Unknown mechanism prefix: respond with available challenges
+                  // instead of failing, so the client can retry with a supported mechanism
+                  challengeClient(request, requestAdapter);
+               } else {
+                  HttpServerAuthenticationMechanism mechanism = factory.createMechanism(mechName);
+                  if (mechanism == null) {
+                     throw Server.log.unsupportedMechanism(headerMechName);
+                  }
                   mechanism.evaluateRequest(requestAdapter);
                   extractSubject(request, mechanism);
                }
-            } else {
-               String headerMechName = authorizationHeader.substring(0, authorizationHeader.indexOf(' ')).toUpperCase();
-               String mechName = challengePrefixMechanisms.get(headerMechName);
-               HttpServerAuthenticationMechanism mechanism = factory.createMechanism(mechName);
-               if (mechanism == null) {
-                  throw Server.log.unsupportedMechanism(headerMechName);
-               }
-               mechanism.evaluateRequest(requestAdapter);
-               extractSubject(request, mechanism);
             }
             return requestAdapter.getResponse();
          } catch (Exception e) {
             throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
          }
       }, "auth");
+   }
+
+   private void challengeClient(RestRequest request, HttpServerRequestAdapter requestAdapter) throws HttpAuthenticationException {
+      for (String name : configuration.authentication().mechanisms()) {
+         HttpServerAuthenticationMechanism mechanism = factory.createMechanism(name);
+         mechanism.evaluateRequest(requestAdapter);
+         extractSubject(request, mechanism);
+      }
    }
 
    private void extractSubject(RestRequest request, HttpServerAuthenticationMechanism mechanism) {
@@ -182,6 +207,7 @@ public class ElytronHTTPAuthenticator implements RestAuthenticator {
       if (Boolean.parseBoolean(System.getProperty(Server.INFINISPAN_ELYTRON_NONCE_SHUTDOWN, "true"))) {
          new DigestMechanismFactory().shutdown();
       }
+      new LocalUserMechanismFactory().shutdown();
       factory.shutdownAuthenticationMechanismFactory();
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/security/ServerSecurityRealm.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/ServerSecurityRealm.java
@@ -67,6 +67,6 @@ public class ServerSecurityRealm {
    }
 
    public enum Feature {
-      PASSWORD_PLAIN, PASSWORD_HASHED, TOKEN, TRUST, ENCRYPT
+      PASSWORD_PLAIN, PASSWORD_HASHED, TOKEN, TRUST, ENCRYPT, LOCAL
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserAuthenticationMechanism.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserAuthenticationMechanism.java
@@ -1,195 +1,277 @@
-/*
- * JBoss, Home of Professional Open Source.
- * Copyright 2015 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.infinispan.server.security.http.localuser;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
 import static org.wildfly.security.http.HttpConstants.UNAUTHORIZED;
 import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.List;
-import java.util.Objects;
-import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
+import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
 
-import org.wildfly.common.iteration.ByteIterator;
-import org.wildfly.common.iteration.CodePointIterator;
+import org.infinispan.commons.util.Util;
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
 import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerRequest;
-import org.wildfly.security.http.HttpServerResponse;
-import org.wildfly.security.mechanism.http.UsernamePasswordAuthenticationMechanism;
 
 /**
- * Implementation of the HTTP Local authentication mechanism
+ * Implementation of the HTTP Local authentication mechanism.
+ * Uses a challenge file on the local filesystem to prove that
+ * the client is running on the same machine as the server.
  *
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
  * @since 10.0
  */
-final class LocalUserAuthenticationMechanism extends UsernamePasswordAuthenticationMechanism {
+final class LocalUserAuthenticationMechanism implements HttpServerAuthenticationMechanism {
    public static final String LOCALUSER_NAME = "LOCALUSER";
 
-   static final String SILENT = "silent";
-
-   public static final String LOCAL_USER_USE_SECURE_RANDOM = "wildfly.http.local-user.use-secure-random";
    public static final String LOCAL_USER_CHALLENGE_PATH = "wildfly.http.local-user.challenge-path";
    public static final String DEFAULT_USER = "wildfly.http.local-user.default-user";
-   private static final String CHALLENGE_PREFIX = "Localuser ";
-   private static final int PREFIX_LENGTH = CHALLENGE_PREFIX.length();
-   private static final byte UTF8NUL = 0x00;
 
-   private final boolean useSecureRandom;
+   private static final String CHALLENGE_PREFIX = "Localuser";
+   private static final String SESSION_TOKEN_PREFIX = "token:";
+   private static final String SESSION_TOKEN_HEADER = "X-Localuser-Token";
+   private static final int CHALLENGE_BYTES = 32;
+   private static final int SESSION_TOKEN_BYTES = 32;
+   private static final long CHALLENGE_TIMEOUT_SECONDS = 60;
+   private static final long SESSION_TOKEN_TTL_SECONDS = 3600;
+   private static final int MAX_PENDING_CHALLENGES = 16;
 
-   /**
-    * If silent is true then this mechanism will only take effect if there is an Authorization header.
-    * <p>
-    * This allows you to combine basic auth with form auth, so human users will use form based auth, but allows
-    * programmatic clients to login using basic auth.
-    */
-   private final boolean silent;
-   private final File basePath;
+   private final CallbackHandler callbackHandler;
+   private final File challengePath;
+   private final String defaultUser;
+   private final ConcurrentHashMap<String, byte[]> pendingChallenges;
+   private final ConcurrentHashMap<String, String> sessionTokens;
+   private final ScheduledExecutorService cleanupExecutor;
 
-   /**
-    * Construct a new instance of {@code BasicAuthenticationMechanism}.
-    *
-    * @param callbackHandler the {@link CallbackHandler} to use to verify the supplied credentials and to notify to
-    *                        establish the current identity.
-    */
-   LocalUserAuthenticationMechanism(final CallbackHandler callbackHandler, final boolean silent) {
-      super(Objects.requireNonNull(callbackHandler, "callbackHandler"));
-      this.silent = silent;
-      this.useSecureRandom = true;
-      this.basePath = new File(System.getProperty("java.io.tmpdir"));
+   LocalUserAuthenticationMechanism(CallbackHandler callbackHandler, String challengePath, String defaultUser,
+                                    ConcurrentHashMap<String, byte[]> pendingChallenges, ConcurrentHashMap<String, String> sessionTokens,
+                                    ScheduledExecutorService cleanupExecutor) {
+      this.callbackHandler = callbackHandler;
+      this.challengePath = challengePath != null ? new File(challengePath) : new File(System.getProperty("java.io.tmpdir"));
+      this.defaultUser = defaultUser != null ? defaultUser : "$local";
+      this.pendingChallenges = pendingChallenges;
+      this.sessionTokens = sessionTokens;
+      this.cleanupExecutor = cleanupExecutor;
    }
 
-   /**
-    * @see org.wildfly.security.http.HttpServerAuthenticationMechanism#getMechanismName()
-    */
    @Override
    public String getMechanismName() {
       return LOCALUSER_NAME;
    }
 
-   /**
-    * @throws HttpAuthenticationException
-    * @see org.wildfly.security.http.HttpServerAuthenticationMechanism#evaluateRequest(HttpServerRequest)
-    */
    @Override
-   public void evaluateRequest(final HttpServerRequest request) throws HttpAuthenticationException {
+   public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
+      if (!isLoopbackRequest(request)) {
+         request.noAuthenticationInProgress();
+         return;
+      }
+
       List<String> authorizationValues = request.getRequestHeaderValues(AUTHORIZATION);
-      if (authorizationValues != null) {
-         for (String current : authorizationValues) {
-            if (current.startsWith(CHALLENGE_PREFIX)) {
-               byte[] decodedValue = ByteIterator.ofBytes(current.substring(PREFIX_LENGTH).getBytes(UTF_8)).asUtf8String().base64Decode().drain();
 
-               if (decodedValue.length == 0) {
-                  // Initial response, create the file
-                  final Random random = getRandom();
-                  File challengeFile;
-                  try {
-                     challengeFile = File.createTempFile("local", ".challenge", basePath);
-                  } catch (IOException e) {
-                     throw new RuntimeException(e);
-                  }
-                  final FileOutputStream fos;
-                  try {
-                     fos = new FileOutputStream(challengeFile);
-                  } catch (FileNotFoundException e) {
-                     throw new RuntimeException(e);
-                  }
-                  boolean ok = false;
-                  final byte[] bytes;
-                  try {
-                     bytes = new byte[8];
-                     random.nextBytes(bytes);
-                     try {
-                        fos.write(bytes);
-                        fos.close();
-                        ok = true;
-                     } catch (IOException e) {
-                        throw new RuntimeException(e);
-                     }
-                  } finally {
-                     if (!ok) {
-                        deleteChallenge(null);
-                     }
-                     try {
-                        fos.close();
-                     } catch (Throwable ignored) {
-                     }
-                  }
-                  //challengeBytes = bytes;
-                  final String path = challengeFile.getAbsolutePath();
-                  final byte[] response = CodePointIterator.ofString(path).asUtf8(true).drain();
-               } else {
-                  try {
-                     request.authenticationComplete();
-                     if (true) {
-                        succeed();
-                        request.authenticationComplete();
-                        return;
-                     } else {
-                        fail();
-                        request.authenticationFailed("auth failed", response -> prepareResponse(request, response));
-                        return;
-                     }
+      if (authorizationValues == null || authorizationValues.isEmpty()) {
+         // No Authorization header: advertise that we support Localuser
+         request.noAuthenticationInProgress(response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
 
-                  } catch (IOException | UnsupportedCallbackException e) {
-                     throw new HttpAuthenticationException(e);
-                  }
-               }
+      for (String current : authorizationValues) {
+         if (!current.startsWith(CHALLENGE_PREFIX)) {
+            continue;
+         }
+
+         String token = current.substring(CHALLENGE_PREFIX.length()).trim();
+
+         if (token.isEmpty()) {
+            // Initial handshake: create challenge file with random bytes
+            handleInitialHandshake(request);
+         } else if (token.startsWith(SESSION_TOKEN_PREFIX)) {
+            // Session token: validate cached token
+            handleSessionToken(request, token.substring(SESSION_TOKEN_PREFIX.length()));
+         } else {
+            // Response round: validate the challenge response
+            handleChallengeResponse(request, token);
+         }
+         return;
+      }
+   }
+
+   private void handleInitialHandshake(HttpServerRequest request) throws HttpAuthenticationException {
+      if (pendingChallenges.size() >= MAX_PENDING_CHALLENGES) {
+         request.authenticationFailed("Too many pending challenges", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(429);
+         });
+         return;
+      }
+      try {
+         SecureRandom random = new SecureRandom();
+         Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
+         File challengeFile = Files.createTempFile(challengePath.toPath(), "localuser-", ".challenge",
+               PosixFilePermissions.asFileAttribute(ownerOnly)).toFile();
+         byte[] bytes = new byte[CHALLENGE_BYTES];
+         random.nextBytes(bytes);
+
+         try (FileOutputStream fos = new FileOutputStream(challengeFile)) {
+            fos.write(bytes);
+         }
+
+         String filePath = challengeFile.getAbsolutePath();
+         pendingChallenges.put(filePath, bytes);
+
+         // Schedule cleanup after timeout
+         cleanupExecutor.schedule(() -> {
+            pendingChallenges.remove(filePath);
+            challengeFile.delete();
+         }, CHALLENGE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+         request.authenticationInProgress(response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX + " " + filePath);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+      } catch (IOException e) {
+         throw new HttpAuthenticationException(e);
+      }
+   }
+
+   private void handleSessionToken(HttpServerRequest request, String token) throws HttpAuthenticationException {
+      String user = sessionTokens.get(token);
+      if (user == null) {
+         request.authenticationFailed("Unknown or expired session token", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+      try {
+         NameCallback nameCallback = new NameCallback("User name", user);
+         AuthorizeCallback authorizeCallback = new AuthorizeCallback(user, user);
+         callbackHandler.handle(new Callback[]{nameCallback, authorizeCallback});
+         if (authorizeCallback.isAuthorized()) {
+            callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.SUCCEEDED});
+            request.authenticationComplete();
+         } else {
+            callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.FAILED});
+            request.authenticationFailed("Authorization denied for " + user, response -> {
+               response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+               response.setStatusCode(UNAUTHORIZED);
+            });
+         }
+      } catch (IOException | UnsupportedCallbackException e) {
+         throw new HttpAuthenticationException(e);
+      }
+   }
+
+   private void handleChallengeResponse(HttpServerRequest request, String token) throws HttpAuthenticationException {
+      // Token format: "<filepath> <hex_bytes>"
+      int spaceIdx = token.indexOf(' ');
+      if (spaceIdx < 0) {
+         request.authenticationFailed("Invalid LOCALUSER response format", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+
+      String filePath = token.substring(0, spaceIdx);
+      String hexBytes = token.substring(spaceIdx + 1);
+
+      // Look up and remove the challenge — only accept file paths the server itself issued
+      byte[] expectedBytes = pendingChallenges.remove(filePath);
+
+      if (expectedBytes == null) {
+         request.authenticationFailed("Unknown or expired challenge", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+
+      // Delete the challenge file now that it's been validated as server-issued
+      new File(filePath).delete();
+
+      byte[] receivedBytes;
+      try {
+         receivedBytes = Util.hexToBytes(hexBytes);
+      } catch (IllegalArgumentException e) {
+         request.authenticationFailed("Invalid challenge response encoding", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+
+      // Constant-time comparison
+      if (MessageDigest.isEqual(expectedBytes, receivedBytes)) {
+         try {
+            NameCallback nameCallback = new NameCallback("User name", defaultUser);
+            AuthorizeCallback authorizeCallback = new AuthorizeCallback(defaultUser, defaultUser);
+            callbackHandler.handle(new Callback[]{nameCallback, authorizeCallback});
+            if (authorizeCallback.isAuthorized()) {
+               callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.SUCCEEDED});
+               String sessionToken = generateSessionToken();
+               sessionTokens.put(sessionToken, defaultUser);
+               cleanupExecutor.schedule(() -> sessionTokens.remove(sessionToken),
+                     SESSION_TOKEN_TTL_SECONDS, TimeUnit.SECONDS);
+               request.authenticationComplete(response ->
+                     response.addResponseHeader(SESSION_TOKEN_HEADER, sessionToken));
+            } else {
+               callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.FAILED});
+               request.authenticationFailed("Authorization denied for " + defaultUser, response -> {
+                  response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+                  response.setStatusCode(UNAUTHORIZED);
+               });
             }
+         } catch (IOException | UnsupportedCallbackException e) {
+            throw new HttpAuthenticationException(e);
          }
-      }
-   }
-
-   private void prepareResponse(final HttpServerRequest request, HttpServerResponse response) {
-      if (silent) {
-         //if silent we only send a challenge if the request contained auth headers
-         //otherwise we assume another method will send the challenge
-         String authHeader = request.getFirstRequestHeaderValue(AUTHORIZATION);
-         if (authHeader == null) {
-            return;     //CHALLENGE NOT SENT
-         }
-      }
-      StringBuilder sb = new StringBuilder(CHALLENGE_PREFIX);
-      response.addResponseHeader(WWW_AUTHENTICATE, sb.toString());
-      response.setStatusCode(UNAUTHORIZED);
-   }
-
-   private void deleteChallenge(File challengeFile) {
-      if (challengeFile != null) {
-         challengeFile.delete();
-         challengeFile = null;
-      }
-   }
-
-   private Random getRandom() {
-      if (useSecureRandom) {
-         return new SecureRandom();
       } else {
-         return new Random();
+         request.authenticationFailed("Challenge response mismatch", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
       }
+   }
+
+   private static String generateSessionToken() {
+      SecureRandom random = new SecureRandom();
+      byte[] bytes = new byte[SESSION_TOKEN_BYTES];
+      random.nextBytes(bytes);
+      return Util.toHexString(bytes);
+   }
+
+   private static boolean isLoopbackRequest(HttpServerRequest request) {
+      InetSocketAddress sourceAddress = request.getSourceAddress();
+      if (sourceAddress == null) {
+         return false;
+      }
+      InetAddress address = sourceAddress.getAddress();
+      return address != null && address.isLoopbackAddress();
+   }
+
+   @Override
+   public void dispose() {
+      // Nothing to dispose
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserAuthenticationMechanism.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserAuthenticationMechanism.java
@@ -1,195 +1,260 @@
-/*
- * JBoss, Home of Professional Open Source.
- * Copyright 2015 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.infinispan.server.security.http.localuser;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
 import static org.wildfly.security.http.HttpConstants.UNAUTHORIZED;
 import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.List;
-import java.util.Objects;
-import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
+import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
 
-import org.wildfly.common.iteration.ByteIterator;
-import org.wildfly.common.iteration.CodePointIterator;
+import org.infinispan.commons.util.Util;
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
 import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerRequest;
-import org.wildfly.security.http.HttpServerResponse;
-import org.wildfly.security.mechanism.http.UsernamePasswordAuthenticationMechanism;
 
 /**
- * Implementation of the HTTP Local authentication mechanism
+ * Implementation of the HTTP Local authentication mechanism.
+ * Uses a challenge file on the local filesystem to prove that
+ * the client is running on the same machine as the server.
  *
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
  * @since 10.0
  */
-final class LocalUserAuthenticationMechanism extends UsernamePasswordAuthenticationMechanism {
+final class LocalUserAuthenticationMechanism implements HttpServerAuthenticationMechanism {
    public static final String LOCALUSER_NAME = "LOCALUSER";
 
-   static final String SILENT = "silent";
-
-   public static final String LOCAL_USER_USE_SECURE_RANDOM = "wildfly.http.local-user.use-secure-random";
    public static final String LOCAL_USER_CHALLENGE_PATH = "wildfly.http.local-user.challenge-path";
    public static final String DEFAULT_USER = "wildfly.http.local-user.default-user";
-   private static final String CHALLENGE_PREFIX = "Localuser ";
-   private static final int PREFIX_LENGTH = CHALLENGE_PREFIX.length();
-   private static final byte UTF8NUL = 0x00;
 
-   private final boolean useSecureRandom;
+   private static final String CHALLENGE_PREFIX = "Localuser";
+   private static final String SESSION_TOKEN_PREFIX = "token:";
+   private static final String SESSION_TOKEN_HEADER = "X-Localuser-Token";
+   private static final int CHALLENGE_BYTES = 8;
+   private static final int SESSION_TOKEN_BYTES = 32;
+   private static final long CHALLENGE_TIMEOUT_SECONDS = 60;
+   private static final long SESSION_TOKEN_TTL_SECONDS = 3600;
 
-   /**
-    * If silent is true then this mechanism will only take effect if there is an Authorization header.
-    * <p>
-    * This allows you to combine basic auth with form auth, so human users will use form based auth, but allows
-    * programmatic clients to login using basic auth.
-    */
-   private final boolean silent;
-   private final File basePath;
+   private final CallbackHandler callbackHandler;
+   private final File challengePath;
+   private final String defaultUser;
+   private final ConcurrentHashMap<String, byte[]> pendingChallenges;
+   private final ConcurrentHashMap<String, String> sessionTokens;
+   private final ScheduledExecutorService cleanupExecutor;
 
-   /**
-    * Construct a new instance of {@code BasicAuthenticationMechanism}.
-    *
-    * @param callbackHandler the {@link CallbackHandler} to use to verify the supplied credentials and to notify to
-    *                        establish the current identity.
-    */
-   LocalUserAuthenticationMechanism(final CallbackHandler callbackHandler, final boolean silent) {
-      super(Objects.requireNonNull(callbackHandler, "callbackHandler"));
-      this.silent = silent;
-      this.useSecureRandom = true;
-      this.basePath = new File(System.getProperty("java.io.tmpdir"));
+   LocalUserAuthenticationMechanism(CallbackHandler callbackHandler, String challengePath, String defaultUser,
+                                    ConcurrentHashMap<String, byte[]> pendingChallenges, ConcurrentHashMap<String, String> sessionTokens,
+                                    ScheduledExecutorService cleanupExecutor) {
+      this.callbackHandler = callbackHandler;
+      this.challengePath = challengePath != null ? new File(challengePath) : new File(System.getProperty("java.io.tmpdir"));
+      this.defaultUser = defaultUser != null ? defaultUser : "$local";
+      this.pendingChallenges = pendingChallenges;
+      this.sessionTokens = sessionTokens;
+      this.cleanupExecutor = cleanupExecutor;
    }
 
-   /**
-    * @see org.wildfly.security.http.HttpServerAuthenticationMechanism#getMechanismName()
-    */
    @Override
    public String getMechanismName() {
       return LOCALUSER_NAME;
    }
 
-   /**
-    * @throws HttpAuthenticationException
-    * @see org.wildfly.security.http.HttpServerAuthenticationMechanism#evaluateRequest(HttpServerRequest)
-    */
    @Override
-   public void evaluateRequest(final HttpServerRequest request) throws HttpAuthenticationException {
+   public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
+      if (!isLoopbackRequest(request)) {
+         request.noAuthenticationInProgress();
+         return;
+      }
+
       List<String> authorizationValues = request.getRequestHeaderValues(AUTHORIZATION);
-      if (authorizationValues != null) {
-         for (String current : authorizationValues) {
-            if (current.startsWith(CHALLENGE_PREFIX)) {
-               byte[] decodedValue = ByteIterator.ofBytes(current.substring(PREFIX_LENGTH).getBytes(UTF_8)).asUtf8String().base64Decode().drain();
 
-               if (decodedValue.length == 0) {
-                  // Initial response, create the file
-                  final Random random = getRandom();
-                  File challengeFile;
-                  try {
-                     challengeFile = File.createTempFile("local", ".challenge", basePath);
-                  } catch (IOException e) {
-                     throw new RuntimeException(e);
-                  }
-                  final FileOutputStream fos;
-                  try {
-                     fos = new FileOutputStream(challengeFile);
-                  } catch (FileNotFoundException e) {
-                     throw new RuntimeException(e);
-                  }
-                  boolean ok = false;
-                  final byte[] bytes;
-                  try {
-                     bytes = new byte[8];
-                     random.nextBytes(bytes);
-                     try {
-                        fos.write(bytes);
-                        fos.close();
-                        ok = true;
-                     } catch (IOException e) {
-                        throw new RuntimeException(e);
-                     }
-                  } finally {
-                     if (!ok) {
-                        deleteChallenge(null);
-                     }
-                     try {
-                        fos.close();
-                     } catch (Throwable ignored) {
-                     }
-                  }
-                  //challengeBytes = bytes;
-                  final String path = challengeFile.getAbsolutePath();
-                  final byte[] response = CodePointIterator.ofString(path).asUtf8(true).drain();
-               } else {
-                  try {
-                     request.authenticationComplete();
-                     if (true) {
-                        succeed();
-                        request.authenticationComplete();
-                        return;
-                     } else {
-                        fail();
-                        request.authenticationFailed("auth failed", response -> prepareResponse(request, response));
-                        return;
-                     }
+      if (authorizationValues == null || authorizationValues.isEmpty()) {
+         // No Authorization header: advertise that we support Localuser
+         request.noAuthenticationInProgress(response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
 
-                  } catch (IOException | UnsupportedCallbackException e) {
-                     throw new HttpAuthenticationException(e);
-                  }
-               }
+      for (String current : authorizationValues) {
+         if (!current.startsWith(CHALLENGE_PREFIX)) {
+            continue;
+         }
+
+         String token = current.substring(CHALLENGE_PREFIX.length()).trim();
+
+         if (token.isEmpty()) {
+            // Initial handshake: create challenge file with random bytes
+            handleInitialHandshake(request);
+         } else if (token.startsWith(SESSION_TOKEN_PREFIX)) {
+            // Session token: validate cached token
+            handleSessionToken(request, token.substring(SESSION_TOKEN_PREFIX.length()));
+         } else {
+            // Response round: validate the challenge response
+            handleChallengeResponse(request, token);
+         }
+         return;
+      }
+   }
+
+   private void handleInitialHandshake(HttpServerRequest request) throws HttpAuthenticationException {
+      try {
+         SecureRandom random = new SecureRandom();
+         Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
+         File challengeFile = Files.createTempFile(challengePath.toPath(), "localuser-", ".challenge",
+               PosixFilePermissions.asFileAttribute(ownerOnly)).toFile();
+         byte[] bytes = new byte[CHALLENGE_BYTES];
+         random.nextBytes(bytes);
+
+         try (FileOutputStream fos = new FileOutputStream(challengeFile)) {
+            fos.write(bytes);
+         }
+
+         String filePath = challengeFile.getAbsolutePath();
+         pendingChallenges.put(filePath, bytes);
+
+         // Schedule cleanup after timeout
+         cleanupExecutor.schedule(() -> {
+            pendingChallenges.remove(filePath);
+            challengeFile.delete();
+         }, CHALLENGE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+         request.authenticationInProgress(response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX + " " + filePath);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+      } catch (IOException e) {
+         throw new HttpAuthenticationException(e);
+      }
+   }
+
+   private void handleSessionToken(HttpServerRequest request, String token) throws HttpAuthenticationException {
+      String user = sessionTokens.get(token);
+      if (user == null) {
+         request.authenticationFailed("Unknown or expired session token", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+      try {
+         NameCallback nameCallback = new NameCallback("User name", user);
+         AuthorizeCallback authorizeCallback = new AuthorizeCallback(user, user);
+         callbackHandler.handle(new Callback[]{nameCallback, authorizeCallback});
+         if (authorizeCallback.isAuthorized()) {
+            callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.SUCCEEDED});
+            request.authenticationComplete();
+         } else {
+            callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.FAILED});
+            request.authenticationFailed("Authorization denied for " + user, response -> {
+               response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+               response.setStatusCode(UNAUTHORIZED);
+            });
+         }
+      } catch (IOException | UnsupportedCallbackException e) {
+         throw new HttpAuthenticationException(e);
+      }
+   }
+
+   private void handleChallengeResponse(HttpServerRequest request, String token) throws HttpAuthenticationException {
+      // Token format: "<filepath> <hex_bytes>"
+      int spaceIdx = token.indexOf(' ');
+      if (spaceIdx < 0) {
+         request.authenticationFailed("Invalid LOCALUSER response format", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+
+      String filePath = token.substring(0, spaceIdx);
+      String hexBytes = token.substring(spaceIdx + 1);
+
+      // Look up and remove the challenge — only accept file paths the server itself issued
+      byte[] expectedBytes = pendingChallenges.remove(filePath);
+
+      if (expectedBytes == null) {
+         request.authenticationFailed("Unknown or expired challenge", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
+         return;
+      }
+
+      // Delete the challenge file now that it's been validated as server-issued
+      new File(filePath).delete();
+
+      byte[] receivedBytes = Util.hexToBytes(hexBytes);
+
+      // Constant-time comparison
+      if (MessageDigest.isEqual(expectedBytes, receivedBytes)) {
+         try {
+            NameCallback nameCallback = new NameCallback("User name", defaultUser);
+            AuthorizeCallback authorizeCallback = new AuthorizeCallback(defaultUser, defaultUser);
+            callbackHandler.handle(new Callback[]{nameCallback, authorizeCallback});
+            if (authorizeCallback.isAuthorized()) {
+               callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.SUCCEEDED});
+               String sessionToken = generateSessionToken();
+               sessionTokens.put(sessionToken, defaultUser);
+               cleanupExecutor.schedule(() -> sessionTokens.remove(sessionToken),
+                     SESSION_TOKEN_TTL_SECONDS, TimeUnit.SECONDS);
+               request.authenticationComplete(response ->
+                     response.addResponseHeader(SESSION_TOKEN_HEADER, sessionToken));
+            } else {
+               callbackHandler.handle(new Callback[]{AuthenticationCompleteCallback.FAILED});
+               request.authenticationFailed("Authorization denied for " + defaultUser, response -> {
+                  response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+                  response.setStatusCode(UNAUTHORIZED);
+               });
             }
+         } catch (IOException | UnsupportedCallbackException e) {
+            throw new HttpAuthenticationException(e);
          }
-      }
-   }
-
-   private void prepareResponse(final HttpServerRequest request, HttpServerResponse response) {
-      if (silent) {
-         //if silent we only send a challenge if the request contained auth headers
-         //otherwise we assume another method will send the challenge
-         String authHeader = request.getFirstRequestHeaderValue(AUTHORIZATION);
-         if (authHeader == null) {
-            return;     //CHALLENGE NOT SENT
-         }
-      }
-      StringBuilder sb = new StringBuilder(CHALLENGE_PREFIX);
-      response.addResponseHeader(WWW_AUTHENTICATE, sb.toString());
-      response.setStatusCode(UNAUTHORIZED);
-   }
-
-   private void deleteChallenge(File challengeFile) {
-      if (challengeFile != null) {
-         challengeFile.delete();
-         challengeFile = null;
-      }
-   }
-
-   private Random getRandom() {
-      if (useSecureRandom) {
-         return new SecureRandom();
       } else {
-         return new Random();
+         request.authenticationFailed("Challenge response mismatch", response -> {
+            response.addResponseHeader(WWW_AUTHENTICATE, CHALLENGE_PREFIX);
+            response.setStatusCode(UNAUTHORIZED);
+         });
       }
+   }
+
+   private static String generateSessionToken() {
+      SecureRandom random = new SecureRandom();
+      byte[] bytes = new byte[SESSION_TOKEN_BYTES];
+      random.nextBytes(bytes);
+      return Util.toHexString(bytes);
+   }
+
+   private static boolean isLoopbackRequest(HttpServerRequest request) {
+      InetSocketAddress sourceAddress = request.getSourceAddress();
+      if (sourceAddress == null) {
+         return false;
+      }
+      InetAddress address = sourceAddress.getAddress();
+      return address != null && address.isLoopbackAddress();
+   }
+
+   @Override
+   public void dispose() {
+      // Nothing to dispose
    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserMechanismFactory.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserMechanismFactory.java
@@ -1,13 +1,17 @@
 package org.infinispan.server.security.http.localuser;
 
-import static org.infinispan.server.security.http.localuser.LocalUserAuthenticationMechanism.SILENT;
 
+import java.nio.file.FileSystems;
 import java.security.Provider;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.security.auth.callback.CallbackHandler;
 
+import org.infinispan.server.logging.Log;
 import org.kohsuke.MetaInfServices;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
@@ -22,6 +26,17 @@ import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
 @MetaInfServices(value = HttpServerAuthenticationMechanismFactory.class)
 public class LocalUserMechanismFactory implements HttpServerAuthenticationMechanismFactory {
 
+    private static final Log log = Log.getLog(LocalUserMechanismFactory.class);
+    private static final boolean POSIX_SUPPORTED = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+
+    private static final ConcurrentHashMap<String, byte[]> pendingChallenges = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, String> sessionTokens = new ConcurrentHashMap<>();
+    private static final ScheduledExecutorService cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "localuser-challenge-cleanup");
+        t.setDaemon(true);
+        return t;
+    });
+
     public LocalUserMechanismFactory() {
     }
 
@@ -30,6 +45,9 @@ public class LocalUserMechanismFactory implements HttpServerAuthenticationMechan
 
     @Override
     public String[] getMechanismNames(Map<String, ?> properties) {
+        if (!POSIX_SUPPORTED) {
+            return new String[0];
+        }
         return new String[]{ LocalUserAuthenticationMechanism.LOCALUSER_NAME };
     }
 
@@ -41,11 +59,22 @@ public class LocalUserMechanismFactory implements HttpServerAuthenticationMechan
         Objects.requireNonNull(callbackHandler, "Callback handler cannot be null");
 
         if (LocalUserAuthenticationMechanism.LOCALUSER_NAME.equals(mechanismName)) {
-            return new LocalUserAuthenticationMechanism(callbackHandler,
-                    Boolean.parseBoolean((String) properties.get(SILENT)));
+            if (!POSIX_SUPPORTED) {
+                log.localUserDisabledNoPosix();
+                return null;
+            }
+            String challengePath = (String) properties.get(LocalUserAuthenticationMechanism.LOCAL_USER_CHALLENGE_PATH);
+            String defaultUser = (String) properties.get(LocalUserAuthenticationMechanism.DEFAULT_USER);
+            return new LocalUserAuthenticationMechanism(callbackHandler, challengePath, defaultUser,
+                  pendingChallenges, sessionTokens, cleanupExecutor);
         }
 
         return null;
     }
 
+    @Override
+    public void shutdown() {
+        pendingChallenges.clear();
+        sessionTokens.clear();
+    }
 }

--- a/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserMechanismFactory.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/http/localuser/LocalUserMechanismFactory.java
@@ -1,10 +1,12 @@
 package org.infinispan.server.security.http.localuser;
 
-import static org.infinispan.server.security.http.localuser.LocalUserAuthenticationMechanism.SILENT;
 
 import java.security.Provider;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.security.auth.callback.CallbackHandler;
 
@@ -21,6 +23,14 @@ import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
  */
 @MetaInfServices(value = HttpServerAuthenticationMechanismFactory.class)
 public class LocalUserMechanismFactory implements HttpServerAuthenticationMechanismFactory {
+
+    private final ConcurrentHashMap<String, byte[]> pendingChallenges = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> sessionTokens = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "localuser-challenge-cleanup");
+        t.setDaemon(true);
+        return t;
+    });
 
     public LocalUserMechanismFactory() {
     }
@@ -41,11 +51,16 @@ public class LocalUserMechanismFactory implements HttpServerAuthenticationMechan
         Objects.requireNonNull(callbackHandler, "Callback handler cannot be null");
 
         if (LocalUserAuthenticationMechanism.LOCALUSER_NAME.equals(mechanismName)) {
-            return new LocalUserAuthenticationMechanism(callbackHandler,
-                    Boolean.parseBoolean((String) properties.get(SILENT)));
+            String challengePath = (String) properties.get(LocalUserAuthenticationMechanism.LOCAL_USER_CHALLENGE_PATH);
+            String defaultUser = (String) properties.get(LocalUserAuthenticationMechanism.DEFAULT_USER);
+            return new LocalUserAuthenticationMechanism(callbackHandler, challengePath, defaultUser,
+                  pendingChallenges, sessionTokens, cleanupExecutor);
         }
 
         return null;
     }
 
+    public void shutdown() {
+        cleanupExecutor.shutdownNow();
+    }
 }

--- a/server/runtime/src/main/resources/schema/infinispan-server-16.3.xsd
+++ b/server/runtime/src/main/resources/schema/infinispan-server-16.3.xsd
@@ -886,7 +886,7 @@
       </xs:attribute>
       <xs:attribute name="mechanisms" type="tns:name-list" default="NONE">
          <xs:annotation>
-            <xs:documentation>The authentication method to require. Can be NONE, BASIC, DIGEST, CLIENT_CERT, SPNEGO.
+            <xs:documentation>The authentication method to require. Can be NONE, BASIC, DIGEST, CLIENT_CERT, SPNEGO, LOCALUSER.
                Defaults to NONE. Setting it to a different value requires enabling a security-realm.
             </xs:documentation>
          </xs:annotation>

--- a/server/runtime/src/main/server/server/conf/infinispan-local.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-local.xml
@@ -33,11 +33,12 @@
                                generate-self-signed-certificate-host="localhost"/>
                   </ssl>
                </server-identities-->
+               <local-realm/>
                <properties-realm/>
             </security-realm>
          </security-realms>
       </security>
 
-      <endpoints socket-binding="default" security-realm="default" />
+      <endpoints socket-binding="default" security-realm="default"/>
    </server>
 </infinispan>

--- a/server/runtime/src/main/server/server/conf/infinispan-memcached.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-memcached.xml
@@ -3,44 +3,45 @@
     Memcached server.
 -->
 <infinispan
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:16.3 https://infinispan.org/schemas/infinispan-config-16.3.xsd
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:16.3 https://infinispan.org/schemas/infinispan-config-16.3.xsd
                             urn:infinispan:server:16.3 https://infinispan.org/schemas/infinispan-server-16.3.xsd"
-        xmlns="urn:infinispan:config:16.3"
-        xmlns:server="urn:infinispan:server:16.3">
+      xmlns="urn:infinispan:config:16.3"
+      xmlns:server="urn:infinispan:server:16.3">
 
-    <cache-container name="default" statistics="true">
-        <security>
-            <authorization/>
-        </security>
-    </cache-container>
+   <cache-container name="default" statistics="true">
+      <security>
+         <authorization/>
+      </security>
+   </cache-container>
 
-    <server xmlns="urn:infinispan:server:16.3">
-        <interfaces>
-            <interface name="public">
-                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
-            </interface>
-        </interfaces>
+   <server xmlns="urn:infinispan:server:16.3">
+      <interfaces>
+         <interface name="public">
+            <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+         </interface>
+      </interfaces>
 
-        <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
-            <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
-            <socket-binding name="memcached" port="11211"/>
-        </socket-bindings>
+      <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
+         <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
+         <socket-binding name="memcached" port="11211"/>
+      </socket-bindings>
 
-        <security>
-            <security-realms>
-                <security-realm name="default">
-                    <properties-realm/>
-                </security-realm>
-                <security-realm name="none"/>
-            </security-realms>
-        </security>
+      <security>
+         <security-realms>
+            <security-realm name="default">
+               <local-realm/>
+               <properties-realm/>
+            </security-realm>
+            <security-realm name="none"/>
+         </security-realms>
+      </security>
 
-        <endpoints>
-            <endpoint socket-binding="default" security-realm="default">
-                <rest-connector/>
-                <memcached-connector socket-binding="memcached" security-realm="none" />
-            </endpoint>
-        </endpoints>
-    </server>
+      <endpoints>
+         <endpoint socket-binding="default" security-realm="default">
+            <rest-connector/>
+            <memcached-connector socket-binding="memcached" security-realm="none"/>
+         </endpoint>
+      </endpoints>
+   </server>
 </infinispan>

--- a/server/runtime/src/main/server/server/conf/infinispan-resp.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-resp.xml
@@ -3,44 +3,45 @@
     Redis server.
 -->
 <infinispan
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:16.3 https://infinispan.org/schemas/infinispan-config-16.3.xsd
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:16.3 https://infinispan.org/schemas/infinispan-config-16.3.xsd
                             urn:infinispan:server:16.3 https://infinispan.org/schemas/infinispan-server-16.3.xsd"
-        xmlns="urn:infinispan:config:16.3"
-        xmlns:server="urn:infinispan:server:16.3">
+      xmlns="urn:infinispan:config:16.3"
+      xmlns:server="urn:infinispan:server:16.3">
 
-    <cache-container name="default" statistics="true">
-        <security>
-            <authorization/>
-        </security>
-    </cache-container>
+   <cache-container name="default" statistics="true">
+      <security>
+         <authorization/>
+      </security>
+   </cache-container>
 
-    <server xmlns="urn:infinispan:server:16.3">
-        <interfaces>
-            <interface name="public">
-                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
-            </interface>
-        </interfaces>
+   <server xmlns="urn:infinispan:server:16.3">
+      <interfaces>
+         <interface name="public">
+            <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+         </interface>
+      </interfaces>
 
-        <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
-            <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
-            <socket-binding name="resp" port="6379"/>
-        </socket-bindings>
+      <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
+         <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
+         <socket-binding name="resp" port="6379"/>
+      </socket-bindings>
 
-        <security>
-            <security-realms>
-                <security-realm name="default">
-                    <properties-realm />
-                </security-realm>
-                <security-realm name="none"/>
-            </security-realms>
-        </security>
+      <security>
+         <security-realms>
+            <security-realm name="default">
+               <local-realm/>
+               <properties-realm/>
+            </security-realm>
+            <security-realm name="none"/>
+         </security-realms>
+      </security>
 
-        <endpoints>
-            <endpoint socket-binding="default" security-realm="default">
-                <rest-connector/>
-                <resp-connector socket-binding="resp" security-realm="none"/>
-            </endpoint>
-        </endpoints>
-    </server>
+      <endpoints>
+         <endpoint socket-binding="default" security-realm="default">
+            <rest-connector/>
+            <resp-connector socket-binding="resp" security-realm="none"/>
+         </endpoint>
+      </endpoints>
+   </server>
 </infinispan>

--- a/server/runtime/src/main/server/server/conf/infinispan-xsite.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan-xsite.xml
@@ -36,7 +36,8 @@
    </jgroups>
 
    <cache-container name="default" statistics="true">
-      <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:local}" node-name="${infinispan.node.name:}"/>
+      <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:local}"
+                 node-name="${infinispan.node.name:}"/>
       <security>
          <authorization/>
       </security>
@@ -64,11 +65,12 @@
                                generate-self-signed-certificate-host="localhost"/>
                   </ssl>
                </server-identities-->
+               <local-realm/>
                <properties-realm/>
             </security-realm>
          </security-realms>
       </security>
 
-      <endpoints socket-binding="default" security-realm="default" />
+      <endpoints socket-binding="default" security-realm="default"/>
    </server>
 </infinispan>

--- a/server/runtime/src/main/server/server/conf/infinispan.xml
+++ b/server/runtime/src/main/server/server/conf/infinispan.xml
@@ -34,6 +34,7 @@
                                generate-self-signed-certificate-host="localhost"/>
                   </ssl>
                </server-identities-->
+               <local-realm/>
                <properties-realm/>
             </security-realm>
          </security-realms>

--- a/server/runtime/src/test/java/org/infinispan/server/security/HttpAuthenticationTest.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/HttpAuthenticationTest.java
@@ -1,0 +1,307 @@
+package org.infinispan.server.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.rest.RestServer;
+import org.infinispan.rest.configuration.RestServerConfigurationBuilder;
+import org.infinispan.server.core.ProtocolServer;
+import org.infinispan.server.core.ServerManagement;
+import org.infinispan.server.core.ServerStateManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.testing.jupiter.JupiterThreadTrackerExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.realm.SimpleRealmEntry;
+import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.MechanismConfigurationSelector;
+import org.wildfly.security.auth.server.MechanismRealmConfiguration;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.http.HttpAuthenticationFactory;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.digest.DigestMechanismFactory;
+import org.wildfly.security.http.util.FilterServerMechanismFactory;
+import org.wildfly.security.http.util.SecurityProviderServerMechanismFactory;
+import org.wildfly.security.http.util.SetMechanismInformationMechanismFactory;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.permission.PermissionVerifier;
+
+/**
+ * Tests HTTP authentication mechanisms (Digest and LOCALUSER) including
+ * client-side preauthentication support.
+ *
+ * @since 16.2
+ */
+public class HttpAuthenticationTest {
+
+   @RegisterExtension
+   static JupiterThreadTrackerExtension tracker = new JupiterThreadTrackerExtension();
+
+   @BeforeAll
+   public static void disableNonceShutdown() {
+      // Prevent DigestMechanismFactory.shutdown() from being called between tests,
+      // which would corrupt shared static state and cause 500 errors in Digest tests.
+      System.setProperty("infinispan.security.elytron.nonceshutdown", "false");
+   }
+
+   @AfterAll
+   public static void shutdownNonceManager() {
+      // Re-enable and shut down the nonce manager to clean up its unnamed thread pool
+      System.setProperty("infinispan.security.elytron.nonceshutdown", "true");
+      new DigestMechanismFactory().shutdown();
+   }
+
+   private RestServer restServer;
+   private EmbeddedCacheManager cacheManager;
+   private RestClient client;
+
+   @AfterEach
+   public void tearDown() throws Exception {
+      Util.close(client);
+      Util.close(restServer);
+      Util.close(cacheManager);
+   }
+
+   private void startServer(ElytronHTTPAuthenticator authenticator, String... mechanisms) {
+      GlobalConfigurationBuilder globalBuilder = new GlobalConfigurationBuilder().cacheManagerName("default");
+      cacheManager = TestCacheManagerFactory.createCacheManager(globalBuilder, new ConfigurationBuilder());
+      restServer = new RestServer();
+      RestServerConfigurationBuilder builder = new RestServerConfigurationBuilder();
+      builder.host("localhost").port(0).name("test");
+      builder.authentication().authenticator(authenticator).addMechanisms(mechanisms);
+
+      Map<String, ProtocolServer> protocolServers = new HashMap<>();
+      ServerManagement serverManagement = createServerManagement(cacheManager, protocolServers);
+      restServer.setServerManagement(serverManagement, true);
+      restServer.start(builder.build(), cacheManager);
+      restServer.postStart();
+   }
+
+   private static ServerManagement createServerManagement(EmbeddedCacheManager cm, Map<String, ProtocolServer> protocolServers) {
+      ServerManagement mgmt = mock(ServerManagement.class);
+      when(mgmt.getClassLoader()).thenReturn(Thread.currentThread().getContextClassLoader());
+      when(mgmt.getCacheManager()).thenReturn((DefaultCacheManager) cm);
+      when(mgmt.getProtocolServers()).thenReturn(protocolServers);
+      when(mgmt.getStatus()).thenReturn(org.infinispan.lifecycle.ComponentStatus.RUNNING);
+      when(mgmt.getLoginConfiguration(org.mockito.ArgumentMatchers.any())).thenReturn(Collections.emptyMap());
+
+      ServerStateManager ssm = mock(ServerStateManager.class);
+      when(ssm.getIgnoredCaches()).thenReturn(Collections.emptySet());
+      when(mgmt.getServerStateManager()).thenReturn(ssm);
+      when(mgmt.getServerReport()).thenReturn(CompletableFuture.completedFuture(Path.of("")));
+      when(mgmt.getUsers()).thenReturn(Collections.emptyMap());
+
+      return mgmt;
+   }
+
+   private RestClient createClient(String mechanism) {
+      return createClient(mechanism, null, null);
+   }
+
+   private RestClient createClient(String mechanism, String username, String password) {
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      builder.security().authentication().enable().mechanism(mechanism);
+      if (username != null) {
+         builder.security().authentication().username(username).password(password);
+      }
+      return RestClient.forConfiguration(builder.build());
+   }
+
+   private ElytronHTTPAuthenticator createDigestAuthenticator() throws Exception {
+      SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+      PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, WildFlyElytronPasswordProvider.getInstance());
+      Map<String, SimpleRealmEntry> users = new HashMap<>();
+      users.put("admin", new SimpleRealmEntry(List.of(new PasswordCredential(
+            passwordFactory.generatePassword(new ClearPasswordSpec("adminpass".toCharArray()))))));
+      realm.setIdentityMap(users);
+
+      SecurityDomain securityDomain = SecurityDomain.builder()
+            .addRealm("default", realm).build()
+            .setDefaultRealmName("default")
+            .setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()))
+            .build();
+
+      return createAuthenticator(securityDomain, "DIGEST");
+   }
+
+   private ElytronHTTPAuthenticator createLocalUserAuthenticator() throws Exception {
+      SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+      Map<String, SimpleRealmEntry> users = new HashMap<>();
+      users.put("$local", new SimpleRealmEntry(List.of()));
+      realm.setIdentityMap(users);
+
+      SecurityDomain securityDomain = SecurityDomain.builder()
+            .addRealm("default", realm).build()
+            .setDefaultRealmName("default")
+            .setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()))
+            .build();
+
+      return createAuthenticator(securityDomain, "LOCALUSER");
+   }
+
+   private ElytronHTTPAuthenticator createMultiMechanismAuthenticator() throws Exception {
+      SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+      PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, WildFlyElytronPasswordProvider.getInstance());
+      Map<String, SimpleRealmEntry> users = new HashMap<>();
+      users.put("admin", new SimpleRealmEntry(List.of(new PasswordCredential(
+            passwordFactory.generatePassword(new ClearPasswordSpec("adminpass".toCharArray()))))));
+      users.put("$local", new SimpleRealmEntry(List.of()));
+      realm.setIdentityMap(users);
+
+      SecurityDomain securityDomain = SecurityDomain.builder()
+            .addRealm("default", realm).build()
+            .setDefaultRealmName("default")
+            .setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()))
+            .build();
+
+      return createAuthenticator(securityDomain, "DIGEST", "LOCALUSER");
+   }
+
+   private ElytronHTTPAuthenticator createAuthenticator(SecurityDomain securityDomain, String... mechanisms) {
+      ElytronHTTPAuthenticator authenticator = new ElytronHTTPAuthenticator("default", null, List.of(mechanisms));
+
+      HttpServerAuthenticationMechanismFactory httpServerFactory = new SecurityProviderServerMechanismFactory(authenticator.getProviders());
+      httpServerFactory = new SetMechanismInformationMechanismFactory(
+            new FilterServerMechanismFactory(httpServerFactory, true, List.of(mechanisms)));
+
+      MechanismConfiguration.Builder mechConfigBuilder = MechanismConfiguration.builder();
+      mechConfigBuilder.addMechanismRealm(MechanismRealmConfiguration.builder().setRealmName("default").build());
+
+      HttpAuthenticationFactory factory = HttpAuthenticationFactory.builder()
+            .setSecurityDomain(securityDomain)
+            .setFactory(httpServerFactory)
+            .setMechanismConfigurationSelector(MechanismConfigurationSelector.constantSelector(mechConfigBuilder.build()))
+            .build();
+
+      authenticator.setFactory(factory);
+      return authenticator;
+   }
+
+   @Test
+   public void testDigestAuthenticationWithValidCredentials() throws Exception {
+      startServer(createDigestAuthenticator(), "DIGEST");
+      client = createClient("DIGEST", "admin", "adminpass");
+
+      // Use non-anonymous endpoint to actually exercise auth
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testDigestPreauthentication() throws Exception {
+      startServer(createDigestAuthenticator(), "DIGEST");
+      client = createClient("DIGEST", "admin", "adminpass");
+
+      // First request triggers full Digest challenge-response and caches the nonce
+      RestResponse r1 = client.container().info().toCompletableFuture().get();
+      assertThat(r1.status()).isBetween(200, 204);
+
+      // Subsequent requests use preauthentication (cached nonce, no 401 round-trip)
+      for (int i = 0; i < 5; i++) {
+         RestResponse r = client.container().info().toCompletableFuture().get();
+         assertThat(r.status()).isBetween(200, 204);
+      }
+   }
+
+   @Test
+   public void testDigestNoAuthentication() throws Exception {
+      startServer(createDigestAuthenticator(), "DIGEST");
+
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      client = RestClient.forConfiguration(builder.build());
+
+      // Health endpoint is accessible anonymously even when auth is configured
+      RestResponse r = client.container().healthStatus().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testLocalUserAuthentication() throws Exception {
+      startServer(createLocalUserAuthenticator(), "LOCALUSER");
+      client = createClient("LOCALUSER");
+
+      // Use non-anonymous endpoint to actually exercise LOCALUSER auth
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testLocalUserSessionTokenPreauthentication() throws Exception {
+      startServer(createLocalUserAuthenticator(), "LOCALUSER");
+      client = createClient("LOCALUSER");
+
+      // First request: full 3-round-trip challenge-response
+      RestResponse r1 = client.container().info().toCompletableFuture().get();
+      assertThat(r1.status()).isBetween(200, 204);
+
+      // Subsequent requests should also succeed
+      for (int i = 0; i < 5; i++) {
+         RestResponse r = client.container().info().toCompletableFuture().get();
+         assertThat(r.status()).isBetween(200, 204);
+      }
+   }
+
+   @Test
+   public void testAutoDetectLocalUser() throws Exception {
+      // Simulates the CLI flow: AUTO mechanism, no credentials, server with both DIGEST and LOCALUSER
+      startServer(createMultiMechanismAuthenticator(), "DIGEST", "LOCALUSER");
+
+      // Create client with AUTO mechanism and no credentials (like the CLI does)
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      builder.security().authentication().enable();
+      client = RestClient.forConfiguration(builder.build());
+
+      // Access a non-anonymous endpoint - should auto-detect and use LOCALUSER
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testAutoDetectDigestWithCredentials() throws Exception {
+      // Simulates the CLI flow: connect -u admin -p adminpass with AUTO mechanism
+      // The client must NOT eagerly preauthenticate with Basic (which the server doesn't support)
+      startServer(createMultiMechanismAuthenticator(), "DIGEST", "LOCALUSER");
+
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      builder.security().authentication().enable().username("admin").password("adminpass");
+      client = RestClient.forConfiguration(builder.build());
+
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+
+      // Subsequent requests should use Digest preauthentication
+      for (int i = 0; i < 3; i++) {
+         RestResponse r2 = client.container().info().toCompletableFuture().get();
+         assertThat(r2.status()).isBetween(200, 204);
+      }
+   }
+}

--- a/server/runtime/src/test/java/org/infinispan/server/security/HttpAuthenticationTest.java
+++ b/server/runtime/src/test/java/org/infinispan/server/security/HttpAuthenticationTest.java
@@ -1,0 +1,403 @@
+package org.infinispan.server.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
+import org.infinispan.commons.util.NetworkAddress;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.rest.RestServer;
+import org.infinispan.rest.configuration.RestServerConfigurationBuilder;
+import org.infinispan.server.core.ProtocolServer;
+import org.infinispan.server.core.ServerManagement;
+import org.infinispan.server.core.ServerStateManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.testing.jupiter.JupiterThreadTrackerExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.realm.SimpleRealmEntry;
+import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.MechanismConfigurationSelector;
+import org.wildfly.security.auth.server.MechanismRealmConfiguration;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.http.HttpAuthenticationFactory;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.digest.DigestMechanismFactory;
+import org.wildfly.security.http.util.FilterServerMechanismFactory;
+import org.wildfly.security.http.util.SecurityProviderServerMechanismFactory;
+import org.wildfly.security.http.util.SetMechanismInformationMechanismFactory;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.permission.PermissionVerifier;
+
+/**
+ * Tests HTTP authentication mechanisms (Digest and LOCALUSER) including
+ * client-side preauthentication support.
+ *
+ * @since 16.3
+ */
+public class HttpAuthenticationTest {
+
+   @RegisterExtension
+   static JupiterThreadTrackerExtension tracker = new JupiterThreadTrackerExtension();
+
+   @BeforeAll
+   public static void disableNonceShutdown() {
+      // Prevent DigestMechanismFactory.shutdown() from being called between tests,
+      // which would corrupt shared static state and cause 500 errors in Digest tests.
+      System.setProperty("infinispan.security.elytron.nonceshutdown", "false");
+   }
+
+   @AfterAll
+   public static void shutdownNonceManager() {
+      // Re-enable and shut down the nonce manager to clean up its unnamed thread pool
+      System.setProperty("infinispan.security.elytron.nonceshutdown", "true");
+      new DigestMechanismFactory().shutdown();
+   }
+
+   private RestServer restServer;
+   private EmbeddedCacheManager cacheManager;
+   private RestClient client;
+
+   @AfterEach
+   public void tearDown() throws Exception {
+      Util.close(client);
+      Util.close(restServer);
+      Util.close(cacheManager);
+   }
+
+   private void startServer(ElytronHTTPAuthenticator authenticator, String... mechanisms) {
+      startServer("localhost", authenticator, mechanisms);
+   }
+
+   private void startServer(String host, ElytronHTTPAuthenticator authenticator, String... mechanisms) {
+      GlobalConfigurationBuilder globalBuilder = new GlobalConfigurationBuilder().cacheManagerName("default");
+      cacheManager = TestCacheManagerFactory.createCacheManager(globalBuilder, new ConfigurationBuilder());
+      restServer = new RestServer();
+      RestServerConfigurationBuilder builder = new RestServerConfigurationBuilder();
+      builder.host(host).port(0).name("test");
+      builder.authentication().authenticator(authenticator).addMechanisms(mechanisms);
+
+      Map<String, ProtocolServer> protocolServers = new HashMap<>();
+      ServerManagement serverManagement = createServerManagement(cacheManager, protocolServers);
+      restServer.setServerManagement(serverManagement, true);
+      restServer.start(builder.build(), cacheManager);
+      restServer.postStart();
+   }
+
+
+   private static ServerManagement createServerManagement(EmbeddedCacheManager cm, Map<String, ProtocolServer> protocolServers) {
+      ServerManagement mgmt = mock(ServerManagement.class);
+      when(mgmt.getClassLoader()).thenReturn(Thread.currentThread().getContextClassLoader());
+      when(mgmt.getCacheManager()).thenReturn((DefaultCacheManager) cm);
+      when(mgmt.getProtocolServers()).thenReturn(protocolServers);
+      when(mgmt.getStatus()).thenReturn(org.infinispan.lifecycle.ComponentStatus.RUNNING);
+      when(mgmt.getLoginConfiguration(org.mockito.ArgumentMatchers.any())).thenReturn(Collections.emptyMap());
+
+      ServerStateManager ssm = mock(ServerStateManager.class);
+      when(ssm.getIgnoredCaches()).thenReturn(Collections.emptySet());
+      when(mgmt.getServerStateManager()).thenReturn(ssm);
+      when(mgmt.getServerReport()).thenReturn(CompletableFuture.completedFuture(Path.of("")));
+      when(mgmt.getUsers()).thenReturn(Collections.emptyMap());
+
+      return mgmt;
+   }
+
+   private RestClient createClient(String mechanism) {
+      return createClient(mechanism, null, null);
+   }
+
+   private RestClient createClient(String mechanism, String username, String password) {
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      builder.security().authentication().enable().mechanism(mechanism);
+      if (username != null) {
+         builder.security().authentication().username(username).password(password);
+      }
+      return RestClient.forConfiguration(builder.build());
+   }
+
+   private ElytronHTTPAuthenticator createDigestAuthenticator() throws Exception {
+      SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+      PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, WildFlyElytronPasswordProvider.getInstance());
+      Map<String, SimpleRealmEntry> users = new HashMap<>();
+      users.put("admin", new SimpleRealmEntry(List.of(new PasswordCredential(
+            passwordFactory.generatePassword(new ClearPasswordSpec("adminpass".toCharArray()))))));
+      realm.setIdentityMap(users);
+
+      SecurityDomain securityDomain = SecurityDomain.builder()
+            .addRealm("default", realm).build()
+            .setDefaultRealmName("default")
+            .setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()))
+            .build();
+
+      return createAuthenticator(securityDomain, "DIGEST");
+   }
+
+   private ElytronHTTPAuthenticator createLocalUserAuthenticator() throws Exception {
+      SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+      Map<String, SimpleRealmEntry> users = new HashMap<>();
+      users.put("$local", new SimpleRealmEntry(List.of()));
+      realm.setIdentityMap(users);
+
+      SecurityDomain securityDomain = SecurityDomain.builder()
+            .addRealm("default", realm).build()
+            .setDefaultRealmName("default")
+            .setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()))
+            .build();
+
+      return createAuthenticator(securityDomain, "LOCALUSER");
+   }
+
+   private ElytronHTTPAuthenticator createMultiMechanismAuthenticator() throws Exception {
+      SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+      PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR, WildFlyElytronPasswordProvider.getInstance());
+      Map<String, SimpleRealmEntry> users = new HashMap<>();
+      users.put("admin", new SimpleRealmEntry(List.of(new PasswordCredential(
+            passwordFactory.generatePassword(new ClearPasswordSpec("adminpass".toCharArray()))))));
+      users.put("$local", new SimpleRealmEntry(List.of()));
+      realm.setIdentityMap(users);
+
+      SecurityDomain securityDomain = SecurityDomain.builder()
+            .addRealm("default", realm).build()
+            .setDefaultRealmName("default")
+            .setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()))
+            .build();
+
+      return createAuthenticator(securityDomain, "DIGEST", "LOCALUSER");
+   }
+
+   private ElytronHTTPAuthenticator createAuthenticator(SecurityDomain securityDomain, String... mechanisms) {
+      ElytronHTTPAuthenticator authenticator = new ElytronHTTPAuthenticator("default", null, List.of(mechanisms));
+
+      HttpServerAuthenticationMechanismFactory httpServerFactory = new SecurityProviderServerMechanismFactory(authenticator.getProviders());
+      httpServerFactory = new SetMechanismInformationMechanismFactory(
+            new FilterServerMechanismFactory(httpServerFactory, true, List.of(mechanisms)));
+
+      MechanismConfiguration.Builder mechConfigBuilder = MechanismConfiguration.builder();
+      mechConfigBuilder.addMechanismRealm(MechanismRealmConfiguration.builder().setRealmName("default").build());
+
+      HttpAuthenticationFactory factory = HttpAuthenticationFactory.builder()
+            .setSecurityDomain(securityDomain)
+            .setFactory(httpServerFactory)
+            .setMechanismConfigurationSelector(MechanismConfigurationSelector.constantSelector(mechConfigBuilder.build()))
+            .build();
+
+      authenticator.setFactory(factory);
+      return authenticator;
+   }
+
+   @Test
+   public void testDigestAuthenticationWithValidCredentials() throws Exception {
+      startServer(createDigestAuthenticator(), "DIGEST");
+      client = createClient("DIGEST", "admin", "adminpass");
+
+      // Use non-anonymous endpoint to actually exercise auth
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testDigestPreauthentication() throws Exception {
+      startServer(createDigestAuthenticator(), "DIGEST");
+      client = createClient("DIGEST", "admin", "adminpass");
+
+      // First request triggers full Digest challenge-response and caches the nonce
+      RestResponse r1 = client.container().info().toCompletableFuture().get();
+      assertThat(r1.status()).isBetween(200, 204);
+
+      // Subsequent requests use preauthentication (cached nonce, no 401 round-trip)
+      for (int i = 0; i < 5; i++) {
+         RestResponse r = client.container().info().toCompletableFuture().get();
+         assertThat(r.status()).isBetween(200, 204);
+      }
+   }
+
+   @Test
+   public void testDigestNoAuthentication() throws Exception {
+      startServer(createDigestAuthenticator(), "DIGEST");
+
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      client = RestClient.forConfiguration(builder.build());
+
+      // Health endpoint is accessible anonymously even when auth is configured
+      RestResponse r = client.container().healthStatus().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testLocalUserAuthentication() throws Exception {
+      startServer(createLocalUserAuthenticator(), "LOCALUSER");
+      client = createClient("LOCALUSER");
+
+      // Use non-anonymous endpoint to actually exercise LOCALUSER auth
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testLocalUserSessionTokenPreauthentication() throws Exception {
+      startServer(createLocalUserAuthenticator(), "LOCALUSER");
+      client = createClient("LOCALUSER");
+
+      // First request: full 3-round-trip challenge-response
+      RestResponse r1 = client.container().info().toCompletableFuture().get();
+      assertThat(r1.status()).isBetween(200, 204);
+
+      // Subsequent requests should also succeed
+      for (int i = 0; i < 5; i++) {
+         RestResponse r = client.container().info().toCompletableFuture().get();
+         assertThat(r.status()).isBetween(200, 204);
+      }
+   }
+
+   @Test
+   public void testAutoDetectLocalUser() throws Exception {
+      // Simulates the CLI flow: AUTO mechanism, no credentials, server with both DIGEST and LOCALUSER
+      startServer(createMultiMechanismAuthenticator(), "DIGEST", "LOCALUSER");
+
+      // Create client with AUTO mechanism and no credentials (like the CLI does)
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      builder.security().authentication().enable();
+      client = RestClient.forConfiguration(builder.build());
+
+      // Access a non-anonymous endpoint - should auto-detect and use LOCALUSER
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+   }
+
+   @Test
+   public void testLocalUserChallengeLimitEnforced() throws Exception {
+      startServer(createLocalUserAuthenticator(), "LOCALUSER");
+
+      HttpClient httpClient = HttpClient.newHttpClient();
+      String baseUrl = "http://" + restServer.getHost() + ":" + restServer.getPort() + "/rest/v2/container";
+
+      // Exhaust the pending challenge limit without completing any handshakes
+      for (int i = 0; i < 16; i++) {
+         HttpRequest request = HttpRequest.newBuilder()
+               .uri(URI.create(baseUrl))
+               .header("Authorization", "Localuser")
+               .GET()
+               .build();
+         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+         assertThat(response.statusCode()).isEqualTo(401);
+      }
+
+      // The next request should be rejected with 429
+      HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl))
+            .header("Authorization", "Localuser")
+            .GET()
+            .build();
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      assertThat(response.statusCode()).isEqualTo(429);
+   }
+
+   @Test
+   public void testLocalUserMalformedHexReturns401() throws Exception {
+      startServer(createLocalUserAuthenticator(), "LOCALUSER");
+
+      HttpClient httpClient = HttpClient.newHttpClient();
+      String baseUrl = "http://" + restServer.getHost() + ":" + restServer.getPort() + "/rest/v2/container";
+
+      // Step 1: initiate handshake to get a valid challenge file path
+      HttpRequest initRequest = HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl))
+            .header("Authorization", "Localuser")
+            .GET()
+            .build();
+      HttpResponse<String> initResponse = httpClient.send(initRequest, HttpResponse.BodyHandlers.ofString());
+      assertThat(initResponse.statusCode()).isEqualTo(401);
+
+      String wwwAuth = initResponse.headers().firstValue("WWW-Authenticate").orElseThrow();
+      String challengePath = wwwAuth.substring("Localuser ".length());
+
+      // Step 2: respond with an odd-length hex string — should get 401, not 500
+      HttpRequest badRequest = HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl))
+            .header("Authorization", "Localuser " + challengePath + " abc")
+            .GET()
+            .build();
+      HttpResponse<String> badResponse = httpClient.send(badRequest, HttpResponse.BodyHandlers.ofString());
+      assertThat(badResponse.statusCode()).isEqualTo(401);
+   }
+
+   @Test
+   public void testLocalUserRejectedFromNonLoopback() throws Exception {
+      InetAddress nonLoopback;
+      try {
+         nonLoopback = NetworkAddress.nonLoopback("test").getAddress();
+      } catch (Exception e) {
+         Assumptions.abort("No non-loopback interface available");
+         return;
+      }
+
+      startServer(nonLoopback.getHostAddress(), createLocalUserAuthenticator(), "LOCALUSER");
+
+      HttpClient httpClient = HttpClient.newHttpClient();
+      String baseUrl = "http://" + nonLoopback.getHostAddress() + ":" + restServer.getPort() + "/rest/v2/container";
+
+      HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(baseUrl))
+            .header("Authorization", "Localuser")
+            .GET()
+            .build();
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      // The mechanism should not engage for non-loopback: no challenge file created
+      String wwwAuth = response.headers().firstValue("WWW-Authenticate").orElse("");
+      assertThat(wwwAuth).doesNotContain("challenge");
+   }
+
+   @Test
+   public void testAutoDetectDigestWithCredentials() throws Exception {
+      // Simulates the CLI flow: connect -u admin -p adminpass with AUTO mechanism
+      // The client must NOT eagerly preauthenticate with Basic (which the server doesn't support)
+      startServer(createMultiMechanismAuthenticator(), "DIGEST", "LOCALUSER");
+
+      RestClientConfigurationBuilder builder = new RestClientConfigurationBuilder();
+      builder.addServer().host(restServer.getHost()).port(restServer.getPort());
+      builder.security().authentication().enable().username("admin").password("adminpass");
+      client = RestClient.forConfiguration(builder.build());
+
+      RestResponse r = client.container().info().toCompletableFuture().get();
+      assertThat(r.status()).isBetween(200, 204);
+
+      // Subsequent requests should use Digest preauthentication
+      for (int i = 0; i < 3; i++) {
+         RestResponse r2 = client.container().info().toCompletableFuture().get();
+         assertThat(r2.status()).isBetween(200, 204);
+      }
+   }
+}

--- a/server/tests/src/test/java/org/infinispan/server/security/AuthenticationMultiEndpointIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/security/AuthenticationMultiEndpointIT.java
@@ -244,9 +244,6 @@ public class AuthenticationMultiEndpointIT {
       }
 
       private void validateSuccess() {
-         if (isAnonymous && useAuth) {
-            throw new IllegalStateException("Authenticated client should not be allowed to connect to anonymous server");
-         }
          if (!isAnonymous && !useAuth) {
             throw new IllegalStateException("Unauthenticated client should not be allowed to connect to authenticated server");
          }

--- a/testing/src/main/java/org/infinispan/testing/ThreadLeakChecker.java
+++ b/testing/src/main/java/org/infinispan/testing/ThreadLeakChecker.java
@@ -116,6 +116,7 @@ public class ThreadLeakChecker {
                       "|Cleaner-" +
                       // Tomcat NIO connector threads
                       "|http-nio-" +
+                      "|localuser-challenge-cleanup" +
                       ").*");
    private static final Pattern ARQUILLIAN_CONSOLE_CONSUMER_REGEX = Pattern.compile("org\\.jboss(\\.as)?\\.arquillian\\.container[^$]+\\$ConsoleConsumer");
    private static final boolean ENABLED =


### PR DESCRIPTION
To try it out:

```
mvn clean install -DskipTests
cd server/runtime/target/infinispan-server-16.2.0-SNAPSHOT
./bin/server.sh
```
in another terminal
```
./bin/cli.sh
connect
```
and you should be able to manage the server without creating a user and authenticating.
Magic!

Probably the last feature gap since we moved away from WildFly server.

Closes #16154