### PR TITLE
Add missing links for the Lock APIs for 15.2.x

### DIFF
--- a/documentation/src/main/asciidoc/topics/proc_configuring_internal_caches_locks.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_internal_caches_locks.adoc
@@ -41,4 +41,5 @@ include::xml/clustered_lock_manager.xml[]
 .Reference
 
 * link:../../apidocs/org/infinispan/lock/configuration/ClusteredLockManagerConfiguration.html[ClusteredLockManagerConfiguration]
-* link:../../configuration-schema/infinispan-clustered-locks-config-infinispan-clustered-locks-config-12.0.html.html[Clustered Locks Configuration Schema]
+
+* link:{configdocroot}infinispan-clustered-locks-config-{schemaversion}.html[{brandname} Clustered Locks Configuration Schema]


### PR DESCRIPTION
Links for ClusteredLockManagerConfiguration and Clustered Locks Configuration schema were giving 404 error messages for subsection "Configuring internal caches for locks" under references in the Embedding in java applications guide.