### PR TITLE
[#16975] Fixing labelling for backport

### DIFF
--- a/.github/workflows/pull_request_open.yml
+++ b/.github/workflows/pull_request_open.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Copy labels from referenced issues
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
           BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body // ""')
 
           # Extract issue numbers from [#N] in title, and Fixes/Closes/Resolves #N in body
@@ -41,6 +42,9 @@ jobs:
 
           # Collect all repo labels for validation
           REPO_LABELS=$(gh api "repos/${GH_REPO}/labels" -q '.[].name' --paginate)
+          
+          # Get all branches for release label filtering
+          ALL_BRANCHES=$(gh api "repos/${GH_REPO}/branches" --paginate -q '.[].name')
 
           for ISSUE in $ISSUES; do
             echo "Processing issue #$ISSUE"
@@ -50,6 +54,34 @@ jobs:
               continue
             fi
             while IFS= read -r LABEL; do
+              # Skip target/* labels - they should only be applied by targetlabel job
+              if [[ "$LABEL" == target/* ]]; then
+                echo "  Skipping $LABEL: target labels are managed by targetlabel job"
+                continue
+              fi
+
+              # Filter release/* labels based on target branch
+              if [[ "$LABEL" == release/* ]]; then
+                # Extract version from label (e.g., release/15.1.0 -> 15.1.0)
+                VERSION="${LABEL#release/}"
+                MAJ_MIN=$(echo "$VERSION" | cut -d. -f1,2)
+
+                if [[ "$BASE_REF" == "main" ]]; then
+                  # For main branch: only apply if no branch matches maj.min.x pattern
+                  if echo "$ALL_BRANCHES" | grep -qE "^${MAJ_MIN}\.x$"; then
+                    echo "  Skipping $LABEL: branch ${MAJ_MIN}.x exists (not for main)"
+                    continue
+                  fi
+                elif [[ "$BASE_REF" =~ ^([0-9]+)\.([0-9]+)\.x$ ]]; then
+                  # For version branches (e.g., 15.1.x): only apply if maj.min matches
+                  BRANCH_MAJ_MIN="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+                  if [[ "$MAJ_MIN" != "$BRANCH_MAJ_MIN" ]]; then
+                    echo "  Skipping $LABEL: version mismatch (branch $BRANCH_MAJ_MIN != label $MAJ_MIN)"
+                    continue
+                  fi
+                fi
+              fi
+
               if echo "$REPO_LABELS" | grep -qxF "$LABEL"; then
                 echo "  Adding label: $LABEL"
                 gh pr edit "$PR_NUMBER" --add-label "$LABEL"


### PR DESCRIPTION
fixes #16975 

currently all the issue labels are copied to PR but this doesn't work if issue affect multiple releases.

This PR implements the following policy.

Bob says:

**Complete filtering logic now in place:**

1. **`target/*` labels**: Always skipped - only applied by the `targetlabel` job based on the PR's base branch

2. **`release/*` labels**: Smart filtering based on target branch:
   - For PRs to `main`: Only applied if no `maj.min.x` branch exists
   - For PRs to `maj.min.x`: Only applied if the label's version matches the branch version

3. **All other labels**: Copied normally from referenced issues (component labels, priority, type, etc.)

This ensures that branch-specific labels (`target/*` and `release/*`) are managed by their respective workflows and not incorrectly inherited when reusing issues for backport PRs.