### PR TITLE
[#16900] Concurrent cache start

### DIFF
--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -13,6 +13,7 @@ import org.infinispan.globalstate.GlobalConfigurationManager;
 import org.infinispan.globalstate.GlobalStateManager;
 import org.infinispan.globalstate.impl.GlobalConfigurationManagerImpl;
 import org.infinispan.globalstate.impl.GlobalStateManagerImpl;
+import org.infinispan.manager.CacheStartupManager;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistryImpl;
 import org.infinispan.remoting.inboundhandler.GlobalInboundInvocationHandler;
@@ -58,7 +59,7 @@ import org.infinispan.xsite.events.XSiteEventsManagerImpl;
       SerializationContextRegistry.class, BlockingManager.class, NonBlockingManager.class,
       RankCalculator.class, EventLoggerNotifier.class, PrincipalRoleMapper.class, RolePermissionMapper.class,
       XSiteCacheMapper.class, XSiteEventsManager.class, SharedContainerMaps.class, DynamicMemoryResizer.class,
-      StateTransferTracker.class,
+      StateTransferTracker.class, CacheStartupManager.class,
 })
 @Scope(Scopes.GLOBAL)
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
@@ -117,6 +118,8 @@ public class EmptyConstructorFactory extends AbstractComponentFactory implements
          return new DynamicMemoryResizer();
       } else if (componentName.equals(StateTransferTracker.class.getName())) {
          return new StateTransferTracker();
+      } else if (componentName.equals(CacheStartupManager.class.getName())) {
+         return new CacheStartupManager();
       }
 
       throw CONTAINER.factoryCannotConstructComponent(componentName);

