### PR TITLE
[#16916] Graceful shutdown handle network partition

### DIFF
--- a/cli/src/main/resources/help/topology.adoc
+++ b/cli/src/main/resources/help/topology.adoc
@@ -1,0 +1,42 @@
+TOPOLOGY(1)
+===========
+:doctype: manpage
+
+
+NAME
+----
+topology - manages the cluster topology for caches recovering from a graceful shutdown.
+
+
+SYNOPSIS
+--------
+*topology set-stable* ['OPTIONS'] ['CACHE_NAME']
+
+
+DESCRIPTION
+-----------
+After a graceful shutdown, caches remain unavailable until all members from the previous topology rejoin the cluster.
+If some members cannot rejoin, use `topology set-stable` to install the current topology as the new stable topology so the cache becomes operational again.
+
+The command verifies that the number of missing members does not exceed the number of owners configured for the cache.
+If too many members are missing, data loss is likely and the command fails unless the `--force` flag is provided.
+
+
+SET-STABLE OPTIONS
+------------------
+*-f*::
+Forces the topology installation even when the number of missing members exceeds the number of owners. This may result in data loss for segments that have no surviving owner.
+
+
+EXAMPLES
+--------
+`topology set-stable my-cache` +
+Installs the current members as the stable topology for cache `my-cache`. Fails if too many members are missing.
+
+`topology set-stable -f my-cache` +
+Forces the topology installation for cache `my-cache`, even if the number of missing members exceeds the number of owners.
+
+
+SEE ALSO
+--------
+shutdown(1), availability(1)

--- a/core/src/main/java/org/infinispan/commands/topology/RebalancePolicyUpdateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/topology/RebalancePolicyUpdateCommand.java
@@ -44,6 +44,7 @@ public class RebalancePolicyUpdateCommand extends AbstractCacheControlCommand {
    public String toString() {
       return "RebalanceEnableCommand{" +
             "cacheName='" + cacheName + '\'' +
+            ", enabled=" + enabled +
             '}';
    }
 }

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -105,6 +105,19 @@ public interface ConsistentHash {
    Set<Integer> getPrimarySegmentsForOwner(Address owner);
 
    /**
+    * Transform this hash into another utilizing the address mapper.
+    *
+    * <p>
+    * This method does not update the mapping of segments. It returns a new consistent hash with the addresses transformed
+    * by the given mapper.
+    * </p>
+    *
+    * @param mapper maps one address to another.
+    * @return A new consistent hash with the addresses remapped.
+    */
+   ConsistentHash transform(Function<Address, Address> mapper);
+
+   /**
     * Returns a string containing all the segments and their associated addresses.
     */
    String getRoutingTableAsString();

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
@@ -205,6 +205,23 @@ public class DefaultConsistentHash extends AbstractConsistentHash {
    }
 
    @Override
+   public ConsistentHash transform(Function<Address, Address> mapper) {
+      List<Address> remappedMembers = new ArrayList<>();
+      Map<Address, Float> remappedCf = new HashMap<>();
+      for (int i = 0; i < members.size(); i++) {
+         Address member = members.get(i);
+         Address remapped = mapper.apply(member);
+         remappedMembers.add(remapped);
+         remappedCf.put(remapped, capacityFactors.get(i));
+      }
+      List<Address>[] remappedSegmentOwners = new List[segmentOwners.length];
+      for (int i = 0; i < segmentOwners.length; i++) {
+         remappedSegmentOwners[i] = segmentOwners[i].stream().map(mapper).toList();
+      }
+      return new DefaultConsistentHash(numOwners, segmentOwners.length, remappedMembers, remappedCf, remappedSegmentOwners);
+   }
+
+   @Override
    public List<Address> locateOwnersForSegment(int segmentId) {
       return segmentOwners[segmentId];
    }

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
@@ -260,6 +260,21 @@ public class ReplicatedConsistentHash implements ConsistentHash {
    }
 
    @Override
+   public ConsistentHash transform(Function<Address, Address> mapper) {
+      List<Address> remappedMembers = new ArrayList<>();
+      Map<Address, Float> remappedCf = new HashMap<>();
+      List<Address> remappedWithoutState = new ArrayList<>();
+      for (Address member : members) {
+         Address remapped = mapper.apply(member);
+         remappedMembers.add(remapped);
+         remappedCf.put(remapped, capacityFactors.get(member));
+         if (membersWithoutState.contains(member))
+            remappedWithoutState.add(remapped);
+      }
+      return new ReplicatedConsistentHash(remappedMembers, remappedCf, remappedWithoutState, primaryOwners);
+   }
+
+   @Override
    public String getRoutingTableAsString() {
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < primaryOwners.size(); i++) {

--- a/core/src/main/java/org/infinispan/topology/CacheStatusResponse.java
+++ b/core/src/main/java/org/infinispan/topology/CacheStatusResponse.java
@@ -2,6 +2,8 @@ package org.infinispan.topology;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.partitionhandling.AvailabilityMode;
@@ -17,7 +19,7 @@ import org.infinispan.remoting.transport.Address;
 @ProtoTypeId(ProtoStreamTypeIds.CACHE_STATUS_RESPONSE)
 public class CacheStatusResponse implements Serializable {
 
-   private static final CacheStatusResponse EMPTY = new CacheStatusResponse(null, null, null, null, null);
+   private static final CacheStatusResponse EMPTY = new CacheStatusResponse(null, null, null, null, null, null);
 
    @ProtoField(1)
    final CacheJoinInfo cacheJoinInfo;
@@ -34,14 +36,18 @@ public class CacheStatusResponse implements Serializable {
    @ProtoField(5)
    final List<Address> current;
 
+   @ProtoField(6)
+   final Set<UUID> previous;
+
    @ProtoFactory
    public CacheStatusResponse(CacheJoinInfo cacheJoinInfo, CacheTopology cacheTopology, CacheTopology stableTopology,
-                              AvailabilityMode availabilityMode, List<Address> current) {
+                              AvailabilityMode availabilityMode, List<Address> current, Set<UUID> previous) {
       this.cacheJoinInfo = cacheJoinInfo;
       this.cacheTopology = cacheTopology;
       this.stableTopology = stableTopology;
       this.availabilityMode = availabilityMode;
       this.current = current;
+      this.previous = previous;
    }
 
    public static CacheStatusResponse empty() {
@@ -53,7 +59,8 @@ public class CacheStatusResponse implements Serializable {
             && cacheTopology == null
             && stableTopology == null
             && availabilityMode == null
-            && current == null;
+            && current == null
+            && previous == null;
    }
 
    public CacheJoinInfo getCacheJoinInfo() {
@@ -79,12 +86,17 @@ public class CacheStatusResponse implements Serializable {
       return current;
    }
 
+   public Set<UUID> previousMembers() {
+      return previous;
+   }
+
    @Override
    public String toString() {
       return "StatusResponse{" +
             "cacheJoinInfo=" + cacheJoinInfo +
             ", cacheTopology=" + cacheTopology +
             ", stableTopology=" + stableTopology +
+            ", previousMembers=" + previous +
             '}';
    }
 }

--- a/core/src/main/java/org/infinispan/topology/CacheTopology.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopology.java
@@ -271,6 +271,7 @@ public class CacheTopology {
             ", unionCH=" + unionCH +
             ", actualMembers=" + actualMembers +
             ", persistentUUIDs=" + persistentUUIDs +
+            ", restored=" + restoredFromState +
             '}';
    }
 

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -14,12 +14,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.IllegalLifecycleStateException;
@@ -28,6 +30,8 @@ import org.infinispan.commons.util.Immutables;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.conflict.impl.InternalConflictManager;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.PersistedConsistentHash;
+import org.infinispan.distribution.ch.impl.ConsistentHashFactory;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.globalstate.ScopedPersistentState;
@@ -83,6 +87,8 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
    private volatile Map<Address, Float> capacityFactors;
    // Cache members that have not yet received state. Always included in the members list.
    private volatile List<Address> joiners;
+   // Cache members restoring from graceful shutdown.
+   private volatile Set<UUID> restoredMembers;
    // Persistent state (if it exists)
    private final Optional<ScopedPersistentState> persistentState;
    // Cache topology. Its consistent hashes contain only members that did receive/are receiving state
@@ -148,6 +154,12 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
    public void queueRebalance(List<Address> newMembers) {
       acquireLock();
       try {
+         if (isRestoringStableTopology()) {
+            log.debugf("Postponing rebalance for cache %s, waiting for stable topology confirmations from %s",
+                  cacheName, restoredMembers);
+            return;
+         }
+
          if (newMembers != null && !newMembers.isEmpty() && totalCapacityFactors() != 0f) {
             log.debugf("Queueing rebalance for cache %s with members %s", cacheName, newMembers);
             queuedRebalanceMembers = newMembers;
@@ -241,6 +253,11 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          this.currentTopology = currentTopology;
          this.stableTopology = stableTopology;
          this.availabilityMode = availabilityMode;
+
+         if (isRestoringStableTopology()) {
+            log.debugf("Skipping broadcast after merge for cache %s, it is restoring from persistent state", cacheName);
+            return;
+         }
 
          clusterTopologyManager.broadcastTopologyUpdate(cacheName, currentTopology, availabilityMode);
 
@@ -527,6 +544,10 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
    public void updateCurrentTopology(List<Address> newMembers) {
       acquireLock();
       try {
+         if (isRestoringStableTopology()) {
+            log.debugf("Postponing topology update for cache %s, waiting stable topology install for %s", cacheName, restoredMembers);
+            return;
+         }
          // The current topology might be null just after a joiner became the coordinator
          if (currentTopology == null) {
             createInitialCacheTopology();
@@ -669,7 +690,10 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          for (Map.Entry<Address, CacheStatusResponse> e : statusResponses.entrySet()) {
             Address sender = e.getKey();
             CacheStatusResponse response = e.getValue();
-            joinInfos.put(sender, response.getCacheJoinInfo());
+            // Include nodes that have completed joining or have persistent state from a graceful shutdown.
+            // Nodes with persistent state need to be in expectedMembers so the coordinator can restore the topology.
+            if (response.getStableTopology() != null || response.getCacheJoinInfo().getPersistentStateChecksum().isPresent())
+               joinInfos.put(sender, response.getCacheJoinInfo());
             if (response.getCacheTopology() != null) {
                currentTopologies.add(response.getCacheTopology());
             }
@@ -681,10 +705,21 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          log.debugf("Recovered %d partition(s) for cache %s: %s", currentTopologies.size(), cacheName, currentTopologies);
          recoverMembers(joinInfos, currentTopologies, stableTopologies);
 
+         // Recreate and flag the cache in case the cache has a graceful shutdown pending.
+         recoverPersistentState(statusResponses);
+
          // TODO Should automatically detect when the coordinator has left and there is only one partition
          // and continue any in-progress rebalance without resetting the cache topology.
 
          availabilityStrategy.onPartitionMerge(this, statusResponses);
+
+         // After merge processing, if all restored members are present, attempt topology restoration.
+         // This handles the case where a coordinator change during graceful shutdown recovery
+         // left some nodes without the restored topology, but all original members are now in the cluster.
+         // This avoids completing the whole join cycle again.
+         if (isRestoringStableTopology() && status == ComponentStatus.INSTANTIATED) {
+            restoreTopologyFromState();
+         }
       } catch (IllegalLifecycleStateException e) {
          // Retrieving the conflict manager fails during shutdown, because internalGetCache checks the manager status
          // Remote invocations also fail if the transport is stopped before recovery finishes
@@ -713,6 +748,54 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          if (!expectedMembers.contains(e.getKey())) {
             addMember(e.getKey(), e.getValue());
          }
+      }
+   }
+
+   @GuardedBy("lock")
+   private void recoverPersistentState(Map<Address, CacheStatusResponse> statusResponses) {
+      // If none of the nodes has a persistent state set, we can return, there is nothing to restore.
+      if (statusResponses.values().stream().map(CacheStatusResponse::getCacheJoinInfo).allMatch(cji -> cji.getPersistentStateChecksum().isEmpty()))
+         return;
+
+      // Otherwise, we need to calculate which nodes belong to the previous topology.
+      // We might have some different cases:
+      //
+      // 1. Everything runs correctly, the coordinator installs the stable topology in all nodes, and later a coordinator change.
+      // In this case, we consider the cache as recovered, we need to carefully calculate the nodes.
+      // If the coordinator change is caused by the previous coordinator leaving, it won't have a status response in the map.
+      //
+      // 2. There was a problem with the network during the stable topology recovery.
+      // In this case, only *some* of the nodes will have a stable topology. The nodes that do not have a stable topology,
+      // have not received the stable topology from the coordinator. We need to keep the addresses of the nodes which haven't
+      // received the topology until they join the cache.
+      //
+      // 3. There was a problem with the network and this is a partial restore.
+      // If the network was split in multiple partitions (or some nodes have left the cluster), they won't be included in
+      // response maps since they are not reachable. We need to be able to distinguish between a node that successfully
+      // recovered and left, to a node that didn't recovered and left.
+      Set<UUID> members = new HashSet<>();
+      Set<UUID> seenStable = new HashSet<>();
+
+      for (CacheStatusResponse csr : statusResponses.values()) {
+         CacheJoinInfo cji = csr.getCacheJoinInfo();
+         if (cji.getPersistentStateChecksum().isEmpty())
+            continue;
+
+         Set<UUID> previous = csr.previousMembers();
+         if (previous != null && !previous.isEmpty()) {
+            members.addAll(previous);
+         }
+
+         CacheTopology topology = csr.getStableTopology();
+         if (topology != null)
+            seenStable.add(cji.getPersistentUUID());
+      }
+
+      members.removeAll(seenStable);
+
+      if (!members.isEmpty()) {
+         restoredMembers = members;
+         log.debugf("Cache %s has pending members %s to restore stable topology", cacheName, restoredMembers);
       }
    }
 
@@ -749,8 +832,17 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
             }
          } else {
             // A joiner with state can not join a cache without a state.
-            if (joinInfo.getPersistentStateChecksum().isPresent()) {
+            // We only allow this in case the nodes were restoring and a partition happened.
+            // A previous participant might have a state and the coordinator don't.
+            if (joinInfo.getPersistentStateChecksum().isPresent() && !isRejoiningFromPersistentState(joinInfo)) {
                throw CLUSTER.nodeWithPersistentStateJoiningClusterWithoutState(joiner, cacheName);
+            }
+
+            // We also validate the case where the coordinator has already installed the stable topology and deleted the state,
+            // but it is still waiting the other nodes confirm the stable topology.
+            // In this case, we delay the joiner same as when the node has the persistent state.
+            if (joinInfo.getPersistentStateChecksum().isEmpty() && isRestoringStableTopology() && !restoredMembers.contains(joinInfo.getPersistentUUID())) {
+               return CacheStatusResponse.empty();
             }
          }
 
@@ -759,14 +851,23 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          if (!memberJoined) {
             if (log.isTraceEnabled()) log.tracef("Trying to add node %s to cache %s, but it is already a member: " +
                                                  "members = %s, joiners = %s, availability = %s", joiner, cacheName, expectedMembers, joiners, availabilityMode);
-            return new CacheStatusResponse(null, currentTopology, stableTopology, availabilityMode, expectedMembers);
+            // Suppress stableTopology only if it has restored=false during recovery, as that would trigger store clearing on the receiving node.
+            // A restored=true stableTopology is safe, it signals data came from persistent state.
+            CacheTopology st = isRestoringStableTopology() && stableTopology != null && !stableTopology.wasTopologyRestoredFromState()
+                  ? null : stableTopology;
+            return new CacheStatusResponse(null, currentTopology, st, availabilityMode, expectedMembers, null);
          }
          final List<Address> current = Collections.unmodifiableList(expectedMembers);
          if (status == ComponentStatus.INSTANTIATED) {
-            if (persistentState.isPresent()) {
+            if (persistentState.isPresent() || isRejoiningFromPersistentState(joinInfo)) {
                if (log.isTraceEnabled()) log.tracef("Node %s joining. Attempting to reform previous cluster", joiner);
                if (restoreTopologyFromState()) {
-                  return new CacheStatusResponse(null, currentTopology, stableTopology, availabilityMode, current);
+                  return new CacheStatusResponse(null, currentTopology, stableTopology, availabilityMode, current, null);
+               }
+
+               // If the cache has a stable topology pending, we return null for now until all missing nodes join again.
+               if (isRestoringStableTopology()) {
+                  return new CacheStatusResponse(null, currentTopology, null, availabilityMode, current, null);
                }
             } else {
                if (isFirstMember) {
@@ -792,10 +893,21 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          if (topologyBeforeRebalance != null)
             availabilityStrategy.onJoin(this, joiner);
 
-         return new CacheStatusResponse(null, topologyBeforeRebalance, stableTopology, availabilityMode, current);
+         return new CacheStatusResponse(null, topologyBeforeRebalance, stableTopology, availabilityMode, current, null);
       } finally {
          releaseLock();
       }
+   }
+
+   /**
+    * Verify whether a joiner is a member missing from the previous topology.
+    *
+    * @param cji The joiner information
+    * @return {@code true} if the joiner UUID is listed as missing. {@code false}, otherwise.
+    */
+   @GuardedBy("lock")
+   private boolean isRejoiningFromPersistentState(CacheJoinInfo cji) {
+      return isRestoringStableTopology() && restoredMembers.contains(cji.getPersistentUUID());
    }
 
    CompletionStage<Void> nodeCanJoinFuture(CacheJoinInfo joinInfo) {
@@ -826,6 +938,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          throw CLUSTER.extraneousMembersJoinRestoredCache(extraneousMembers, cacheName);
       }
       int topologyId = currentTopology == null ? initialTopologyId : currentTopology.getTopologyId() + 1;
+      restoredMembers = new HashSet<>(persistentUUIDManager.mapAddresses(ch.getMembers()));
       CacheTopology initialTopology = new CacheTopology(topologyId, INITIAL_REBALANCE_ID, true, ch, null,
             CacheTopology.Phase.NO_REBALANCE, ch.getMembers(), persistentUUIDManager.mapAddresses(ch.getMembers()));
       return cacheTopologyCreated(initialTopology);
@@ -842,13 +955,58 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
 
    @GuardedBy("lock")
    private boolean restoreTopologyFromState() {
-      assert persistentState.isPresent() : "Persistent state not available";
-      CacheTopology topology = restoreCacheTopology(persistentState.get());
+      assert persistentState.isPresent() || (restoredMembers != null && !restoredMembers.isEmpty()) : "Persistent state not available";
+      CacheTopology topology;
+      // If the persistent state is still present, try restoring from it.
+      if (persistentState.isPresent()) {
+         topology = restoreCacheTopology(persistentState.get());
+      } else {
+         // In case the persistent state was cleaned without completing the stable topology restore.
+         // We restore the topology once all missing nodes join the cluster again.
+         // During this time, all extraneous members will be unable to join.
+         // The list of nodes should include only the previous nodes.
+         topology = restoreMissingMembers();
+      }
+
       if (topology != null) {
          restoreTopologyFromState(topology);
          return true;
       }
       return false;
+   }
+
+   @GuardedBy("lock")
+   private CacheTopology restoreMissingMembers() {
+      if (stableTopology == null || !isRestoringStableTopology())
+         return null;
+
+      Set<UUID> current = expectedMembers.stream()
+            .map(persistentUUIDManager.addressToPersistentUUID())
+            .collect(Collectors.toSet());
+
+      if (!current.containsAll(restoredMembers)) {
+         log.tracef("Cache %s is still missing member exp=%s, curr=%s, rest=%s", cacheName, expectedMembers, current, restoredMembers);
+         return null;
+      }
+
+      List<Address> oldMembers = stableTopology.getMembers();
+      Map<Address, Address> mapper = new HashMap<>();
+      List<Address> remappedMembers = new ArrayList<>(oldMembers.size());
+      for (Address oldAddr : oldMembers) {
+         UUID uuid = persistentUUIDManager.getPersistentUuid(oldAddr);
+         Address newAddr = persistentUUIDManager.getAddress(uuid);
+         mapper.put(oldAddr, newAddr);
+         remappedMembers.add(newAddr);
+      }
+
+      ConsistentHash remappedCH = currentTopology.getCurrentCH().transform(addr -> mapper.getOrDefault(addr, addr));
+      int topologyId = currentTopology.getTopologyId() + 1;
+      CacheTopology topology = new CacheTopology(topologyId, stableTopology.getRebalanceId(), true, remappedCH, null,
+            CacheTopology.Phase.NO_REBALANCE, remappedMembers, stableTopology.getMembersPersistentUUIDs());
+      cacheTopologyCreated(topology);
+      log.debugf("Cache %s restored after missing joins %s", cacheName, topology);
+
+      return topology;
    }
 
    @GuardedBy("lock")
@@ -862,6 +1020,31 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
       clusterTopologyManager.broadcastStableTopologyUpdate(cacheName, topology);
    }
 
+   public void stableTopologyInstallConfirmation(StableTopologyConfirmationCollector.StableTopologyConfirmationResult result) {
+      acquireLock();
+      try {
+         if (result.allNodesConfirmed()) {
+            log.debugf("Cache %s all nodes confirmed installing stable topology %s", cacheName, stableTopology);
+            restoredMembers = null;
+
+            // Phase 2: only update stable topology to trigger state file deletion.
+            // Don't touch currentTopology — preserve the restored CH at id=1.
+            int id = stableTopology.getTopologyId() + 1;
+            CacheTopology commitStable = new CacheTopology(id, stableTopology.getRebalanceId(), false,
+                  stableTopology.getCurrentCH(), null, CacheTopology.Phase.NO_REBALANCE,
+                  stableTopology.getMembers(), stableTopology.getMembersPersistentUUIDs());
+            setStableTopology(commitStable);
+            clusterTopologyManager.broadcastStableTopologyUpdate(cacheName, commitStable);
+            return;
+         }
+
+         restoredMembers = new HashSet<>(persistentUUIDManager.mapAddresses(List.copyOf(result.pending())));
+         log.debugf("Cache %s has unconfirmed nodes %s for stable topology %s", cacheName, restoredMembers, stableTopology);
+      } finally {
+         releaseLock();
+      }
+   }
+
    public boolean setCurrentTopologyAsStable(boolean force) {
       acquireLock();
       try {
@@ -869,9 +1052,22 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
 
          if (persistentState.isPresent()) {
             List<Address> members = getExpectedMembers();
-            var persistedCH = joinInfo.getConsistentHashFactory()
+            @SuppressWarnings("unchecked")
+            PersistedConsistentHash<?> persistedCH = joinInfo.getConsistentHashFactory()
                   .fromPersistentState(persistentState.get(), persistentUUIDManager.persistentUUIDToAddress());
-            int missing = persistedCH.missingUuids().size();
+
+            // Clean stale mappings: addresses resolved by PersistentUUIDManager but belonging to nodes that left during recovery.
+            for (Address chMember : persistedCH.consistentHash().getMembers()) {
+               if (!members.contains(chMember)) {
+                  persistentUUIDManager.removePersistentAddressMapping(chMember);
+               }
+            }
+
+            // Re-create with cleaned mappings — stale UUIDs now go into missingUuids.
+            persistedCH = joinInfo.getConsistentHashFactory()
+                  .fromPersistentState(persistentState.get(), persistentUUIDManager.persistentUUIDToAddress());
+
+            int missing = persistedCH.totalMembers() - members.size();
             int owners = joinInfo.getNumOwners();
             boolean isReplicated = gcr.getCacheManager().getCacheConfiguration(cacheName).clustering().cacheMode().isReplicated();
             if (!isReplicated && !force && missing >= owners) {
@@ -888,11 +1084,12 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
             } else {
                // We don't have enough members to safely recover the previous topology, so we create a new one, as the
                // node will clear the storage, so we don't need the same segments mapping.
-               var chf = joinInfo.getConsistentHashFactory();
+               ConsistentHashFactory<ConsistentHash> chf = joinInfo.getConsistentHashFactory();
                ch = chf.create(joinInfo.getNumOwners(), joinInfo.getNumSegments(), members, getCapacityFactors());
             }
             CacheTopology topology = new CacheTopology(initialTopologyId, INITIAL_REBALANCE_ID, true, ch, null,
                     CacheTopology.Phase.NO_REBALANCE, members, persistentUUIDManager.mapAddresses(members));
+            restoredMembers = null;
             restoreTopologyFromState(cacheTopologyCreated(topology));
             return true;
          }
@@ -942,6 +1139,12 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
    public void startQueuedRebalance() {
       acquireLock();
       try {
+         if (isRestoringStableTopology()) {
+            log.debugf("Postponing rebalance for cache %s, waiting for stable topology confirmations from %s",
+                  cacheName, restoredMembers);
+            return;
+         }
+
          // We cannot start rebalance until queued CR is complete
          if (conflictResolution != null) {
             log.tracef("Postponing rebalance for cache %s as conflict resolution is in progress", cacheName);
@@ -1120,6 +1323,21 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
 
    public void forceRebalance() {
       queueRebalance(getCurrentTopology().getMembers());
+   }
+
+   /**
+    * Verify whether stable topology is still restoring.
+    *
+    * <p>
+    * This execution is triggered in case the cluster is recovering from a graceful shutdown procedure. Until the stable
+    * topology is restored, no rebalancing should happen.
+    * </p>
+    *
+    * @return {@code true} if a stable topology is restoring. {@code false}, otherwise.
+    */
+   @GuardedBy("lock")
+   private boolean isRestoringStableTopology() {
+      return restoredMembers != null && !restoredMembers.isEmpty();
    }
 
    public CompletionStage<Void> forceAvailabilityMode(AvailabilityMode newAvailabilityMode) {

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -382,7 +382,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager, Globa
                Map<Address, CacheStatusResponse> cacheResponses =
                      responsesByCache.computeIfAbsent(cacheName, k -> new HashMap<>());
                cacheResponses.put(sender, new CacheStatusResponse(info, cacheTopology, stableTopology,
-                                                                  csr.getAvailabilityMode(), csr.joinedMembers()));
+                     csr.getAvailabilityMode(), csr.joinedMembers(), csr.previousMembers()));
             }
          }
          return null;
@@ -683,7 +683,24 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager, Globa
 
    void broadcastStableTopologyUpdate(String cacheName, CacheTopology cacheTopology) {
       ReplicableCommand command = new TopologyUpdateStableCommand(cacheName, transport.getAddress(), cacheTopology, viewId);
-      helper.executeOnClusterAsync(transport, command);
+      if (!cacheTopology.wasTopologyRestoredFromState()) {
+         helper.executeOnClusterAsync(transport, command);
+         return;
+      }
+
+      // We track the results in case the topology is restoring after a graceful shutdown.
+      // This is necessary to ensure that all nodes install the stable topology, even after network partitions.
+      // Until a response is collected, we assume the stable topology was not installed.
+      ClusterCacheStatus status = cacheStatusMap.get(cacheName);
+      StableTopologyConfirmationCollector collector = new StableTopologyConfirmationCollector(cacheTopology.getMembers());
+      helper.executeOnClusterSync(transport, command, getGlobalTimeout(), collector)
+            .whenComplete((result, t) -> {
+               if (t != null) {
+                  log.errorf(t, "Failed broadcasting stable topology of %s with topology %s", cacheName, cacheTopology);
+               } else {
+                  status.stableTopologyInstallConfirmation(result);
+               }
+            });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -13,10 +13,12 @@ import static org.infinispan.util.logging.events.Messages.MESSAGES;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +45,7 @@ import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.distribution.ch.PersistedConsistentHash;
+import org.infinispan.distribution.ch.impl.ConsistentHashPersistenceConstants;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.ComponentName;
@@ -178,7 +180,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
       CompletionStage<KeyValuePair<CacheStatusResponse, CacheTopology>> cf = orderOnCache(cacheName, () -> {
          log.debugf("Node %s joining cache %s", transport.getAddress(), cacheName);
          LocalCacheStatus cacheStatus = new LocalCacheStatus(joinInfo, stm, phm,
-               getNumberMembersFromState(cacheName, joinInfo), gcr.getNamedComponentRegistry(cacheName));
+               getNumberMembersFromState(cacheName), gcr.getNamedComponentRegistry(cacheName));
          LocalCacheStatus previousStatus = runningCaches.put(cacheName, cacheStatus);
          if (previousStatus != null) {
             throw new IllegalStateException("A cache can only join once");
@@ -303,8 +305,10 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
                                     viewId, transport.getCoordinator(), cacheStatus, initialStatus)
                    .thenCompose(applied -> {
                       if (!applied) {
-                         throw new IllegalStateException(
-                               "We already had a newer topology by the time we received the join response");
+                         // The node already has this or a newer topology installed.
+                         // This can happen when a recovery join retries after a view change.
+                         log.debugf("Cache %s join response topology already applied, skipping", cacheName);
+                         return CompletableFuture.completedFuture(null);
                       }
 
                       LocalCacheStatus lcs = runningCaches.get(cacheName);
@@ -336,12 +340,40 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
       return ct;
    }
 
-   private int getNumberMembersFromState(String cacheName, CacheJoinInfo joinInfo) {
-      Optional<ScopedPersistentState> optional = globalStateManager.readScopedState(cacheName);
-      return optional.map(state -> joinInfo.getConsistentHashFactory()
-                  .fromPersistentState(state, persistentUUIDManager.persistentUUIDToAddress()))
-            .map(PersistedConsistentHash::totalMembers)
-            .orElse(-1);
+   private int getNumberMembersFromState(String cacheName) {
+      Set<UUID> uuids = getMemberUUIDsFromState(cacheName);
+      return uuids != null ? uuids.size() : -1;
+   }
+
+   private Set<UUID> getMemberUUIDsFromState(String cacheName) {
+      Optional<ScopedPersistentState> cacheStateOptional = globalStateManager.readScopedState(cacheName);
+      if (cacheStateOptional.isEmpty())
+         return null;
+
+      ScopedPersistentState state = cacheStateOptional.get();
+      Set<UUID> uuids = new HashSet<>();
+
+      // Main members
+      String membersCount = state.getProperty(ConsistentHashPersistenceConstants.STATE_MEMBERS);
+      if (membersCount != null) {
+         int count = Integer.parseInt(membersCount);
+         for (int i = 0; i < count; i++) {
+            uuids.add(UUID.fromString(state.getProperty(
+                  String.format(ConsistentHashPersistenceConstants.STATE_MEMBER, i))));
+         }
+      }
+
+      // Members without entries (replicated caches)
+      String noEntriesCount = state.getProperty(ConsistentHashPersistenceConstants.STATE_MEMBERS_NO_ENTRIES);
+      if (noEntriesCount != null) {
+         int count = Integer.parseInt(noEntriesCount);
+         for (int i = 0; i < count; i++) {
+            uuids.add(UUID.fromString(state.getProperty(
+                  String.format(ConsistentHashPersistenceConstants.STATE_MEMBER_NO_ENTRIES, i))));
+         }
+      }
+
+      return uuids.isEmpty() ? null : uuids;
    }
 
    @Override
@@ -385,7 +417,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
                // Ignore caches that haven't finished joining yet.
                // They will either wait for recovery to finish (if started in the current view)
                // or retry (if started in a previous view).
-               if (cacheStatus.getCurrentTopology() == null) {
+               if (cacheStatus.getCurrentTopology() == null || (cacheStatus.getStableTopology() == null && cacheStatus.needRecovery())) {
                   // If the cache has a persistent state, it tries to join again.
                   // The coordinator has cleared the previous information about running caches,
                   // so we need to send a join again for the caches waiting recovery in order to
@@ -397,16 +429,27 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
                            .whenComplete((ignore, t) -> {
                               if (t != null) leave(name, getGlobalTimeout());
                            });
+                     // We include this node information about the cache.
+                     // It has a null stable topology. The coordinator will identify that and mark the node as pending recovery.
+                     // This allows the node join later with a state, even if the coordinator is stateless.
+                     caches.put(cacheName, new CacheStatusResponse(cacheStatus.getJoinInfo(),
+                           cacheStatus.getCurrentTopology(),
+                           null,
+                           cacheStatus.getPartitionHandlingManager()
+                                 .getAvailabilityMode(),
+                           cacheStatus.knownMembers(),
+                           getMemberUUIDsFromState(cacheName)));
                   }
                   continue;
                }
 
                caches.put(e.getKey(), new CacheStatusResponse(cacheStatus.getJoinInfo(),
-                                                              cacheStatus.getCurrentTopology(),
-                                                              cacheStatus.getStableTopology(),
-                                                              cacheStatus.getPartitionHandlingManager()
-                                                                         .getAvailabilityMode(),
-                                                              cacheStatus.knownMembers()));
+                     cacheStatus.getCurrentTopology(),
+                     cacheStatus.getStableTopology(),
+                     cacheStatus.getPartitionHandlingManager()
+                           .getAvailabilityMode(),
+                     cacheStatus.knownMembers(),
+                     getMemberUUIDsFromState(cacheName)));
             }
          }
 
@@ -649,8 +692,14 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager, GlobalSta
          if (stableTopology == null || stableTopology.getTopologyId() < newStableTopology.getTopologyId()) {
             log.tracef("Updating stable topology for cache %s: %s", cacheName, newStableTopology);
             cacheStatus.setStableTopology(newStableTopology);
-            if (newStableTopology != null && cacheStatus.getJoinInfo().getPersistentUUID() != null) {
-               // Don't use the current CH state for the next restart
+            if (newStableTopology != null
+                  && cacheStatus.getJoinInfo().getPersistentUUID() != null
+                  && !newStableTopology.wasTopologyRestoredFromState()) {
+               // Don't use the current CH state for the next restart.
+               // We only delete the consistent hash in a subsequent stable topology installation.
+               // The consistent hash is kept in disk until we confirm, in a 2PC-like approach, that all nodes in the topology
+               // received the stable topology.
+               // If the topology was *not* restored, we then just delete it.
                deleteCHState(cacheName);
             }
          }

--- a/core/src/main/java/org/infinispan/topology/StableTopologyConfirmationCollector.java
+++ b/core/src/main/java/org/infinispan/topology/StableTopologyConfirmationCollector.java
@@ -1,0 +1,65 @@
+package org.infinispan.topology;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.commons.util.Immutables;
+import org.infinispan.remoting.responses.ValidResponse;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.ValidResponseCollector;
+
+/**
+ * Collects confirmations when restoring stable topology after a graceful shutdown.
+ *
+ * <p>
+ * When a stable topology with {@link CacheTopology#wasTopologyRestoredFromState()} is broadcast, this collector tracks
+ * which target nodes have acknowledged the update. Nodes that respond successfully are removed from the pending set; nodes
+ * that are unreachable or respond with an error remain pending.
+ * </p>
+ *
+ * <p>
+ * The resulting {@link StableTopologyConfirmationResult} provides the set of nodes that did not confirm, which is used
+ * by {@link ClusterCacheStatus} to delay rebalancing until all expected members have installed the restored topology.
+ * </p>
+ *
+ * @since 16.2
+ * @author José Bolina
+ */
+final class StableTopologyConfirmationCollector extends ValidResponseCollector<StableTopologyConfirmationCollector.StableTopologyConfirmationResult> {
+
+   private final Set<Address> targets;
+
+   public StableTopologyConfirmationCollector(Collection<Address> targets) {
+      this.targets = new HashSet<>(targets);
+   }
+
+   @Override
+   public StableTopologyConfirmationResult finish() {
+      return new StableTopologyConfirmationResult(Immutables.immutableSetWrap(targets));
+   }
+
+   @Override
+   protected StableTopologyConfirmationResult addValidResponse(Address sender, ValidResponse<?> response) {
+      targets.remove(sender);
+      return null;
+   }
+
+   @Override
+   protected StableTopologyConfirmationResult addTargetNotFound(Address sender) {
+      // Do nothing, keep the sender as still pending confirmation.
+      return null;
+   }
+
+   @Override
+   protected StableTopologyConfirmationResult addException(Address sender, Exception exception) {
+      // Do nothing, keep the sender as still pending confirmation.
+      return null;
+   }
+
+   public record StableTopologyConfirmationResult(Set<Address> pending) {
+      public boolean allNodesConfirmed() {
+         return pending.isEmpty();
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/globalstate/FourNodeTopologyReinstallTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/FourNodeTopologyReinstallTest.java
@@ -1,0 +1,209 @@
+package org.infinispan.globalstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.concurrent.AggregateCompletionStage;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.commons.util.concurrent.CompletionStages;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.testing.Exceptions;
+import org.infinispan.topology.MissingMembersException;
+import org.testng.annotations.Test;
+
+@Test(testName = "globalstate.FourNodeTopologyReinstallTest", groups = "functional")
+public class FourNodeTopologyReinstallTest extends AbstractGlobalStateRestartTest {
+
+   private static final int NUM_OWNERS = 2;
+
+   @Override
+   protected int getClusterSize() {
+      return 4;
+   }
+
+   @Override
+   protected void applyCacheManagerClusteringConfiguration(ConfigurationBuilder config) {
+      config.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(NUM_OWNERS);
+   }
+
+   public void testSafetyCheckWithNodeChurn() {
+      createInitialCluster();
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      assertStateFiles();
+      this.cacheManagers.clear();
+
+      // Start A and B: 2 present, 2 missing >= 2 owners, reject installing topolog.y
+      createStatefulCacheManager("A", false);
+      createStatefulCacheManager("B", false);
+      TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+
+      GlobalComponentRegistry gcrA = TestingUtil.extractGlobalComponentRegistry(manager(0));
+      Exceptions.expectException(MissingMembersException.class,
+            "ISPN000694.*missing too many members.*",
+            () -> gcrA.getClusterTopologyManager().useCurrentTopologyAsStable(CACHE_NAME, false));
+
+      // Stops node B before recovery.
+      EmbeddedCacheManager bManager = cacheManagers.remove(1);
+      TestingUtil.killCacheManagers(bManager);
+      TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+
+      // Start C. Cluster has {A, C}, still 2 missing (B, D) >= 2 owners. Should still reject installing topology.
+      createStatefulCacheManager("C", false);
+      TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+
+      GlobalComponentRegistry gcrAfterChurn = TestingUtil.extractGlobalComponentRegistry(manager(0));
+      Exceptions.expectException(MissingMembersException.class,
+            "ISPN000694.*missing too many members.*",
+            () -> gcrAfterChurn.getClusterTopologyManager().useCurrentTopologyAsStable(CACHE_NAME, false));
+
+      // Create the last node, we'll still miss node B
+      // Data should still be all available and the cluster is functional.
+      createStatefulCacheManager("D", false);
+      TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+
+      assertOperationsFail();
+      installTopologyOnCoordinator(false);
+
+      waitForClusterToForm(CACHE_NAME);
+      waitForStableTopology();
+
+      checkData();
+   }
+
+   public void testCacheOperationsAfterSafeReinstall() {
+      createInitialCluster();
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      assertStateFiles();
+      this.cacheManagers.clear();
+
+      // Restart 3 out of 4 nodes: 1 missing < 2 owners.
+      // Topology should install safely without data loss.
+      for (int i = 0; i < getClusterSize() - 1; i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+      TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+
+      assertOperationsFail();
+
+      installTopologyOnCoordinator(false);
+      waitForClusterToForm(CACHE_NAME);
+      waitForStableTopology();
+
+      checkData();
+
+      // After rebalance, all segments must have numOwners copies.
+      ConsistentHash ch = advancedCache(0, CACHE_NAME).getDistributionManager()
+            .getCacheTopology().getWriteConsistentHash();
+      for (int s = 0; s < ch.getNumSegments(); s++) {
+         assertThat(ch.locateOwnersForSegment(s))
+               .as("Segment %d should have %d owners after rebalance", s, NUM_OWNERS)
+               .hasSize(NUM_OWNERS);
+      }
+
+      // Add the 4th node back and verify full cluster.
+      createStatefulCacheManager("D", false);
+      waitForClusterToForm(CACHE_NAME);
+      checkData();
+   }
+
+   public void testCacheOperationsAfterForceReinstall() {
+      createInitialCluster();
+      cache(0, CACHE_NAME).shutdown();
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      assertStateFiles();
+      this.cacheManagers.clear();
+
+      // Restart only 2 out of 4: 2 missing >= 2 owners.
+      // The topology can only be installed with the force flag since it loses data.
+      for (int i = 0; i < NUM_OWNERS; i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+      TestingUtil.blockUntilViewsReceived(15000, getCaches(CACHE_NAME));
+
+      assertOperationsFail();
+
+      Exceptions.expectException(MissingMembersException.class,
+            "ISPN000694.*missing too many members.*",
+            () -> installTopologyOnCoordinator(false));
+
+      installTopologyOnCoordinator(true);
+      waitForClusterToForm(CACHE_NAME);
+      waitForStableTopology();
+
+      // Force install loses data but cache must be operational.
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         assertThat(cache(i, CACHE_NAME).size()).isGreaterThan(0);
+      }
+      assertCacheOperational();
+
+      // Add remaining nodes.
+      for (int i = NUM_OWNERS; i < getClusterSize(); i++) {
+         createStatefulCacheManager(Character.toString((char) ('A' + i)), false);
+      }
+      waitForClusterToForm(CACHE_NAME);
+
+      for (int i = 0; i < getClusterSize(); i++) {
+         assertThat(cache(i, CACHE_NAME).size()).isGreaterThan(0);
+      }
+   }
+
+   private void installTopologyOnCoordinator(boolean force) {
+      for (int j = 0; j < cacheManagers.size(); j++) {
+         EmbeddedCacheManager ecm = manager(j);
+         if (ecm.isCoordinator()) {
+            boolean installed = TestingUtil.extractGlobalComponentRegistry(ecm)
+                  .getClusterTopologyManager()
+                  .useCurrentTopologyAsStable(CACHE_NAME, force);
+            assertThat(installed).isTrue();
+            return;
+         }
+      }
+      throw new AssertionError("No coordinator found");
+   }
+
+   private void waitForStableTopology() {
+      AggregateCompletionStage<Void> topologyInstall = CompletionStages.aggregateCompletionStage();
+      for (int j = 0; j < cacheManagers.size(); j++) {
+         GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(manager(j));
+         topologyInstall.dependsOn(gcr.getLocalTopologyManager().stableTopologyCompletion(CACHE_NAME));
+      }
+      CompletableFutures.uncheckedAwait(topologyInstall.freeze().toCompletableFuture(), 30, TimeUnit.SECONDS);
+   }
+
+   private void assertOperationsFail() {
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         for (int v = 0; v < DATA_SIZE; v++) {
+            Cache<Object, Object> cache = cache(i, CACHE_NAME);
+            String key = String.valueOf(v);
+            Exceptions.expectException(MissingMembersException.class,
+                  "ISPN000689: Recovering cache 'testCache' but there are missing members, known members \\[.*\\] of a total of 4$",
+                  () -> cache.get(key));
+         }
+      }
+   }
+
+   private void assertStateFiles() {
+      for (int i = 0; i < getClusterSize(); i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertThat(listFiles).as("State file should exist for node %d", i).hasSize(1);
+      }
+   }
+
+   private void assertCacheOperational() {
+      cache(0, CACHE_NAME).put("post-reinstall", "value");
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         assertThat(cache(i, CACHE_NAME).get("post-reinstall")).isEqualTo("value");
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/globalstate/GracefulShutdownNetworkPartitionTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GracefulShutdownNetworkPartitionTest.java
@@ -1,0 +1,236 @@
+package org.infinispan.globalstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.test.TestingUtil.extractGlobalComponent;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.partitionhandling.BaseStatefulPartitionHandlingTest;
+import org.infinispan.partitionhandling.PartitionHandling;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.topology.CacheTopology;
+import org.infinispan.topology.LocalTopologyManager;
+import org.jgroups.JChannel;
+import org.jgroups.protocols.DISCARD;
+import org.jgroups.protocols.LOCAL_PING;
+
+@CleanupAfterMethod
+public class GracefulShutdownNetworkPartitionTest extends BaseStatefulPartitionHandlingTest {
+
+   {
+      partitionHandling = PartitionHandling.ALLOW_READ_WRITES;
+      numMembersInCluster = 5;
+      DATA_SIZE = 1000;
+      createDefault = false;
+   }
+
+   public void testNetworkPartitionWhenRestartingFromShutdown() throws Throwable {
+      createInitialCluster();
+      cache(0, CACHE_NAME).shutdown();
+
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      assertStateFiles();
+      cacheManagers.clear();
+
+      createStatefulCacheManagers(false);
+
+      // All but one member join the cluster. The cache is still not recovered.
+      for (int i = 0; i < numMembersInCluster - 1; i++) {
+         cache(i, CACHE_NAME);
+      }
+
+      final LocalTopologyManager ltm = extractGlobalComponent(manager(0), LocalTopologyManager.class);
+      assertThat(ltm.getCacheTopology(CACHE_NAME)).isNull();
+      assertThat(ltm.getStableCacheTopology(CACHE_NAME)).isNull();
+
+      // We cause a network partition.
+      // The node that needs to join is in the same partition as the coordinator.
+      splitCluster(new int[]{ 0, 3, 4 }, new int[]{ 1, 2 });
+      eventually(() -> {
+         List<Address> members = manager(0).getMembers();
+         return !members.containsAll(List.of(manager(1).getAddress(), manager(2).getAddress()));
+      });
+
+      // During the network partition, the last node joins.
+      cache(numMembersInCluster - 1, CACHE_NAME);
+
+      assertThat(ltm.isCacheRebalancingEnabled(CACHE_NAME)).isTrue();
+
+      partition(0).merge(partition(1), false);
+      eventually(() -> cacheManagers.stream().allMatch(ecm -> ecm.getMembers().size() == numMembersInCluster));
+      eventually(() -> cacheManagers.stream()
+            .map(ecm -> extractGlobalComponent(ecm, LocalTopologyManager.class))
+            .allMatch(localTopologyManager -> {
+               CacheTopology ct = localTopologyManager.getCacheTopology(CACHE_NAME);
+               return ct != null && ct.getMembers().size() == numMembersInCluster;
+            }), 30, TimeUnit.SECONDS);
+
+      int survivingData = cache(0, CACHE_NAME).size();
+      assertThat(survivingData)
+            .as("All data should survive graceful shutdown restart, even with partition")
+            .isEqualTo(DATA_SIZE);
+      assertCacheUsable();
+   }
+
+   public void testCoordinatorLeavesDuringPartition() throws Throwable {
+      actualTest(0);
+   }
+
+   public void testNodeLeavesDuringPartition() throws Throwable {
+      actualTest(1);
+   }
+
+   public void testCoordinatorLeavesAfterRecovery() throws Throwable {
+      createInitialCluster();
+      cache(0, CACHE_NAME).shutdown();
+
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      assertStateFiles();
+      cacheManagers.clear();
+
+      createStatefulCacheManagers(false);
+
+      log.info("Waiting for cluster to form again");
+      // All members join and recovery completes (Phase 1 + Phase 2).
+      waitForClusterToForm(CACHE_NAME);
+      checkData();
+
+      // Verify state files are deleted (Phase 2 completed).
+      for (int i = 0; i < numMembersInCluster; i++) {
+         String loc = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] stateFiles = new File(loc).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertThat(stateFiles).as("State file should be deleted after Phase 2").isNullOrEmpty();
+      }
+
+      // Kill the coordinator.
+      EmbeddedCacheManager killed = cacheManagers.remove(0);
+      TestingUtil.killCacheManagers(killed);
+
+      // The remaining cluster should converge without delays.
+      eventually(() -> cacheManagers.stream().allMatch(ecm -> ecm.getMembers().size() == numMembersInCluster - 1));
+      eventually(() -> cacheManagers.stream()
+            .map(ecm -> extractGlobalComponent(ecm, LocalTopologyManager.class))
+            .allMatch(l -> {
+               CacheTopology ct = l.getCacheTopology(CACHE_NAME);
+               return ct != null && ct.getMembers().size() == numMembersInCluster - 1;
+            }), 30, TimeUnit.SECONDS);
+
+      // No data loss.
+      int survivingData = cache(0, CACHE_NAME).size();
+      assertThat(survivingData)
+            .as("All data should survive coordinator leave after successful recovery")
+            .isEqualTo(DATA_SIZE);
+
+      assertCacheUsable();
+   }
+
+   private void actualTest(int nodeToKill) throws Throwable {
+      createInitialCluster();
+      cache(0, CACHE_NAME).shutdown();
+
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      assertStateFiles();
+      cacheManagers.clear();
+
+      createStatefulCacheManagers(false);
+
+      for (int i = 0; i < numMembersInCluster - 1; i++) {
+         cache(i, CACHE_NAME);
+      }
+
+      LocalTopologyManager ltm = extractGlobalComponent(manager(0), LocalTopologyManager.class);
+      assertThat(ltm.getCacheTopology(CACHE_NAME)).isNull();
+
+      // Partition: {0, 3, 4} vs {1, 2}
+      splitCluster(new int[]{0, 3, 4}, new int[]{1, 2});
+      eventually(() -> {
+         List<Address> members = manager(0).getMembers();
+         return !members.containsAll(List.of(manager(1).getAddress(), manager(2).getAddress()));
+      });
+
+      cache(numMembersInCluster - 1, CACHE_NAME);
+
+      // Kill the specified node while partition is still active
+      EmbeddedCacheManager killed = cacheManagers.remove(nodeToKill);
+      Address killedAddr = killed.getAddress();
+      JChannel killedChannel = channel(killed);
+      TestingUtil.killCacheManagers(killed);
+      for (int pi = 0; pi < 2; pi++) {
+         if (partition(pi).channels().remove(killedChannel)) break;
+      }
+
+      // Wait for surviving nodes to detect the leave, then merge
+      eventually(() -> cacheManagers.stream().noneMatch(ecm -> ecm.getMembers().contains(killedAddr)));
+      partition(0).merge(partition(1), false);
+      eventually(() -> cacheManagers.stream().allMatch(ecm -> ecm.getMembers().size() == numMembersInCluster - 1));
+
+      // Remove DISCARD from all surviving channels
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         channel(manager(i)).getProtocolStack().removeProtocol(DISCARD.class);
+      }
+
+      // Fix LOCAL_PING stale entries: clear and re-register coordinator first.
+      LOCAL_PING.clear();
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         JChannel ch = channel(manager(i));
+         if (ch.getAddress().equals(ch.getView().getCoord())) {
+            ((LOCAL_PING) ch.getProtocolStack().findProtocol(LOCAL_PING.class)).handleConnect();
+            break;
+         }
+      }
+      for (int i = 0; i < cacheManagers.size(); i++) {
+         JChannel ch = channel(manager(i));
+         if (!ch.getAddress().equals(ch.getView().getCoord())) {
+            ((LOCAL_PING) ch.getProtocolStack().findProtocol(LOCAL_PING.class)).handleConnect();
+         }
+      }
+
+      // Restart killed node with its original state directory
+      String stateId = Character.toString((char) ('A' + nodeToKill));
+      createStatefulCacheManager(stateId, false);
+      int restartedIndex = cacheManagers.size() - 1;
+      CompletableFuture<Void> join = CompletableFuture.runAsync(() -> cache(restartedIndex, CACHE_NAME), testExecutor());
+
+      // All nodes converge
+      eventually(() -> cacheManagers.stream().allMatch(ecm -> ecm.getMembers().size() == numMembersInCluster));
+      eventually(() -> cacheManagers.stream()
+            .map(ecm -> extractGlobalComponent(ecm, LocalTopologyManager.class))
+            .allMatch(l -> {
+               CacheTopology ct = l.getCacheTopology(CACHE_NAME);
+               return ct != null && ct.getMembers().size() == numMembersInCluster;
+            }), 30, TimeUnit.SECONDS);
+
+      TestingUtil.join(join);
+
+      // No data loss
+      int survivingData = cache(0, CACHE_NAME).size();
+      assertThat(survivingData)
+            .as("All data should survive graceful shutdown restart, even with node leave during partition")
+            .isEqualTo(DATA_SIZE);
+      assertCacheUsable();
+   }
+
+   private void assertStateFiles() {
+      for (int i = 0; i < numMembersInCluster; i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration().globalState().persistentLocation();
+         File[] listFiles = new File(persistentLocation).listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertEquals(Arrays.toString(listFiles), 1, listFiles.length);
+      }
+   }
+
+   private void assertCacheUsable() {
+      // Verify cache is still usable after recovery.
+      cache(0, CACHE_NAME).put("post-recovery-key", "post-recovery-value");
+      assertThat(cache(1, CACHE_NAME).get("post-recovery-key")).isEqualTo("post-recovery-value");
+      cache(2, CACHE_NAME).put("another-key", "another-value");
+      assertThat(cache(0, CACHE_NAME).get("another-key")).isEqualTo("another-value");
+   }
+}

--- a/core/src/test/java/org/infinispan/globalstate/GracefulShutdownStarPartitionTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GracefulShutdownStarPartitionTest.java
@@ -1,0 +1,264 @@
+package org.infinispan.globalstate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.infinispan.test.TestingUtil.extractGlobalComponent;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.partitionhandling.BaseStatefulPartitionHandlingTest;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.CacheTopology;
+import org.infinispan.topology.LocalTopologyManager;
+import org.jgroups.JChannel;
+import org.jgroups.MergeView;
+import org.jgroups.View;
+import org.jgroups.protocols.DISCARD;
+import org.jgroups.protocols.TP;
+import org.jgroups.protocols.pbcast.STABLE;
+import org.jgroups.stack.ProtocolStack;
+import org.jgroups.util.MutableDigest;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "globalstate.GracefulShutdownStarPartitionTest")
+public class GracefulShutdownStarPartitionTest extends BaseStatefulPartitionHandlingTest {
+
+   {
+      numMembersInCluster = 8;
+      // More data makes it more likely to reproduce the issue.
+      DATA_SIZE = 1000;
+      createDefault = false;
+   }
+
+   public void testDataLossWithStarPartitionDuringGracefulRestart() throws Exception {
+      // Phase 1: Create initial cluster and do graceful shutdown
+      createInitialCluster();
+
+      for (int i = 0; i < numMembersInCluster; i++) {
+         ((DefaultCacheManager) manager(i)).shutdownAllCaches();
+      }
+
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      // Verify all nodes have state files
+      verifyStateFilesExist();
+      cacheManagers.clear();
+
+      // Phase 2: Restart and create star partition
+      createStatefulCacheManagers(false);
+
+      // Create star partition BEFORE caches start
+      starSplitCluster(0);
+
+      LocalTopologyManager ltm = extractGlobalComponent(manager(0), LocalTopologyManager.class);
+
+      // NOW start caches - joins happen through partitioned network
+      // Midway through nodes joining, since the nodes are competing with suspect messages, the coordinator view changes.
+      for (int i = 0; i < numMembersInCluster; i++) {
+         cache(i, CACHE_NAME);
+
+         // After some nodes joined the cache topology, the coordinator view updates and removes some nodes.
+         if (i == numMembersInCluster - 3) {
+            removeFirstNFrom(0, 2);
+            // Wait until members are not included in the cache manager.
+            eventually(() -> {
+               List<Address> members = manager(0).getMembers();
+               return !members.containsAll(List.of(manager(1).getAddress(), manager(2).getAddress()));
+            });
+            assertThat(ltm.getStableCacheTopology(CACHE_NAME)).isNull();
+            assertThat(ltm.isCacheRebalancingEnabled(CACHE_NAME)).isFalse();
+         }
+      }
+
+      // Since there was a partition during the restore, the stable topology should not be installed.
+      // And state transfer should not be enabled.
+      TestingUtil.join(ltm.stableTopologyCompletion(CACHE_NAME));
+      assertThat(ltm.isCacheRebalancingEnabled(CACHE_NAME)).isTrue();
+
+      // Phase 4: Heal partition and check for data loss
+      healStarPartition();
+      eventually(() -> cacheManagers.stream().allMatch(ecm -> ecm.getMembers().size() == numMembersInCluster));
+      eventually(() -> cacheManagers.stream()
+            .map(ecm -> extractGlobalComponent(ecm, LocalTopologyManager.class))
+            .allMatch(localTopologyManager -> {
+               CacheTopology topology = localTopologyManager.getStableCacheTopology(CACHE_NAME);
+               return topology != null && topology.getMembers().size() == numMembersInCluster;
+            })
+      );
+
+      // No data should be lost during the restart.
+      int survivingData = cache(0, CACHE_NAME).size();
+      assertThat(survivingData)
+            .as("All data should survive graceful shutdown restart, even with partition")
+            .isEqualTo(DATA_SIZE);
+   }
+
+   private void verifyStateFilesExist() {
+      for (int i = 0; i < numMembersInCluster; i++) {
+         String persistentLocation = manager(i).getCacheManagerConfiguration()
+               .globalState().persistentLocation();
+         java.io.File[] listFiles = new java.io.File(persistentLocation)
+               .listFiles((dir, name) -> name.equals(CACHE_NAME + ".state"));
+         assertThat(listFiles).hasSize(1);
+      }
+   }
+
+   protected void starSplitCluster(int coordinator) {
+      List<org.jgroups.Address> allMembers = channel(manager(0)).getView().getMembers();
+      partitions = new Partition[numMembersInCluster - 1];
+
+      JChannel c = channel(manager(coordinator));
+
+      // Create N-1 partitions, each containing [coordinator, one other node]
+      int partitionIndex = 0;
+      for (int i = 0; i < numMembersInCluster; i++) {
+         if (i == coordinator) continue;
+
+         Partition p = new Partition(allMembers);
+         p.addNode(c);
+         p.addNode(channel(manager(i)));
+         partitions[partitionIndex] = p;
+         p.discardOtherMembersExceptCoordinator(coordinator);  // Only install DISCARD on non-coordinator
+         partitionIndex++;
+      }
+
+      viewId.set((int) c.getView().getViewId().getId());
+      int id = viewId.incrementAndGet();
+      View v = View.create(c.getAddress(), id, c.view().getMembers().toArray(new org.jgroups.Address[0]));
+      getGms(c).installView(v);
+
+      // Install the new views
+      for (Partition p : partitions) {
+         p.partition(coordinator);
+      }
+   }
+
+   protected void healStarPartition() {
+      if (partitions == null || partitions.length == 0) {
+         throw new IllegalStateException("No star partition to heal!");
+      }
+
+      // Enable for nodes to send messages to each while we install the new views.
+      Partition p0 = partitions[0];
+      for (Partition partition : partitions) {
+         if (partition == p0) continue;
+         p0.observeMembers(partition);
+         partition.observeMembers(p0);
+      }
+
+      // Collect all unique channels from all partitions
+      Set<JChannel> allChannelsSet = new HashSet<>();
+      List<View> subviews = new ArrayList<>();
+
+      for (Partition p : partitions) {
+         allChannelsSet.addAll(p.channels());
+         // Create subview for this partition for the merge
+         List<org.jgroups.Address> partitionAddresses = p.channels().stream()
+               .map(JChannel::getAddress)
+               .toList();
+         View subview = View.create(p.channels().get(0).getAddress(), viewId.get(),
+               partitionAddresses.toArray(new org.jgroups.Address[0]));
+         subviews.add(subview);
+      }
+
+      ArrayList<JChannel> allChannels = new ArrayList<>(allChannelsSet);
+
+      for (JChannel channel : allChannels) {
+         channel.getProtocolStack().removeProtocol(DISCARD.class);
+      }
+
+      // Use STABLE to clear sent messages (like in merge())
+      for (JChannel c : allChannels) {
+         STABLE stable = c.getProtocolStack().findProtocol(STABLE.class);
+         stable.gc();
+      }
+
+      try {
+         Thread.sleep(10);
+      } catch (InterruptedException e) {
+         e.printStackTrace();
+      }
+
+      // Install merge view
+      List<org.jgroups.Address> allAddresses = allChannels.stream()
+            .map(JChannel::getAddress)
+            .toList();
+      MergeView mv = new MergeView(allChannels.get(0).getAddress(), viewId.incrementAndGet(), allAddresses, subviews);
+
+      // Compute merge digest
+      MutableDigest digest = new MutableDigest(allAddresses.toArray(new org.jgroups.Address[0]));
+      for (JChannel c : allChannels) {
+         digest.merge(getGms(c).getDigest());
+      }
+
+      // Re-enable discovery on all channels
+      for (JChannel c : allChannels) {
+         enableDiscoveryProtocol(c);
+      }
+
+      // Install the merge view on all channels
+      for (JChannel c : allChannels) {
+         getGms(c).installView(mv, digest);
+      }
+
+      // Clear partitions
+      partitions = null;
+   }
+
+   protected void removeFirstNFrom(int target, int removals) {
+      JChannel ch = channel(manager(target));
+      org.jgroups.Address addr = ch.address();
+
+      List<org.jgroups.Address> members = new ArrayList<>();
+      members.add(addr);
+      List<org.jgroups.Address> ignore = new ArrayList<>(ch.view().getMembers());
+
+      int index = 0;
+      for (org.jgroups.Address member : ch.getView().getMembers()) {
+         if (Objects.equals(member, addr))
+            continue;
+
+         if (index++ < removals)
+            continue;
+
+         members.add(member);
+      }
+
+      ignore.removeAll(members);
+
+      // Mark some nodes to be ignored by the coordinator.
+      // Simulates as if the coordinator is unable to reach these nodes when they were removed from the view.
+      DISCARD discard = new DISCARD();
+      log.tracef("%s discarding messages from %s", ch.getAddress(), ignore);
+      discard.excludeItself(false);
+      for (org.jgroups.Address a : ignore) discard.addIgnoreMember(a);
+      try {
+         ch.getProtocolStack().insertProtocol(discard, ProtocolStack.Position.ABOVE, TP.class);
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+
+      // Install a new view without the removed nodes.
+      int id = viewId.incrementAndGet();
+      View suspectView = View.create(addr, id, members.toArray(new org.jgroups.Address[0]));
+      getGms(ch).installView(suspectView);
+      log.infof("Installing %s in %s", suspectView, ch.address());
+
+      // Some operations in the server will assert the viewId to accept operations, like joining a topology.
+      // We also update the view of all cluster members just bumping the IDs, the members are still the same.
+      for (int i = 0; i < numMembersInCluster; i++) {
+         JChannel c = channel(manager(i));
+         if (ch == c)
+            continue;
+
+         View v = c.getView();
+         View newView = View.create(v.getCoord(), id, v.getMembersRaw());
+         log.infof("Installing %s in %s", newView, c.address());
+         getGms(c).installView(newView);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -58,7 +58,7 @@ import org.testng.annotations.Test;
 public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
    protected static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
-   private final AtomicInteger viewId = new AtomicInteger(5);
+   protected final AtomicInteger viewId = new AtomicInteger(5);
    protected int numMembersInCluster = 4;
    protected int numberOfOwners = 2;
    protected volatile Partition[] partitions;
@@ -208,35 +208,51 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          channels.add(c);
       }
 
+      public List<JChannel> channels() {
+         return channels;
+      }
+
       public void partition() {
          log.trace("Partition forming");
          disableDiscovery();
-         installNewView();
-         assertPartitionFormed();
+         installNewView(-1, viewId.incrementAndGet());
+         assertPartitionFormed(-1);
          log.trace("New views installed");
+      }
+
+      public void partition(int coordinator) {
+         disableDiscovery();
+         installNewView(coordinator, viewId.get());
+         assertPartitionFormed(coordinator);
       }
 
       private void disableDiscovery() {
          channels.forEach(BasePartitionHandlingTest.this::disableDiscoveryProtocol);
       }
 
-      private void assertPartitionFormed() {
+      private void assertPartitionFormed(int index) {
          final List<Address> viewMembers = new ArrayList<>();
          for (JChannel ac : channels) viewMembers.add(ac.getAddress());
+
+         int i = 0;
          for (JChannel c : channels) {
             List<Address> members = c.getView().getMembers();
-            if (!members.equals(viewMembers)) throw new AssertionError();
+            if (i != index && !members.equals(viewMembers))
+               throw new AssertionError(String.format("Member %s (%d) has view with %s, the full cluster is %s", c.getAddress(), i, members, viewMembers));
+            i++;
          }
       }
 
-      private List<Address> installNewView() {
+      private List<Address> installNewView(int coord, long viewId) {
          final List<Address> viewMembers = new ArrayList<>();
          for (JChannel c : channels) viewMembers.add(c.getAddress());
-         View view = View.create(channels.get(0).getAddress(), viewId.incrementAndGet(),
+         View view = View.create(channels.get(0).getAddress(), viewId,
                                  viewMembers.toArray(new Address[0]));
 
          log.trace("Before installing new view...");
+         int i = 0;
          for (JChannel c : channels) {
+            if (i++ == coord) continue;
             getGms(c).installView(view);
          }
          return viewMembers;
@@ -306,6 +322,36 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          }
       }
 
+      public void discardOtherMembersExceptCoordinator(int coordinatorIndex) {
+         List<Address> outsideMembers = new ArrayList<>();
+         for (Address a : allMembers) {
+            boolean inThisPartition = false;
+            for (JChannel c : channels) {
+               if (c.getAddress().equals(a)) inThisPartition = true;
+            }
+            if (!inThisPartition) outsideMembers.add(a);
+         }
+
+         Address coordinatorAddress = channel(coordinatorIndex).getAddress();
+
+         for (JChannel c : channels) {
+            // Skip coordinator - it should be able to reach everyone
+            if (c.getAddress().equals(coordinatorAddress)) {
+               continue;
+            }
+
+            DISCARD discard = new DISCARD();
+            log.tracef("%s discarding messages from %s", c.getAddress(), outsideMembers);
+            discard.excludeItself(false);
+            for (Address a : outsideMembers) discard.addIgnoreMember(a);
+            try {
+               c.getProtocolStack().insertProtocol(discard, ProtocolStack.Position.ABOVE, TP.class);
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         }
+      }
+
       @Override
       public String toString() {
          StringBuilder addresses = new StringBuilder();
@@ -355,7 +401,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          log.trace("Discovery started.");
       }
 
-      private void observeMembers(Partition partition) {
+      public final void observeMembers(Partition partition) {
          for (JChannel c : channels) {
             List<Protocol> protocols = c.getProtocolStack().getProtocols();
             for (Protocol p : protocols) {
@@ -445,7 +491,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
       }
    }
 
-   private GMS getGms(JChannel c) {
+   protected final GMS getGms(JChannel c) {
       return c.getProtocolStack().findProtocol(GMS.class);
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseStatefulPartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseStatefulPartitionHandlingTest.java
@@ -30,7 +30,7 @@ import org.infinispan.topology.PersistentUUIDManager;
 
 public class BaseStatefulPartitionHandlingTest extends BasePartitionHandlingTest {
 
-   protected static final int DATA_SIZE = 100;
+   protected static int DATA_SIZE = 100;
    protected static final String CACHE_NAME = "testCache";
 
    protected boolean createDefault;
@@ -52,7 +52,7 @@ public class BaseStatefulPartitionHandlingTest extends BasePartitionHandlingTest
       }
    }
 
-   void createStatefulCacheManager(String id, boolean clear) {
+   protected void createStatefulCacheManager(String id, boolean clear) {
       createStatefulCacheManager(id, clear, true);
    }
 
@@ -98,7 +98,7 @@ public class BaseStatefulPartitionHandlingTest extends BasePartitionHandlingTest
       }
    }
 
-   void checkData() {
+   protected void checkData() {
       // Ensure that the cache contains the right data
       assertEquals(DATA_SIZE, cache(0, CACHE_NAME).size());
       for (int i = 0; i < DATA_SIZE; i++) {

--- a/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/impl/PreferAvailabilityStrategyTest.java
@@ -112,7 +112,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
    public void testSinglePartitionOnlyJoiners() {
       // There's no cache topology, so the first cache topology is created with the joiners
       List<Address> joiners = asList(A, B);
-      CacheStatusResponse response = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE, joiners);
+      CacheStatusResponse response = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE, joiners, null);
       Map<Address, CacheStatusResponse> statusResponses = mapOf(A, response, B, response);
 
       when(context.getCacheName()).thenReturn(CACHE_NAME);
@@ -130,7 +130,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
       List<Address> mergeMembers = asList(B, C);
       TestClusterCacheStatus cacheA = start(DIST_INFO, A);
       CacheStatusResponse responseB = availableResponse(B, cacheA);
-      CacheStatusResponse responseC = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE, List.of(B));
+      CacheStatusResponse responseC = new CacheStatusResponse(DIST_INFO, null, null, AVAILABLE, List.of(B), null);
       Map<Address, CacheStatusResponse> statusResponses = mapOf(B, responseB, C, responseC);
 
       when(context.getCacheName()).thenReturn(CACHE_NAME);
@@ -518,7 +518,7 @@ public class PreferAvailabilityStrategyTest extends AbstractInfinispanTest {
 
    private CacheStatusResponse availableResponse(Address a, TestClusterCacheStatus cacheStatus) {
       return new CacheStatusResponse(cacheStatus.joinInfo(a), cacheStatus.topology(), cacheStatus.stableTopology(),
-                                     AVAILABLE, asList(A, B, C));
+                                     AVAILABLE, asList(A, B, C), null);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/topology/MockLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/topology/MockLocalTopologyManager.java
@@ -43,7 +43,7 @@ class MockLocalTopologyManager implements LocalTopologyManager {
 
    public void init(CacheJoinInfo joinInfo, CacheTopology topology, CacheTopology stableTopology,
                     AvailabilityMode availabilityMode) {
-      this.status = new CacheStatusResponse(joinInfo, topology, stableTopology, availabilityMode, Collections.emptyList());
+      this.status = new CacheStatusResponse(joinInfo, topology, stableTopology, availabilityMode, Collections.emptyList(), null);
    }
 
    public void verifyTopology(CacheTopology topology, int topologyId, List<Address> currentMembers,
@@ -95,7 +95,7 @@ class MockLocalTopologyManager implements LocalTopologyManager {
    public CompletionStage<Void> handleTopologyUpdate(String cacheName, CacheTopology cacheTopology, AvailabilityMode availabilityMode,
                                                      int viewId, Address sender) {
       status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology,
-                                       status.getStableTopology(), availabilityMode, status.joinedMembers());
+                                       status.getStableTopology(), availabilityMode, status.joinedMembers(), null);
       topologies.add(cacheTopology);
       return CompletableFutures.completedNull();
    }
@@ -103,14 +103,14 @@ class MockLocalTopologyManager implements LocalTopologyManager {
    @Override
    public CompletionStage<Void> handleStableTopologyUpdate(String cacheName, CacheTopology cacheTopology, Address sender, int viewId) {
       status = new CacheStatusResponse(status.getCacheJoinInfo(), status.getCacheTopology(),
-                                       cacheTopology, status.getAvailabilityMode(), status.joinedMembers());
+                                       cacheTopology, status.getAvailabilityMode(), status.joinedMembers(), null);
       return CompletableFutures.completedNull();
    }
 
    @Override
    public CompletionStage<Void> handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId, Address sender) {
-      status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology,
-                                       status.getStableTopology(), status.getAvailabilityMode(), status.joinedMembers());
+      status = new CacheStatusResponse(status.getCacheJoinInfo(), cacheTopology, status.getStableTopology(),
+            status.getAvailabilityMode(), status.joinedMembers(), null);
       topologies.add(cacheTopology);
       return CompletableFutures.completedNull();
    }


### PR DESCRIPTION
* During a network partition, the stable topology could be installed only inside the partition in which the coordinator is.
* The nodes that install the stable topology will become "stateless" by deleting the consistent hash from persistent state.
* The nodes in the other partition become unable to join the cluster, since they are "stateful" with the persistent state.
* The stable topology was never properly recovered.
* The coordinator would broadcast a stable topology with restore=false, and the nodes would clear the storage and lose data.


To avoid this scenario, I've made changes mostly in the topology package so:

* During the stable topology restore from state, the coordinator will track the UUID of the nodes. As long as the array of UUIDs is not empty, no rebalance can happen, and no "stateless" joiner can join.
* The UUID is only removed from the array after the node confirms the stable topology broadcast. This only happens when restoring from a graceful shutdown. In all other cases, it continues a fire-and-forget method.
* When handling a merge, the nodes insert in the CacheStatus response whether they had a stable topology. The coordinator can utilize this information to know whether it is in the middle of recovering the stable topology.

I've added a test that tries to reproduce the star topology. And another test that creates a clean partition during the restore.

Close #16916.