### PR TITLE
[#17236] Fix flaky LegacyRestMetricsResourceIT.testDetailedKeyMetrics2

### DIFF
--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/LegacyRestMetricsResourceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/LegacyRestMetricsResourceIT.java
@@ -265,14 +265,11 @@ public class LegacyRestMetricsResourceIT {
       // 1 write
       assertEquals(1, Arrays.stream(writes).sum());
 
-      // The arrays must have the same position set
-      // If the request is sent to the primary owner, it is recorded as a hit.
-      // Because "IGNORE_RETURN_VALUES" flag is set, the back owner records it as a miss.
-      if (writes[0] == 1) {
-         assertArrayEquals(writes, rm_hits);
-      } else {
-         assertArrayEquals(writes, rm_misses);
-      }
+      // The arrays must have the same position set.
+      // Remove of an existing entry always returns the old value to the originator,
+      // even in non-primary. We'll always have a hit and no misses.
+      assertArrayEquals(writes, rm_hits);
+      assertEquals(0, Arrays.stream(rm_misses).sum());
    }
 
    private static void assertDetailedMetrics(List<Metric> allMetrics, String name, Consumer<AbstractDoubleAssert<?>> consumer) {


### PR DESCRIPTION
Closes: #17236

## Summary
- Fix flaky assertion in `LegacyRestMetricsResourceIT.testDetailedKeyMetrics2` that assumed remove operations on non-primary originators would be recorded as misses due to `IGNORE_RETURN_VALUES`
- Remove of an existing entry always returns the old value to the originator regardless of ownership role, so it is always recorded as a hit
- Align the assertion with `RestMetricsResourceIT.testDetailedKeyMetrics2` which already has the correct logic

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - This PR *is* the test fix — corrects a flaky test assertion.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - Test-only change, no documentation needed.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.