### PR TITLE
[#15709] Fix flaky ClusterTopologyManagerTest

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -184,6 +184,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       d1.discardAll(false);
       d2.discardAll(false);
       d3.discardAll(false);
+      TestingUtil.installNewView(managers());
 
       // wait for the merged cluster to form
       long startTime = System.currentTimeMillis();
@@ -228,6 +229,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       log.debugf("Merging the cluster partitions");
       d2.discardAll(false);
       d3.discardAll(false);
+      TestingUtil.installNewView(manager(1), manager(2));
 
       // wait for the merged cluster to form
       long startTime = System.currentTimeMillis();
@@ -298,6 +300,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       d1.discardAll(false);
       d2.discardAll(false);
       d3.discardAll(false);
+      TestingUtil.installNewView(managers());
 
       // wait for the JGroups merge
       long startTime = System.currentTimeMillis();


### PR DESCRIPTION
* Do not rely on MERGE3 to install the view. Deterministically install the view instead.

The idea is to verify the topology handling on the Infinispan side. So, instead of relying on the time-based approach to identify the merges in JGroups, we just push the views.

Close #15709
Close #15754 
Close #15894