### PR TITLE
Add log4j-layout-template-json dependency for ECS logging support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -767,6 +767,12 @@
             <scope>provided</scope>
          </dependency>
          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <version>${version.log4j}</version>
+            <scope>provided</scope>
+         </dependency>
+         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analysis-common</artifactId>
             <version>${version.lucene}</version>

--- a/server/runtime/pom.xml
+++ b/server/runtime/pom.xml
@@ -153,6 +153,11 @@
          <scope>compile</scope>
       </dependency>
       <dependency>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-layout-template-json</artifactId>
+         <scope>compile</scope>
+      </dependency>
+      <dependency>
          <groupId>org.latencyutils</groupId>
          <artifactId>LatencyUtils</artifactId>
          <scope>compile</scope>


### PR DESCRIPTION
This adds the log4j-layout-template-json dependency to enable
structured logging with Elastic Common Schema (ECS) format.

The log4j-layout-template-json artifact includes built-in ECS
templates that can be used via JsonTemplateLayout in log4j2.xml.

This enables better integration with log aggregation pipelines
(Elasticsearch, Kibana, etc.) without requiring custom configurations
or manual library additions at runtime.

**Changes:**
- Added to root pom.xml dependencyManagement
- Added to server/runtime/pom.xml dependencies (version 2.25.3)

**Usage Example:**
After this change, users can configure ECS logging in their log4j2.xml:
```xml
<Console name="ECS-STDOUT">
  <JsonTemplateLayout eventTemplateUri="classpath:EcsLayout.json"/>
</Console>
```

Impact:
- Minimal footprint: ~60KB JAR added to lib/
- No breaking changes: Optional dependency, only loaded when configured
- Enables modern observability practices for cloud-native deployments

Closes: #17143

---
Author Checklist

- Commit message includes reference to GitHub issue #17143
- Commits squashed into self-contained units
- Tests included - NOT REQUIRED: Dependency addition with no code changes. Functionality will be tested when users configure it in
 log4j2.xml
- Documentation included - NOT REQUIRED: Optional dependency for advanced users familiar with Log4j2. Users can reference
https://logging.apache.org/log4j/2.x/manual/json-template-layout.html
- Log messages internationalized - NOT APPLICABLE: No log messages added
- Performance benchmarks - NOT APPLICABLE: No performance impact, dependency only loaded if explicitly configured
- CLI/Console output examples - NOT APPLICABLE: No CLI or console output changes
- Follow-up issues - NONE REQUIRED: Complete, self-contained change