### PR TITLE
Bump WildFly from 39.0.0.Final to 39.0.1.Final

### DIFF
--- a/build/configuration/pom.xml
+++ b/build/configuration/pom.xml
@@ -55,7 +55,7 @@
 
       <!-- org.wildfly / org.jboss.eap -->
       <appserver.groupId>org.wildfly</appserver.groupId>
-      <appserver.version>39.0.0.Final</appserver.version>
+      <appserver.version>39.0.1.Final</appserver.version>
 
       <!-- Java source/target version -->
       <maven.min.version>3.9.0</maven.min.version>


### PR DESCRIPTION
https://www.wildfly.org/news/2026/02/12/WildFly-39-0-1-is-released/