--- a/core/src/main/java/org/infinispan/globalstate/LocalConfigurationStorage.java
+++ b/core/src/main/java/org/infinispan/globalstate/LocalConfigurationStorage.java
@@ -35,6 +35,17 @@ public interface LocalConfigurationStorage {
    void validateFlags(EnumSet<CacheContainerAdmin.AdminFlag> flags);
 
    /**
+    * Defines the cache configuration without starting the cache.
+    *
+    * @param name the name of the cache to define. Must not be {@code null}.
+    * @param template the template that should be used to configure the cache. Can be {@code null}.
+    * @param configuration the {@link Configuration} to use. Must not be {@code null}.
+    * @param flags the desired {@link org.infinispan.commons.api.CacheContainerAdmin.AdminFlag}s
+    * @return a stage that completes when the configuration is defined
+    */
+   CompletionStage<Void> defineCacheConfiguration(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags);
+
+   /**
     * Creates the cache using the supplied template, configuration and flags. This method may be invoked either with or
     * without a template. In both cases a concrete configuration will also be available. If a template name is present,
     * the {@link LocalConfigurationStorage} should use it, e.g. when persisting the configuration.

--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalConfigurationManagerImpl.java
@@ -4,6 +4,7 @@ import static org.infinispan.util.logging.Log.CONFIG;
 
 import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -37,6 +38,7 @@ import org.infinispan.globalstate.GlobalConfigurationManager;
 import org.infinispan.globalstate.LocalConfigurationStorage;
 import org.infinispan.globalstate.ScopeType;
 import org.infinispan.globalstate.ScopedState;
+import org.infinispan.manager.CacheStartupManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.notifications.cachemanagerlistener.event.ConfigurationChangedEvent;
@@ -86,6 +88,8 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
    PrincipalRoleMapper principalRoleMapper;
    @Inject
    SharedContainerMaps sharedContainerMaps;
+   @Inject
+   CacheStartupManager cacheStartupManager;
 
    private Cache<ScopedState, Object> stateCache;
    private ParserRegistry parserRegistry;
@@ -118,16 +122,12 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
             new ConfigurationBuilder().build(),
             EnumSet.of(InternalCacheRegistry.Flag.GLOBAL));
 
-      internalCacheRegistry.startInternalCaches();
+      cacheStartupManager.startInternalCaches(internalCacheRegistry.getInternalCacheNames());
 
       parserRegistry = new ParserRegistry();
 
       Set<String> staticCacheNames = new TreeSet<>(configurationManager.getDefinedCaches());
       staticCacheNames.removeAll(internalCacheRegistry.getInternalCacheNames());
-      log.debugf("Starting user defined caches: %s", staticCacheNames);
-      for (String cacheName : staticCacheNames) {
-         SecurityActions.getCache(cacheManager, cacheName);
-      }
 
       localConfigurationManager.initialize(cacheManager, configurationManager, blockingManager);
 
@@ -139,6 +139,7 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
       Map<String, Configuration> persistedTemplates = localConfigurationManager.loadAllTemplates();
       Map<String, Configuration> persistedCaches = localConfigurationManager.loadAllCaches();
 
+      Set<String> persistedCacheNames = new HashSet<>();
       getStateCache().forEach((key, v) -> {
          ScopeType scopeType = ScopeType.fromString(key.getScope());
          if (scopeType != null) {
@@ -148,7 +149,8 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
                case CONTAINER -> CompletionStages.join(updateGlobalConfigurationLocally(state));
                case CACHE -> {
                   ensureClusterCompatibility(name, state, persistedCaches);
-                  CompletionStages.join(createCacheLocally(name, state));
+                  CompletionStages.join(createConfigurationLocally(name, state));
+                  persistedCacheNames.add(name);
                }
                case TEMPLATE -> {
                   ensureClusterCompatibility(name, state, persistedTemplates);
@@ -167,7 +169,7 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
          CompletionStages.join(getOrCreateTemplate(name, configuration, adminFlags));
       });
 
-      // Create the caches
+      // Create the caches: define the configurations and collect the cache names.
       persistedCaches.forEach((name, configuration) -> {
          ensurePersistenceCompatibility(name, configuration);
          // The cache configuration was permanent, it still needs to be
@@ -176,11 +178,18 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
                   if (r instanceof CacheState) {
                      Configuration remoteConf = buildConfiguration(name, ((CacheState) r).getConfiguration(), false);
                      ensurePersistenceCompatibility(name, configuration, remoteConf);
-                     return createCacheLocally(name, (CacheState) r);
+                     return createConfigurationLocally(name, (CacheState) r);
                   }
                   return CompletableFutures.completedNull();
                }));
+         persistedCacheNames.add(name);
       });
+
+      // Start the caches after the configuration is defined.
+      Set<String> allUserCaches = new HashSet<>(staticCacheNames);
+      allUserCaches.addAll(persistedCacheNames);
+      log.debugf("Starting user defined caches: %s", allUserCaches);
+      CompletionStages.join(cacheStartupManager.startUserCaches(allUserCaches));
    }
 
    private void ensureClusterCompatibility(String name, CacheState state, Map<String, Configuration> configs) {
@@ -345,6 +354,19 @@ public class GlobalConfigurationManagerImpl implements GlobalConfigurationManage
       return localConfigurationManager.createTemplate(name, configuration, flags)
             .thenCompose(v -> cacheManagerNotifier.notifyConfigurationChanged(ConfigurationChangedEvent.EventType.CREATE, ConfigurationChangedEvent.TEMPLATE, name, null))
             .toCompletableFuture();
+   }
+
+   CompletionStage<Void> createConfigurationLocally(String name, CacheState state) {
+      Configuration configuration = buildConfiguration(name, state.getConfiguration(), false);
+      return createConfigurationLocally(name, state.getTemplate(), configuration, state.getFlags());
+   }
+
+   CompletionStage<Void> createConfigurationLocally(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+      log.debugf("Defining cache configuration %s from global state", name);
+      return localConfigurationManager.defineCacheConfiguration(name, template, configuration, flags)
+            .thenCompose(v -> cacheManagerNotifier.notifyConfigurationChanged(
+                  ConfigurationChangedEvent.EventType.CREATE, ConfigurationChangedEvent.CACHE, name, null
+            ));
    }
 
    CompletionStage<Void> createCacheLocally(String name, CacheState state) {

--- a/core/src/main/java/org/infinispan/globalstate/impl/ImmutableLocalConfigurationStorage.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/ImmutableLocalConfigurationStorage.java
@@ -36,6 +36,11 @@ public class ImmutableLocalConfigurationStorage implements LocalConfigurationSto
    }
 
    @Override
+   public CompletionStage<Void> defineCacheConfiguration(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+      throw CONFIG.immutableConfiguration();
+   }
+
+   @Override
    public CompletionStage<Void> createCache(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       throw CONFIG.immutableConfiguration();
    }

--- a/core/src/main/java/org/infinispan/globalstate/impl/OverlayLocalConfigurationStorage.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/OverlayLocalConfigurationStorage.java
@@ -87,6 +87,19 @@ public class OverlayLocalConfigurationStorage extends VolatileLocalConfiguration
    }
 
    @Override
+   public CompletionStage<Void> defineCacheConfiguration(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+      CompletionStage<Void> cs = super.defineCacheConfiguration(name, template, configuration, flags);
+      if (flags.contains(CacheContainerAdmin.AdminFlag.VOLATILE))
+         return cs;
+
+      return blockingManager.thenApplyBlocking(cs, ignore -> {
+         persistentCaches.add(name);
+         storeCaches();
+         return null;
+      }, name);
+   }
+
+   @Override
    public CompletionStage<Void> createCache(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       CompletionStage<Void> future = super.createCache(name, template, configuration, flags);
       if (!flags.contains(CacheContainerAdmin.AdminFlag.VOLATILE)) {

--- a/core/src/main/java/org/infinispan/globalstate/impl/VolatileLocalConfigurationStorage.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/VolatileLocalConfigurationStorage.java
@@ -74,7 +74,7 @@ public class VolatileLocalConfigurationStorage implements LocalConfigurationStor
    }
 
    @Override
-   public CompletionStage<Void> createCache(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
+   public CompletionStage<Void> defineCacheConfiguration(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       Configuration existing = SecurityActions.getCacheConfiguration(cacheManager, name);
       if (existing == null) {
          SecurityActions.defineConfiguration(cacheManager, name, configuration);
@@ -89,15 +89,21 @@ public class VolatileLocalConfigurationStorage implements LocalConfigurationStor
             log.debugf("%s already has a cache %s with configuration %s", cacheManager.getAddress(), name, configuration);
          }
       }
+      return CompletableFutures.completedNull();
+   }
+
+   @Override
+   public CompletionStage<Void> createCache(String name, String template, Configuration configuration, EnumSet<CacheContainerAdmin.AdminFlag> flags) {
       // Ensure the cache is started
-      return blockingManager.<Void>supplyBlocking(() -> {
-         try {
-            SecurityActions.getCache(cacheManager, name);
-         } catch (CacheException cacheException) {
-            log.cannotObtainFailedCache(name, cacheException);
-         }
-         return null;
-      }, name).toCompletableFuture();
+      return defineCacheConfiguration(name, template, configuration, flags)
+            .thenCompose(ignore -> blockingManager.<Void>supplyBlocking(() -> {
+               try {
+                  SecurityActions.getCache(cacheManager, name);
+               } catch (CacheException cacheException) {
+                  log.cannotObtainFailedCache(name, cacheException);
+               }
+               return null;
+            }, name));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/manager/CacheStartupManager.java
+++ b/core/src/main/java/org/infinispan/manager/CacheStartupManager.java
@@ -1,0 +1,229 @@
+package org.infinispan.manager;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.infinispan.commons.executors.ThreadPoolExecutorFactory;
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.commons.util.ProgressTracker;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.commons.util.concurrent.CompletionStages;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.executors.ManageableExecutorService;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.factories.threads.AbstractThreadPoolExecutorFactory;
+import org.infinispan.security.actions.SecurityActions;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import io.reactivex.rxjava3.schedulers.Schedulers;
+
+/**
+ * Orchestrates cache startup during container initialization.
+ *
+ * <p>
+ * Internal caches are started serially and must all succeed before the cache manager becomes {@code RUNNING}. User caches
+ * are submitted concurrently to the blocking executor and start in the background. The cache manager does not wait for user
+ * caches to initialize.
+ * </p>
+ *
+ * @since 16.2
+ * @author José Bolina
+ */
+@Scope(Scopes.GLOBAL)
+public class CacheStartupManager {
+
+   private static final int USER_CACHE_PARALLELISM = 5;
+   private static final Log LOG = LogFactory.getLog(CacheStartupManager.class);
+
+   @Inject
+   protected EmbeddedCacheManager cacheManager;
+
+   @Inject
+   protected GlobalConfiguration configuration;
+
+   @Inject
+   protected TimeService timeService;
+
+   @Inject
+   @ComponentName(KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR)
+   protected ScheduledExecutorService timeoutExecutor;
+
+   @Inject
+   @ComponentName(KnownComponentNames.BLOCKING_EXECUTOR)
+   protected ExecutorService blockingExecutor;
+
+   private final Map<String, CacheStartupState> states = new ConcurrentHashMap<>();
+   private final Function<String, CompletionStage<?>> startCacheFunction = name -> {
+      startCache(name);
+      return CompletableFutures.completedNull();
+   };
+   private volatile boolean stopped;
+   private volatile ProgressTracker progressTracker;
+
+   @Start
+   protected void initialize() {
+      if (progressTracker == null) {
+         progressTracker = new ProgressTracker("cache-startup", timeoutExecutor, timeService, 30, TimeUnit.SECONDS);
+      }
+   }
+
+   /**
+    * Starts internal caches serially. Blocks until all caches are running.
+    *
+    * <p>
+    * Failure is fatal. The exception propagates and the cache manager shuts down.
+    * </p>
+    *
+    * @param names the names of the internal caches to start. Must not be {@code null}.
+    * @throws RuntimeException if any internal cache fails to start
+    * @throws NullPointerException if the provided names are {@code null}
+    */
+   public void startInternalCaches(Set<String> names) {
+      Objects.requireNonNull(names, "Cache names can not be null");
+      LOG.debugf("Starting internal caches serially: %s", names);
+      for (String name : names) {
+         SecurityActions.getCache(cacheManager, name);
+      }
+   }
+
+   /**
+    * Submits user caches for concurrent startup via the blocking executor.
+    *
+    * <p>
+    * Can be called multiple times and accumulate the tasks across calls. The {@link ProgressTracker} tracks the total
+    * count and progress.
+    * </p>
+    *
+    * <p>
+    * If the blocking executor thread pool is too small for concurrent startup, caches are started serially to avoid potential
+    * deadlock. Cache components submit nested blocking work during {@code cache.start()}, so the pool must have enough
+    * threads for both the cache start tasks and the nested work.
+    * </p>
+    *
+    * @param names the names of the user caches to start. Must not be {@code null}.
+    * @throws NullPointerException In case the provided names are {@code null}.
+    */
+   public CompletionStage<Void> startUserCaches(Set<String> names) {
+      Objects.requireNonNull(names, "Cache names can not be null");
+      if (stopped || names.isEmpty())
+         return CompletableFutures.completedNull();
+
+      for (String name : names) {
+         states.put(name, CacheStartupState.STARTING);
+      }
+
+      progressTracker.addTasks(names.size());
+
+      int parallelism = resolveMaximumConcurrency();
+      LOG.debugf("Starting %d user caches concurrently: %s", parallelism, names);
+      if (parallelism > 1) {
+         return CompletionStages.performConcurrently(names, parallelism, Schedulers.from(blockingExecutor), startCacheFunction);
+      }
+
+      // In case it is not safe to start concurrently, we fallback to starting serially.
+      for (String name : names) {
+         startCache(name);
+      }
+      return CompletableFutures.completedNull();
+   }
+
+   /**
+    * Returns the startup state of a specific cache.
+    *
+    * @param name the cache name to query. Must not be {@code null}.
+    * @return the current {@link CacheStartupState}, or {@code null} if the cache is not tracked by this manager
+    */
+   public CacheStartupState getState(String name) {
+      return states.get(name);
+   }
+
+   /**
+    * Returns an unmodifiable snapshot of all tracked caches and their states.
+    *
+    * @return a map from cache name to {@link CacheStartupState}. Never {@code null}.
+    */
+   public Map<String, CacheStartupState> getAllStates() {
+      return Collections.unmodifiableMap(states);
+   }
+
+   /**
+    * Signals shutdown.
+    *
+    * <p>
+    * Prevents new cache submissions and causes pending tasks to complete with {@link CacheStartupState#FAILED}.
+    * </p>
+    */
+   @Stop
+   public void stop() {
+      stopped = true;
+      if (progressTracker != null)
+         progressTracker.finishedAllTasks();
+   }
+
+   private int resolveMaximumConcurrency() {
+      // Some custom executor injected externally.
+      // This means the executor was not created by our internal setup, we'll play it safe and start serially.
+      if (!(blockingExecutor instanceof ManageableExecutorService<?> mes)) {
+         return 1;
+      }
+
+      // We have an upper bound of <PARALLELISM> concurrent starts.
+      // Each request to start a cache will block, and additionally, the components can block, too.
+      // This requires a minimum of 2 thread to start a single cache.
+      int maxPoolSize = mes.getMaximumPoolSize();
+      if (maxPoolSize > 0) {
+         return Math.max(Math.min(USER_CACHE_PARALLELISM, maxPoolSize / 2), 1);
+      }
+
+      ThreadPoolExecutorFactory<?> tpef = configuration.blockingThreadPool().threadPoolFactory();
+      if (tpef == null)
+         return USER_CACHE_PARALLELISM;
+
+      if (tpef instanceof AbstractThreadPoolExecutorFactory<?> f) {
+         return Math.max(Math.min(USER_CACHE_PARALLELISM, f.maxThreads() / 2), 1);
+      }
+
+      // Unknown executor type or configuration.
+      // We default serial execution instead of risking a deadlock.
+      return 1;
+   }
+
+   private void taskCompleted(String name, CacheStartupState state) {
+      states.put(name, state);
+      progressTracker.removeTasks(1);
+      if (progressTracker.pendingTasks() == 0) {
+         progressTracker.finishedAllTasks();
+      }
+   }
+
+   private void startCache(String name) {
+      if (stopped) {
+         taskCompleted(name, CacheStartupState.FAILED);
+         return;
+      }
+
+      try {
+         LOG.debugf("Requesting cache %s to start", name);
+         SecurityActions.getCache(cacheManager, name);
+         taskCompleted(name, CacheStartupState.READY);
+      } catch (Throwable t) {
+         LOG.errorf(t, "Failed to start cache %s", name);
+         taskCompleted(name, CacheStartupState.FAILED);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/manager/CacheStartupState.java
+++ b/core/src/main/java/org/infinispan/manager/CacheStartupState.java
@@ -1,0 +1,35 @@
+package org.infinispan.manager;
+
+/**
+ * Tracks the startup state of a cache during container initialization.
+ *
+ * <p>
+ * State transitions:
+ * <pre>
+ *   STARTING -> READY   (cache started successfully)
+ *   STARTING -> FAILED   (cache startup threw an exception, or shutdown occurred)
+ * </pre>
+ * Terminal states ({@link CacheStartupState#READY} and {@link CacheStartupState#FAILED}) are never revisited.
+ *
+ * @since 16.2
+ * @author José Bolina
+ */
+public enum CacheStartupState {
+
+   /**
+    * The cache has been submitted for startup and initialization is in progress. This includes component wiring, state
+    * transfer, and persistence loading. The cache is not ready for use yet.
+    */
+   STARTING,
+
+   /**
+    * The cache started successfully and is available to serve requests.
+    */
+   READY,
+
+   /**
+    * The cache failed to start. The failure is logged and does not affect other caches or the cache manager. The cache
+    * can be retried manually via {@link EmbeddedCacheManager#getCache(String)}.
+    */
+   FAILED
+}

--- a/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
+++ b/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
@@ -16,7 +16,6 @@ import org.infinispan.factories.scopes.Scopes;
  */
 @Scope(Scopes.GLOBAL)
 public interface InternalCacheRegistry {
-   void startInternalCaches();
 
    enum Flag {
       /**

--- a/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
@@ -126,12 +126,4 @@ public class InternalCacheRegistryImpl implements InternalCacheRegistry {
       EnumSet<Flag> flags = internalCaches.get(name);
       return flags != null && flags.contains(flag);
    }
-
-   @Override
-   public void startInternalCaches() {
-      log.debugf("Starting internal caches: %s", internalCaches.keySet());
-      for (String cacheName : internalCaches.keySet()) {
-         SecurityActions.getCache(cacheManager, cacheName);
-      }
-   }
 }

--- a/core/src/test/java/org/infinispan/manager/CacheStartupManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheStartupManagerTest.java
@@ -1,0 +1,115 @@
+package org.infinispan.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.persistence.file.SingleFileStoreConfigurationBuilder;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "manager.CacheStartupManagerTest")
+public class CacheStartupManagerTest extends SingleCacheManagerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      return TestCacheManagerFactory.createCacheManager((ConfigurationBuilder) null);
+   }
+
+   private CacheStartupManager startupManager() {
+      return GlobalComponentRegistry.of(cacheManager).getComponent(CacheStartupManager.class);
+   }
+
+   public void testInternalCacheFailureIsFatal() {
+      assertThatThrownBy(() -> startupManager().startInternalCaches(Set.of("nonExistentInternalCache")))
+            .isInstanceOf(Exception.class);
+   }
+
+   public void testUserCacheFailureIsIsolated() {
+      cacheManager.defineConfiguration("goodCache", new ConfigurationBuilder().build());
+
+      ConfigurationBuilder brokenConfig = new ConfigurationBuilder();
+      brokenConfig.persistence()
+            .addStore(SingleFileStoreConfigurationBuilder.class)
+            .location("/nonexistent/invalid/path/that/will/fail");
+      cacheManager.defineConfiguration("brokenCache", brokenConfig.build());
+
+      CacheStartupManager sm = startupManager();
+      sm.startUserCaches(Set.of("goodCache", "brokenCache"));
+
+      eventually(() -> sm.getState("goodCache") != CacheStartupState.STARTING
+            && sm.getState("brokenCache") != CacheStartupState.STARTING);
+
+      assertThat(sm.getState("goodCache")).isEqualTo(CacheStartupState.READY);
+      assertThat(sm.getState("brokenCache")).isEqualTo(CacheStartupState.FAILED);
+      assertThat(cacheManager.getStatus()).isEqualTo(ComponentStatus.RUNNING);
+   }
+
+   public void testFailedCacheDoesNotPreventOtherCachesFromStarting() {
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(gcb, null, false);
+      try {
+         cm.defineConfiguration("alpha", new ConfigurationBuilder().build());
+         cm.defineConfiguration("beta", new ConfigurationBuilder().build());
+         cm.defineConfiguration("gamma", new ConfigurationBuilder().build());
+         cm.defineConfiguration("delta", new ConfigurationBuilder().build());
+
+         ConfigurationBuilder brokenConfig = new ConfigurationBuilder();
+         brokenConfig.persistence()
+               .addStore(SingleFileStoreConfigurationBuilder.class)
+               .location("/nonexistent/invalid/path/that/will/fail");
+         cm.defineConfiguration("broken", brokenConfig.build());
+
+         cm.start();
+
+         CacheStartupManager sm = GlobalComponentRegistry.of(cm).getComponent(CacheStartupManager.class);
+
+         assertThat(sm.getState("broken")).isEqualTo(CacheStartupState.FAILED);
+         assertThat(sm.getState("alpha")).isEqualTo(CacheStartupState.READY);
+         assertThat(sm.getState("beta")).isEqualTo(CacheStartupState.READY);
+         assertThat(sm.getState("gamma")).isEqualTo(CacheStartupState.READY);
+         assertThat(sm.getState("delta")).isEqualTo(CacheStartupState.READY);
+
+         assertThat(cm.getStatus()).isEqualTo(ComponentStatus.RUNNING);
+
+         assertThat(cm.isRunning("alpha")).isTrue();
+         assertThat(cm.isRunning("beta")).isTrue();
+         assertThat(cm.isRunning("gamma")).isTrue();
+         assertThat(cm.isRunning("delta")).isTrue();
+         assertThat(cm.isRunning("broken")).isFalse();
+
+         cm.getCache("alpha").put("key", "value");
+         assertThat((String) cm.getCache("alpha").get("key")).isEqualTo("value");
+      } finally {
+         cm.stop();
+      }
+   }
+
+   public void testMultipleStartUserCachesCallsAccumulate() {
+      cacheManager.defineConfiguration("cache1", new ConfigurationBuilder().build());
+      cacheManager.defineConfiguration("cache2", new ConfigurationBuilder().build());
+      cacheManager.defineConfiguration("cache3", new ConfigurationBuilder().build());
+
+      CacheStartupManager sm = startupManager();
+      sm.startUserCaches(Set.of("cache1", "cache2"));
+      sm.startUserCaches(Set.of("cache3"));
+
+      eventually(() -> sm.getAllStates().values().stream()
+            .noneMatch(s -> s == CacheStartupState.STARTING));
+
+      assertThat(sm.getState("cache1")).isEqualTo(CacheStartupState.READY);
+      assertThat(sm.getState("cache2")).isEqualTo(CacheStartupState.READY);
+      assertThat(sm.getState("cache3")).isEqualTo(CacheStartupState.READY);
+      assertThat(sm.getAllStates()).hasSize(3).containsValue(CacheStartupState.READY);
+
+      assertThat(cacheManager.getCache("cache1")).isNotNull();
+      assertThat(cacheManager.getCache("cache2")).isNotNull();
+      assertThat(cacheManager.getCache("cache3")).isNotNull();
+   }
+}

--- a/core/src/test/java/org/infinispan/manager/ConcurrentCacheStartupTest.java
+++ b/core/src/test/java/org/infinispan/manager/ConcurrentCacheStartupTest.java
@@ -1,0 +1,181 @@
+package org.infinispan.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.FlagBitSets;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.interceptors.BaseAsyncInterceptor;
+import org.infinispan.interceptors.impl.InvocationContextInterceptor;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TransportFlags;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "manager.ConcurrentCacheStartupTest")
+@CleanupAfterMethod
+public class ConcurrentCacheStartupTest extends MultipleCacheManagersTest {
+
+   private static final String CACHE_A = "cacheA";
+   private static final String CACHE_B = "cacheB";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cfg = replicatedSyncConfig();
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      EmbeddedCacheManager cm1 = addClusterEnabledCacheManager(gcb, new ConfigurationBuilder());
+      cm1.defineConfiguration(CACHE_A, cfg.build());
+      cm1.defineConfiguration(CACHE_B, cfg.build());
+      cm1.getCache(CACHE_A).put("key", "value");
+      cm1.getCache(CACHE_B).put("key", "value");
+      waitForClusterToForm(CACHE_A, CACHE_B);
+   }
+
+   public void testStopDuringStartup() throws Exception {
+      CountDownLatch started = new CountDownLatch(1);
+      CountDownLatch proceed = new CountDownLatch(1);
+
+      EmbeddedCacheManager cm2 = startSecondNodeWithDelay(CACHE_A, started, proceed);
+
+      assertThat(started.await(30, TimeUnit.SECONDS))
+            .as("State transfer should have started").isTrue();
+
+      cm2.stop();
+      proceed.countDown();
+
+      assertThat(cm2.getStatus()).isEqualTo(ComponentStatus.TERMINATED);
+   }
+
+   public void testGetAllStatesSnapshot() throws Exception {
+      CountDownLatch started = new CountDownLatch(1);
+      CountDownLatch proceed = new CountDownLatch(1);
+
+      EmbeddedCacheManager cm2 = startSecondNodeWithDelay(CACHE_A, started, proceed);
+
+      assertThat(started.await(30, TimeUnit.SECONDS))
+            .as("State transfer should have started").isTrue();
+
+      CacheStartupManager sm = startupManager(cm2);
+      Map<String, CacheStartupState> states = sm.getAllStates();
+      assertThat(states).isNotNull();
+      assertThat(states.get(CACHE_A)).isEqualTo(CacheStartupState.STARTING);
+
+      proceed.countDown();
+      eventually(() -> sm.getAllStates().values().stream()
+            .noneMatch(s -> s == CacheStartupState.STARTING));
+
+      assertThat(sm.getState(CACHE_A)).isEqualTo(CacheStartupState.READY);
+      assertThat(sm.getState(CACHE_B)).isEqualTo(CacheStartupState.READY);
+   }
+
+   public void testCacheServesRequestsWhileOthersStarting() throws Exception {
+      CountDownLatch started = new CountDownLatch(1);
+      CountDownLatch proceed = new CountDownLatch(1);
+
+      EmbeddedCacheManager cm2 = startSecondNodeWithDelay(CACHE_A, started, proceed);
+
+      assertThat(started.await(30, TimeUnit.SECONDS))
+            .as("State transfer should have started").isTrue();
+
+      Cache<String, String> cacheB = cm2.getCache(CACHE_B);
+      cacheB.put("newKey", "newValue");
+      assertThat(cacheB.get("newKey")).isEqualTo("newValue");
+      assertThat(cacheB.get("key")).isEqualTo("value");
+
+      proceed.countDown();
+      eventually(() -> startupManager(cm2).getState(CACHE_A) == CacheStartupState.READY);
+   }
+
+   public void testGetCacheBlocksUntilReady() throws Exception {
+      CountDownLatch started = new CountDownLatch(1);
+      CountDownLatch proceed = new CountDownLatch(1);
+
+      EmbeddedCacheManager cm2 = startSecondNodeWithDelay(CACHE_A, started, proceed);
+
+      assertThat(started.await(30, TimeUnit.SECONDS))
+            .as("State transfer should have started").isTrue();
+
+      Future<Cache<String, String>> getCacheFuture = fork(() -> cm2.getCache(CACHE_A));
+
+      assertThat(getCacheFuture.isDone()).isFalse();
+      assertThat(cm2.getStatus()).isEqualTo(ComponentStatus.INITIALIZING);
+      assertThat(cm2.cacheExists(CACHE_A)).isTrue();
+
+      proceed.countDown();
+
+      Cache<String, String> cacheA = getCacheFuture.get(30, TimeUnit.SECONDS);
+      assertThat(cacheA).isNotNull();
+      assertThat(cacheA.get("key")).isEqualTo("value");
+      assertThat(startupManager(cm2).getState(CACHE_A)).isEqualTo(CacheStartupState.READY);
+   }
+
+   private EmbeddedCacheManager startSecondNodeWithDelay(String delayedCache,
+         CountDownLatch started, CountDownLatch proceed) {
+      ConfigurationBuilder cfg = replicatedSyncConfig();
+
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      TestCacheManagerFactory.addInterceptor(gcb, delayedCache::equals,
+            new StateTransferLatchInterceptor(started, proceed),
+            TestCacheManagerFactory.InterceptorPosition.BEFORE, InvocationContextInterceptor.class);
+
+      TransportFlags flags = new TransportFlags();
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(false,
+            gcb, new ConfigurationBuilder(), flags);
+      amendCacheManagerBeforeStart(cm);
+      cacheManagers.add(cm);
+
+      cm.defineConfiguration(CACHE_A, cfg.build());
+      cm.defineConfiguration(CACHE_B, cfg.build());
+
+      CompletableFuture.runAsync(cm::start);
+
+      return cm;
+   }
+
+   private static ConfigurationBuilder replicatedSyncConfig() {
+      ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      cfg.clustering().stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(true);
+      return cfg;
+   }
+
+   private static CacheStartupManager startupManager(EmbeddedCacheManager cm) {
+      return GlobalComponentRegistry.of(cm).getComponent(CacheStartupManager.class);
+   }
+
+   static class StateTransferLatchInterceptor extends BaseAsyncInterceptor {
+      private final CountDownLatch started;
+      private final CountDownLatch proceed;
+
+      StateTransferLatchInterceptor(CountDownLatch started, CountDownLatch proceed) {
+         this.started = started;
+         this.proceed = proceed;
+      }
+
+      @Override
+      public Object visitCommand(InvocationContext ctx, VisitableCommand cmd) throws Throwable {
+         if (cmd instanceof PutKeyValueCommand put
+               && put.hasAnyFlag(FlagBitSets.PUT_FOR_STATE_TRANSFER)) {
+            started.countDown();
+            if (!proceed.await(30, TimeUnit.SECONDS)) {
+               throw new TimeoutException("State transfer proceed latch timed out");
+            }
+         }
+         return invokeNext(ctx, cmd);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/support/AsyncStoreEvictionTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/AsyncStoreEvictionTest.java
@@ -42,9 +42,6 @@ public class AsyncStoreEvictionTest extends AbstractInfinispanTest {
       return config;
    }
 
-   private static final ThreadLocal<LockableStore> STORE = new ThreadLocal<>();
-
-
    public static class LockableStoreConfigurationBuilder extends DummyInMemoryStoreConfigurationBuilder {
       public LockableStoreConfigurationBuilder(PersistenceConfigurationBuilder builder) {
          super(builder);
@@ -68,11 +65,6 @@ public class AsyncStoreEvictionTest extends AbstractInfinispanTest {
    public static class LockableStore extends DummyInMemoryStore {
       private volatile CompletableFuture<Void> future = CompletableFutures.completedNull();
 
-      public LockableStore() {
-         super();
-         STORE.set(this);
-      }
-
       @Override
       public CompletionStage<Void> write(int segment, MarshallableEntry entry) {
          return future.thenCompose(ignore -> super.write(segment, entry));
@@ -91,7 +83,7 @@ public class AsyncStoreEvictionTest extends AbstractInfinispanTest {
       CacheCallable(ConfigurationBuilder builder) {
          super(TestCacheManagerFactory.createCacheManager(builder));
          cache = cm.getCache();
-         store = STORE.get();
+         store = TestingUtil.getFirstStore(cache);
       }
    }
 

--- a/persistence/sql/src/test/java/org/infinispan/persistence/sql/QueriesJdbcJoinTest.java
+++ b/persistence/sql/src/test/java/org/infinispan/persistence/sql/QueriesJdbcJoinTest.java
@@ -21,7 +21,6 @@ import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.manager.EmbeddedCacheManagerStartupException;
 import org.infinispan.persistence.jdbc.common.UnitTestDatabaseManager;
 import org.infinispan.persistence.jdbc.common.configuration.ConnectionFactoryConfiguration;
 import org.infinispan.persistence.jdbc.common.configuration.ConnectionFactoryConfigurationBuilder;
@@ -59,8 +58,7 @@ public class QueriesJdbcJoinTest extends AbstractInfinispanTest {
          @Override
          void runTest(ExceptionRunnable runnable) {
             Exceptions.expectException(".*Additional value columns.*found that were not part of the schema.*", runnable,
-                  EmbeddedCacheManagerStartupException.class, CacheConfigurationException.class,
-                  CompletionException.class, CacheConfigurationException.class);
+                  CacheConfigurationException.class, CompletionException.class, CacheConfigurationException.class);
          }
 
          @Override
@@ -85,8 +83,7 @@ public class QueriesJdbcJoinTest extends AbstractInfinispanTest {
          @Override
          void runTest(ExceptionRunnable runnable) {
             Exceptions.expectException(".*was found in the value schema .* but embedded key was not true", runnable,
-                  EmbeddedCacheManagerStartupException.class, CacheConfigurationException.class,
-                  CompletionException.class, CacheConfigurationException.class);
+                  CacheConfigurationException.class, CompletionException.class, CacheConfigurationException.class);
          }
 
          @Override

--- a/query/src/test/java/org/infinispan/query/mapper/ProgrammaticSearchMappingProviderTest.java
+++ b/query/src/test/java/org/infinispan/query/mapper/ProgrammaticSearchMappingProviderTest.java
@@ -2,7 +2,7 @@ package org.infinispan.query.mapper;
 
 import static org.infinispan.configuration.cache.IndexStorage.LOCAL_HEAP;
 
-import java.util.Arrays;
+import java.util.Objects;
 
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.ProgrammaticMappingConfigurationContext;
 import org.hibernate.search.mapper.pojo.mapping.definition.programmatic.TypeMappingStep;
@@ -12,6 +12,7 @@ import org.infinispan.query.mapper.mapping.MappingConfigurationContext;
 import org.infinispan.query.mapper.mapping.ProgrammaticSearchMappingProvider;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.testing.TestResourceTracker;
 import org.kohsuke.MetaInfServices;
 import org.testng.annotations.Test;
 
@@ -48,8 +49,7 @@ public class ProgrammaticSearchMappingProviderTest extends SingleCacheManagerTes
 
       private boolean isTestRunning() {
          // Check if our specific test is in the call stack
-         return Arrays.stream(Thread.currentThread().getStackTrace())
-                 .anyMatch(frame -> frame.getClassName().equals(ProgrammaticSearchMappingProviderTest.class.getName()));
+         return Objects.equals(TestResourceTracker.getCurrentTestName(), ProgrammaticSearchMappingProviderTest.class.getName());
       }
    }
 

--- a/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/footprint/FootprintIT.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  **/
 public class FootprintIT {
    private static final int LOADED_CLASS_COUNT_LOWER_BOUND = 12_320;
-   private static final int LOADED_CLASS_COUNT_UPPER_BOUND = 12_420;
+   private static final int LOADED_CLASS_COUNT_UPPER_BOUND = 12_430;
    private static final long HEAP_USAGE_LOWER_BOUND = 24_000_000L;
    private static final long HEAP_USAGE_UPPER_BOUND = 26_000_000L;
    private static final long DISK_USAGE_LOWER_BOUND = 90_000_000L;


### PR DESCRIPTION
* Start user caches concurrently without blocking the cache manager start.
* The caches initialize concurrently without delaying each other. The cache starts serving requests as soon as they are ready.
* The cache manager does not wait for the user caches to start.

Closes: #16900

The idea is for the configuration to still be declared serially, but the actual start is asynchronous. Right now, the start does not bound the number of caches that can start concurrently. The caches are operational as soon as the initialization is complete; they don't need to wait on other caches. If the cache fails, it is listed as failed.

I had to apply some wait blocks in the tests to ensure the test runs after the caches are ready. Many tests implicitly rely on the fact the caches start serially after starting the cache manager. For example, replacing the TimeService wouldn't work now since the caches are still initializing, causing a data race for the component registry. It was simpler to just make every test wait instead of fixing the tests.

---

Author Checklist (all must be checked):
- [X] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [X] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [X] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [ ] ~The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.~
- [ ] ~Log messages of level `INFO` and above have been internationalized.~
- [ ] ~If the PR affects performance, include before/after benchmarks.~
- [ ] ~If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).~
- [ ] ~If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.~

---

Reviewer Checklist (all must be checked):
- [ ] Code review
  - Are the changes reasonable?
  - Are there any use cases, integrations, inputs that haven't been considered in the implementation?
  - Is the code understandable? (KISS, comments)
  - Is there a better way to implement/write the functionality, code pieces?
  - Is formatting in line with the rest of the project? (checkstyle and spotless)
- [ ] Test review
  - Is the new test coverage rich enough to cover all the changes and considerations above?
  - Does the base functionality works as expected in the build project?
  - Does it behave as expected when given various inputs? (Valid and invalid, missing, partial)
  - Are there integrations to be considered? (Does the new functionality work well with the rest of the project, environment)
  -  Even if all above works as expected, are there weird behaviors to be improved on?
- [ ] Documentation review
  - Does the new/changed documentation cover the PR in sufficient matter?
  - For public API, are JavaDocs included for every new/changed class/method ?
  - For new features, does the documentation add/amend any usage examples ?
  - Grammar and syntax checks 
  - Does AsciiDoc generation report any WARN messages ?
