### PR TITLE
[#16800] Consider supporting generic Micrometer MeterRegistry

### DIFF
--- a/core/src/main/java/org/infinispan/metrics/impl/GenericMetricRegistry.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/GenericMetricRegistry.java
@@ -1,0 +1,27 @@
+package org.infinispan.metrics.impl;
+
+import java.util.Objects;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * A concrete implementation of {@link MetricsRegistry} that accepts any Micrometer {@link MeterRegistry}
+ * implementation.
+ * <p>
+ * This registry implementation provides flexibility by allowing integration with any Micrometer-compatible meter
+ * registry. The provided registry is treated as externally managed, meaning its lifecycle (creation and closure) is
+ * handled outside of Infinispan.
+ * <p>
+ * <strong>Note:</strong> This implementation does not support metric scraping. The {@link #supportScrape()} method
+ * will return {@code false}, and {@link #scrape(String)} will return {@code null}.
+ *
+ * @see AbstractMetricsRegistry
+ * @see MeterRegistry
+ */
+public class GenericMetricRegistry extends AbstractMetricsRegistry {
+   @Override
+   ScrapeRegistry createScrapeRegistry(MeterRegistry registry) {
+      Objects.requireNonNull(registry);
+      return new NoScrapeRegistry(registry, true);
+   }
+}

--- a/core/src/main/java/org/infinispan/metrics/impl/MetricsComponentFactory.java
+++ b/core/src/main/java/org/infinispan/metrics/impl/MetricsComponentFactory.java
@@ -3,6 +3,9 @@ package org.infinispan.metrics.impl;
 import static org.infinispan.commons.util.Util.loadClassStrict;
 import static org.infinispan.util.logging.Log.CONTAINER;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.AutoInstantiableFactory;
 import org.infinispan.factories.ComponentFactory;
@@ -10,6 +13,7 @@ import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.metrics.config.MicrometerMeterRegistryConfiguration;
 import org.infinispan.remoting.transport.jgroups.JGroupsMetricsManager;
 import org.infinispan.remoting.transport.jgroups.JGroupsMetricsManagerImpl;
 import org.infinispan.remoting.transport.jgroups.NoOpJGroupsMetricManager;
@@ -84,26 +88,54 @@ public final class MetricsComponentFactory implements ComponentFactory, AutoInst
          return registry;
       }
 
-      String registryClass = "io.micrometer.prometheusmetrics.PrometheusMeterRegistry";
-      try {
-         loadClassStrict(registryClass, classLoader);
-         registry = new PrometheusRegistry();
-      } catch (ClassNotFoundException ignore) {
-         logMissingMicrometerImpl(registryClass);
-         try {
-            registryClass = "io.micrometer.prometheus.PrometheusMeterRegistry";
-            loadClassStrict(registryClass, classLoader);
-            registry = new PrometheusSimpleClientRegistry();
-         } catch (ClassNotFoundException e) {
-            logMissingMicrometerImpl(registryClass);
-            log.warnFallbackToNoOpMetrics(NoMetricRegistry.class.getSimpleName());
-            registry = NoMetricRegistry.NO_OP_INSTANCE;
-         }
-      }
-      return registry;
+      registry = tryLoadPrometheusRegistry(classLoader)
+            .or(() -> tryLoadDeprecatedPrometheusRegistry(classLoader))
+            .or(() -> tryLoadGenericMetricRegistry(globalConfig))
+            .orElseGet(MetricsComponentFactory::fallbackMetricRegistry);
+      return Objects.requireNonNull(registry);
    }
 
-   private void logMissingMicrometerImpl(String clazz) {
+   private static Optional<MetricsRegistry> tryLoadPrometheusRegistry(ClassLoader classLoader) {
+      var registryClass = "io.micrometer.prometheusmetrics.PrometheusMeterRegistry";
+      try {
+         loadClassStrict(registryClass, classLoader);
+         return Optional.of(new PrometheusRegistry());
+      } catch (ClassNotFoundException ignore) {
+         logMissingMicrometerImpl(registryClass);
+      }
+      return Optional.empty();
+   }
+
+   private static Optional<MetricsRegistry> tryLoadDeprecatedPrometheusRegistry(ClassLoader classLoader) {
+      var registryClass = "io.micrometer.prometheus.PrometheusMeterRegistry";
+      try {
+         loadClassStrict(registryClass, classLoader);
+         return Optional.of(new PrometheusSimpleClientRegistry());
+      } catch (ClassNotFoundException ignore) {
+         logMissingMicrometerImpl(registryClass);
+      }
+      return Optional.empty();
+   }
+
+   private static Optional<MetricsRegistry> tryLoadGenericMetricRegistry(GlobalConfiguration configuration) {
+      var registryClass = "io.micrometer.core.instrument.MeterRegistry";
+      try {
+         loadClassStrict(registryClass, configuration.classLoader());
+         return Optional.ofNullable(configuration.module(MicrometerMeterRegistryConfiguration.class))
+               .map(MicrometerMeterRegistryConfiguration::meterRegistry)
+               .map(ignored -> new GenericMetricRegistry());
+      } catch (ClassNotFoundException ignore) {
+         logMissingMicrometerImpl(registryClass);
+      }
+      return Optional.empty();
+   }
+
+   private static MetricsRegistry fallbackMetricRegistry() {
+      log.warnFallbackToNoOpMetrics(NoMetricRegistry.class.getSimpleName());
+      return NoMetricRegistry.NO_OP_INSTANCE;
+   }
+
+   private static void logMissingMicrometerImpl(String clazz) {
       log.debugf("Micrometer implementation '%s' not available on classpath", clazz);
    }
 }


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
Closes: #16800 

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Reviewer Checklist (all must be checked):
- [ ] Code review
  - Are the changes reasonable?
  - Are there any use cases, integrations, inputs that haven't been considered in the implementation?
  - Is the code understandable? (KISS, comments)
  - Is there a better way to implement/write the functionality, code pieces?
  - Is formatting in line with the rest of the project? (checkstyle and spotless)
- [ ] Test review
  - Is the new test coverage rich enough to cover all the changes and considerations above?
  - Does the base functionality works as expected in the build project?
  - Does it behave as expected when given various inputs? (Valid and invalid, missing, partial)
  - Are there integrations to be considered? (Does the new functionality work well with the rest of the project, environment)
  -  Even if all above works as expected, are there weird behaviors to be improved on?
- [ ] Documentation review
  - Does the new/changed documentation cover the PR in sufficient matter?
  - For public API, are JavaDocs included for every new/changed class/method ?
  - For new features, does the documentation add/amend any usage examples ?
  - Grammar and syntax checks 
  - Does AsciiDoc generation report any WARN messages ?

---

### Manual tested with Simple Tutorials

All of our test suites contain the Prometheus jars in the classpath, making it impossible to test this code path.
Using the following diff with the development branch in the simple tutorials repo:
* The main branch gets `Registry is a NoMetricRegistry`.
* This PR gets `Scrape not supported`. 

```diff
diff --git a/infinispan-embedded/metrics/pom.xml b/infinispan-embedded/metrics/pom.xml
index 452c7a4c..5773796c 100644
--- a/infinispan-embedded/metrics/pom.xml
+++ b/infinispan-embedded/metrics/pom.xml
diff --git a/infinispan-embedded/metrics/pom.xml b/infinispan-embedded/metrics/pom.xml
index 452c7a4c..5773796c 100644
--- a/infinispan-embedded/metrics/pom.xml
+++ b/infinispan-embedded/metrics/pom.xml
@@ -62,11 +62,11 @@
             <version>${version.micrometer}</version>
         </dependency>
 
-        <dependency>
+        <!--dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
             <version>${version.micrometer}</version>
-        </dependency>
+        </dependency-->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
diff --git a/infinispan-embedded/metrics/src/main/java/org/infinispan/tutorial/simple/metrics/InfinispanCacheMetrics.java b/infinispan-embedded/metrics/src/main/java/org/infinispan/tutorial/simple/metrics/InfinispanCacheMetrics.java
index 875b05b4..c4450071 100644
--- a/infinispan-embedded/metrics/src/main/java/org/infinispan/tutorial/simple/metrics/InfinispanCacheMetrics.java
+++ b/infinispan-embedded/metrics/src/main/java/org/infinispan/tutorial/simple/metrics/InfinispanCacheMetrics.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import javax.management.ObjectName;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import org.infinispan.Cache;
 import org.infinispan.commons.api.CacheContainerAdmin;
 import org.infinispan.commons.jmx.MBeanServerLookup;
@@ -13,7 +14,9 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.metrics.config.MicrometerMeterRegisterConfigurationBuilder;
 import org.infinispan.metrics.impl.MetricsRegistry;
+import org.infinispan.metrics.impl.NoMetricRegistry;
 
 public class InfinispanCacheMetrics {
     public static final String CACHE_NAME = "my-cache";
@@ -46,6 +49,8 @@ public class InfinispanCacheMetrics {
 
     public void createDefaultCacheManager() {
         GlobalConfigurationBuilder builder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+        builder.addModule(MicrometerMeterRegisterConfigurationBuilder.class)
+                .meterRegistry(new CompositeMeterRegistry());
 
         // Toggle statistics for the cache manager.
         // Equivalent of the following in the XML:
@@ -81,6 +86,9 @@ public class InfinispanCacheMetrics {
     public String scrapePrometheusMetrics() {
         MetricsRegistry registry = GlobalComponentRegistry.componentOf(dcm, MetricsRegistry.class);
         Objects.requireNonNull(registry, "Registry is null");
+        if (registry instanceof NoMetricRegistry) {
+            throw new IllegalStateException("Registry is a NoMetricRegistry: " + registry);
+        }
 
         if (!registry.supportScrape())
             throw new IllegalStateException("Scrape not supported");

```