### PR TITLE
[#16959] Update GitHub organization variables when publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,3 +216,14 @@ jobs:
       image: quay.io/infinispan/server:${{ inputs.version }}
       ref: 2.4.x
       repository: infinispan/infinispan-operator
+
+  update-org-vars:    
+    needs: published
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update GitHub Organization Variable to next release version
+        shell: bash
+        env:
+          GH_TOKEN: "${{ secrets.INFINISPAN_RELEASE_TOKEN }}"
+        run: >
+          gh variable set "RELEASE_$(echo '${{ inputs.version }}' | cut -f 1-2 -d '.' | tr . _)_VERSION" -b "${{ inputs.nextVersion }}" --org infinispan;


### PR DESCRIPTION
Create or update GitHub variables to hold the next version to be released from a branch. The variables have the format RELEASE_<MAJOR_MINOR>_VERSION (i.e. RELEASE_16_0_VERSION), and the value is the full release version. These variables will be used in other repos when applying labels to issues that have been fixed with merged PRs.

Closes #16959