### PR TITLE
[#16899] Update ConnectionMetadata protocol version on every Hot Rod request

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
@@ -81,11 +81,4 @@ public enum ProtocolVersion {
       throw new IllegalArgumentException("Illegal version " + version);
    }
 
-   public ProtocolVersion choose(ProtocolVersion serverVersion) {
-      if (serverVersion == null) {
-         return this;
-      }
-
-      return (serverVersion.compareTo(this) >= 0) ? this : serverVersion;
-   }
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheRequestProcessor.java
@@ -29,7 +29,6 @@ import org.infinispan.reactive.publisher.impl.DeliveryGuarantee;
 import org.infinispan.security.actions.SecurityActions;
 import org.infinispan.server.core.iteration.IterableIterationResult;
 import org.infinispan.server.core.iteration.IterationState;
-import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.hotrod.HotRodServer.ExtendedCacheInfo;
 import org.infinispan.server.hotrod.logging.Log;
 import org.infinispan.server.hotrod.streaming.GetStreamResponse;
@@ -75,8 +74,6 @@ class CacheRequestProcessor extends BaseRequestProcessor {
    }
 
    void pingResults(HotRodHeader header) {
-      ConnectionMetadata metadata = ConnectionMetadata.getInstance(channel);
-      metadata.protocolVersion(HotRodVersion.forVersion(header.version).toString());
       writeResponse(header, header.encoder().pingResponse(header, server, channel, OperationStatus.Success));
    }
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodHeader.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodHeader.java
@@ -91,22 +91,6 @@ public class HotRodHeader implements InfinispanSpanContext {
       return HotRodVersion.getEncoder(version);
    }
 
-   boolean isSkipCacheLoad() {
-      if (version < 20) {
-         return false;
-      } else {
-         return op.canSkipCacheLoading() && hasFlag(ProtocolFlag.SkipCacheLoader);
-      }
-   }
-
-   boolean isSkipIndexing() {
-      if (version < 20) {
-         return false;
-      } else {
-         return op.canSkipIndexing() && hasFlag(ProtocolFlag.SkipIndexing);
-      }
-   }
-
    AdvancedCache<byte[], byte[]> getOptimizedCache(AdvancedCache<byte[], byte[]> c,
                                                    boolean transactional, boolean clustered) {
       if (clustered && !transactional && op.isConditional()) {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodVersion.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodVersion.java
@@ -27,14 +27,10 @@ public enum HotRodVersion {
    HOTROD_41(4, 1), // since 15.1
    ;
 
-   private final int major;
-   private final int minor;
    private final byte version;
    private final String text;
 
    HotRodVersion(int major, int minor) {
-      this.major = major;
-      this.minor = minor;
       this.version = (byte) (major * 10 + minor);
       this.text = version > 0 ? String.format("HOTROD/%d.%d", major, minor) : "UNKNOWN";
    }

--- a/server/hotrod/src/main/resources/hotrod.gr
+++ b/server/hotrod/src/main/resources/hotrod.gr
@@ -25,6 +25,7 @@ import org.infinispan.counter.api.CounterConfiguration;
 import org.infinispan.counter.api._private.CounterEncodeUtil;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.hotrod.tx.ControlByte;
 
 init {
@@ -78,7 +79,10 @@ deadend {
 root request
    : { posBefore = buf.readerIndex(); }
      magic { if (accessLogging) { requestStart = Instant.now(); } }
-     header { if (log.isTraceEnabled()) log.tracef("Parsed header: %s", header); }
+     header {
+        if (log.isTraceEnabled()) log.tracef("Parsed header: %s", header);
+        ConnectionMetadata.getInstance(cacheProcessor.channel()).protocolVersion(HotRodVersion.forVersion(header.version).toString());
+     }
      parameters
    ;
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConnectionMetadataTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConnectionMetadataTest.java
@@ -11,6 +11,7 @@ import java.net.InetSocketAddress;
 
 import org.infinispan.server.core.transport.ConnectionMetadata;
 import org.infinispan.server.hotrod.test.HotRodClient;
+import org.infinispan.server.hotrod.test.Op;
 import org.testng.annotations.Test;
 
 import io.netty.channel.Channel;
@@ -51,6 +52,30 @@ public class HotRodConnectionMetadataTest extends HotRodSingleNodeTest {
 
          ConnectionMetadata metadata = getConnectionMetadata(client31);
          assertEquals("HOTROD/3.1", metadata.protocolVersion());
+      }
+   }
+
+   public void testProtocolVersionUpdatedOnVersionChange(Method m) {
+      // Use a v2.1 client so the Encoder doesn't write media type bytes (added in v2.8).
+      // This lets us safely send Ops at different versions < 2.8 on the same connection,
+      // simulating what happens during protocol auto-negotiation.
+      try (HotRodClient client = new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName,
+            HotRodVersion.HOTROD_21.getVersion(), false)) {
+         // Send a GET at version 2.1
+         Op getV21 = new Op(0xA0, HotRodVersion.HOTROD_21.getVersion(), HotRodConstants.GET_REQUEST,
+               cacheName, k(m), 0, 0, null, 0, 0, (byte) 1, 0);
+         client.execute(getV21);
+
+         ConnectionMetadata metadata = getConnectionMetadata(client);
+         assertEquals("HOTROD/2.1", metadata.protocolVersion());
+
+         // Send a GET at version 2.5 on the SAME connection
+         Op getV25 = new Op(0xA0, HotRodVersion.HOTROD_25.getVersion(), HotRodConstants.GET_REQUEST,
+               cacheName, k(m), 0, 0, null, 0, 0, (byte) 1, 0);
+         client.execute(getV25);
+
+         // Metadata should update to reflect the new version
+         assertEquals("HOTROD/2.5", metadata.protocolVersion());
       }
    }
 

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConnectionMetadataTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/HotRodConnectionMetadataTest.java
@@ -1,0 +1,68 @@
+package org.infinispan.server.hotrod;
+
+import static org.infinispan.server.hotrod.OperationStatus.Success;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.assertStatus;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.k;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.v;
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+
+import org.infinispan.server.core.transport.ConnectionMetadata;
+import org.infinispan.server.hotrod.test.HotRodClient;
+import org.testng.annotations.Test;
+
+import io.netty.channel.Channel;
+import io.netty.channel.group.ChannelGroup;
+
+/**
+ * Tests that {@link ConnectionMetadata#protocolVersion()} is correctly updated
+ * on every request, not just on PING.
+ */
+@Test(groups = "functional", testName = "server.hotrod.HotRodConnectionMetadataTest")
+public class HotRodConnectionMetadataTest extends HotRodSingleNodeTest {
+
+   public void testProtocolVersionSetOnPing() {
+      // The default client (v2.1) sent a PING on startup
+      ConnectionMetadata metadata = getConnectionMetadata(client());
+      assertEquals("HOTROD/2.1", metadata.protocolVersion());
+   }
+
+   public void testProtocolVersionSetOnNonPingRequest(Method m) {
+      // Create a client at version 3.0 without sending a startup PING.
+      // Before the fix, ConnectionMetadata.protocolVersion was only set during PING processing,
+      // so a client that never sends PING would have null protocolVersion.
+      try (HotRodClient client30 = new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName,
+            HotRodVersion.HOTROD_30.getVersion(), false)) {
+         // Send a PUT at version 3.0 — this should set the metadata
+         assertStatus(client30.put(k(m), 0, 0, v(m)), Success);
+
+         ConnectionMetadata metadata = getConnectionMetadata(client30);
+         assertEquals("HOTROD/3.0", metadata.protocolVersion());
+      }
+   }
+
+   public void testProtocolVersionReflectsCorrectVersion() {
+      // Create a v3.1 client without PING, send a GET, verify the version
+      try (HotRodClient client31 = new HotRodClient("127.0.0.1", hotRodServer.getPort(), cacheName,
+            HotRodVersion.HOTROD_31.getVersion(), false)) {
+         client31.get("nonexistent");
+
+         ConnectionMetadata metadata = getConnectionMetadata(client31);
+         assertEquals("HOTROD/3.1", metadata.protocolVersion());
+      }
+   }
+
+   private ConnectionMetadata getConnectionMetadata(HotRodClient client) {
+      ChannelGroup channels = hotRodServer.getTransport().getAcceptedChannels();
+      InetSocketAddress clientLocal = (InetSocketAddress) client.getChannel().localAddress();
+      for (Channel ch : channels) {
+         InetSocketAddress serverRemote = (InetSocketAddress) ch.remoteAddress();
+         if (serverRemote != null && serverRemote.getPort() == clientLocal.getPort()) {
+            return ConnectionMetadata.getInstance(ch);
+         }
+      }
+      throw new AssertionError("Could not find server-side channel for client connection");
+   }
+}


### PR DESCRIPTION
Closes: #16899

`ConnectionMetadata.protocolVersion` was only updated during PING processing in `CacheRequestProcessor.pingResults()`. Since auto-negotiating clients send the initial PING at the safe handshake version (3.1), the metadata permanently showed `HOTROD/3.1` even after the client upgraded to 4.1 for all subsequent requests.

This PR moves the `protocolVersion` update into the `hotrod.gr` grammar's `root request` rule, so it runs after every request's header is parsed. The redundant update in `CacheRequestProcessor.pingResults()` is removed along with unused fields in `HotRodVersion`, `HotRodHeader`, and `ProtocolVersion`.

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - No documentation changes needed: internal behavior fix with no user-facing API change.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
  - No performance impact: the `ConnectionMetadata.protocolVersion()` setter is a simple field assignment.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.