### PR TITLE
Fixes docs for clustered locks

### DIFF
--- a/documentation/src/main/asciidoc/topics/proc_configuring_internal_caches_locks.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_internal_caches_locks.adoc
@@ -41,4 +41,4 @@ include::xml/clustered_lock_manager.xml[]
 .Reference
 
 * link:../../apidocs/org/infinispan/lock/configuration/ClusteredLockManagerConfiguration.html[ClusteredLockManagerConfiguration]
-* link:../../configuration-schema/infinispan-clustered-locks-config-infinispan-clustered-locks-config-12.0.html.html[Clustered Locks Configuration Schema]
+* link:{configdocroot}infinispan-clustered-locks-config-{schemaversion}.html[{brandname} Clustered Locks Configuration Schema]


### PR DESCRIPTION
This was found in 15.2, but needs to up fixed in 16.0 too