### PR TITLE
[16.0.x] [#16851] Local RESP cache in clustered server

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/RespServer.java
@@ -115,9 +115,9 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
          } else {
             if (globalConfiguration.isClustered()) { // We are running in clustered mode
                builder.clustering().cacheMode(CacheMode.DIST_SYNC);
-               // See: https://redis.io/docs/reference/cluster-spec/#key-distribution-model
-               builder.clustering().hash().keyPartitioner(new RESPHashFunctionPartitioner());
             }
+            // See: https://redis.io/docs/reference/cluster-spec/#key-distribution-model
+            builder.clustering().hash().keyPartitioner(new RESPHashFunctionPartitioner());
             builder.encoding().key().mediaType(RESP_KEY_MEDIA_TYPE);
             builder.encoding().value().mediaType(configuredValueType);
          }
@@ -131,7 +131,7 @@ public class RespServer extends AbstractProtocolServer<RespServerConfiguration> 
          if (!RESP_KEY_MEDIA_TYPE.equals(explicitConfiguration.encoding().keyDataType().mediaType()))
             throw CONFIG.respCacheKeyMediaTypeSupplied(cacheName, explicitConfiguration.encoding().keyDataType().mediaType());
 
-         if (globalConfiguration.isClustered() &&
+         if (explicitConfiguration.clustering().cacheMode().isClustered() &&
                !(explicitConfiguration.clustering().hash().keyPartitioner() instanceof RESPHashFunctionPartitioner)) {
             throw CONFIG.respCacheUseDefineConsistentHash(cacheName, explicitConfiguration.clustering().hash().keyPartitioner().getClass().getName());
          }


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/16852

* Configure the hash function for non-clustered RESP.
* Validate hash configuration based on stored value.

Closes #16851.