### PR TITLE
[#17271] Add AGGREGATE COUNT to ZUNION, ZINTER, ZUNIONSTORE, ZINTERSTORE

### DIFF
--- a/multimap/src/main/java/org/infinispan/multimap/impl/BaseSetBucket.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/BaseSetBucket.java
@@ -52,7 +52,7 @@ public interface BaseSetBucket<E> {
             if (existing == null) {
                unionScore = element.score();
             } else {
-               unionScore = function.apply(element.score(), SetUtil.calculate(existing, weight));
+               unionScore = function.apply(element.score(), function.weightedScore(existing, weight));
             }
             output.add(new ScoredValue<>(unionScore, element.wrappedValue()));
             merge.put(element.wrappedValue(), unionScore);
@@ -64,7 +64,7 @@ public interface BaseSetBucket<E> {
          ScoredValue<E> element = ite.next();
          Double existing = merge.get(element.wrappedValue());
          if (existing == null) {
-            output.add(new ScoredValue<>(SetUtil.calculate(element.score(), weight), element.wrappedValue()));
+            output.add(new ScoredValue<>(function.weightedScore(element.score(), weight), element.wrappedValue()));
          }
       }
 
@@ -86,7 +86,7 @@ public interface BaseSetBucket<E> {
    default Collection<ScoredValue<E>> inter(Collection<ScoredValue<E>> input, double weight, SortedSetBucket.AggregateFunction function) {
       if (input == null || input.isEmpty()) {
          return getAsSet().stream()
-               .map(s -> new ScoredValue<>(SetUtil.calculate(s.score(), weight), s.wrappedValue()))
+               .map(s -> new ScoredValue<>(function.weightedScore(s.score(), weight), s.wrappedValue()))
                .toList();
       }
 
@@ -94,7 +94,7 @@ public interface BaseSetBucket<E> {
       for (ScoredValue<E> element : input) {
          Double existing = getScore(element.wrappedValue());
          if (existing != null) {
-            double score = function.apply(element.score(), SetUtil.calculate(existing, weight));
+            double score = function.apply(element.score(), function.weightedScore(existing, weight));
             output.add(new ScoredValue<>(score, element.wrappedValue()));
          }
       }
@@ -108,12 +108,4 @@ public interface BaseSetBucket<E> {
 
    Double getScore(MultimapObjectWrapper<E> key);
 
-   final class SetUtil {
-      private SetUtil() { }
-
-
-      private static double calculate(Double existing, double weight) {
-         return weight == 0d ? 0d : existing * weight;
-      }
-   }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/impl/SortedSetBucket.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/SortedSetBucket.java
@@ -39,9 +39,6 @@ public class SortedSetBucket<V> implements SortableBucket<V>, BaseSetBucket<V> {
    @Proto
    @ProtoTypeId(ProtoStreamTypeIds.MULTIMAP_SORTED_SET_BUCKET_AGGREGATE_FUNCTION)
    public enum AggregateFunction {
-      /**
-       *
-       */
       SUM {
          @Override
          public double apply(double first, double second) {
@@ -57,9 +54,23 @@ public class SortedSetBucket<V> implements SortableBucket<V>, BaseSetBucket<V> {
          public double apply(double first, double second) {
             return Math.max(first, second);
          }
+      }, COUNT {
+         @Override
+         public double apply(double first, double second) {
+            return first + second;
+         }
+
+         @Override
+         public double weightedScore(double score, double weight) {
+            return weight;
+         }
       };
 
       public abstract double apply(double first, double second);
+
+      public double weightedScore(double score, double weight) {
+         return weight == 0d ? 0d : score * weight;
+      }
    }
 
    @Override

--- a/server/resp/src/test/java/org/infinispan/server/resp/SortedSetCommandsTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/SortedSetCommandsTest.java
@@ -1423,6 +1423,91 @@ public class SortedSetCommandsTest extends SingleNodeRespBaseTest {
               .containsExactly(just(0, "neginf"));
    }
 
+   @Test
+   @SuppressWarnings("unchecked")
+   public void testAggregateCount() {
+      RedisCodec<String, String> codec = StringCodec.UTF8;
+
+      // Setup: 3 sorted sets with varying membership
+      // s1: foo=1, bar=1
+      // s2: foo=2, bar=2
+      // s3: foo=3
+      redis.zadd("s1", just(1, "foo"), just(1, "bar"));
+      redis.zadd("s2", just(2, "foo"), just(2, "bar"));
+      redis.zadd("s3", just(3, "foo"));
+
+      // ZUNIONSTORE with AGGREGATE COUNT (no weights)
+      // foo appears in 3 sets -> score 3, bar appears in 2 sets -> score 2
+      assertThat(redis.dispatch(CommandType.ZUNIONSTORE, new IntegerOutput<>(codec),
+            new CommandArgs<>(codec).addKey("out").add(3)
+                  .add("s1").add("s2").add("s3").add("AGGREGATE").add("COUNT"))).isEqualTo(2);
+      assertThat(redis.zrangeWithScores("out", 0, -1)).containsExactly(
+            just(2, "bar"),
+            just(3, "foo"));
+
+      // ZINTERSTORE with AGGREGATE COUNT (no weights)
+      // Only foo is in all 3 sets -> score 3
+      assertThat(redis.dispatch(CommandType.ZINTERSTORE, new IntegerOutput<>(codec),
+            new CommandArgs<>(codec).addKey("out").add(3)
+                  .add("s1").add("s2").add("s3").add("AGGREGATE").add("COUNT"))).isEqualTo(1);
+      assertThat(redis.zrangeWithScores("out", 0, -1)).containsExactly(
+            just(3, "foo"));
+
+      // ZUNIONSTORE with AGGREGATE COUNT and WEIGHTS
+      // foo: weight 10 + 5 + 3 = 18, bar: weight 10 + 5 = 15
+      assertThat(redis.dispatch(CommandType.ZUNIONSTORE, new IntegerOutput<>(codec),
+            new CommandArgs<>(codec).addKey("out").add(3)
+                  .add("s1").add("s2").add("s3")
+                  .add("WEIGHTS").add(10).add(5).add(3)
+                  .add("AGGREGATE").add("COUNT"))).isEqualTo(2);
+      assertThat(redis.zrangeWithScores("out", 0, -1)).containsExactly(
+            just(15, "bar"),
+            just(18, "foo"));
+
+      // ZINTERSTORE with AGGREGATE COUNT and WEIGHTS
+      // Only foo is in all 3 sets: weight 10 + 5 + 3 = 18
+      assertThat(redis.dispatch(CommandType.ZINTERSTORE, new IntegerOutput<>(codec),
+            new CommandArgs<>(codec).addKey("out").add(3)
+                  .add("s1").add("s2").add("s3")
+                  .add("WEIGHTS").add(10).add(5).add(3)
+                  .add("AGGREGATE").add("COUNT"))).isEqualTo(1);
+      assertThat(redis.zrangeWithScores("out", 0, -1)).containsExactly(
+            just(18, "foo"));
+
+      // ZUNION with AGGREGATE COUNT and WITHSCORES
+      List<Object> result = redis.dispatch(CommandType.ZUNION, new ArrayOutput<>(codec),
+            new CommandArgs<>(codec).add(3)
+                  .add("s1").add("s2").add("s3")
+                  .add("AGGREGATE").add("COUNT").add("WITHSCORES"));
+      // Returns scored value pairs, sorted by score: bar(2), foo(3)
+      assertThat(result).hasSize(2);
+      List<Object> first = (List<Object>) result.get(0);
+      assertThat(first.get(0).toString()).isEqualTo("bar");
+      assertThat(Double.parseDouble(first.get(1).toString())).isEqualTo(2.0);
+      List<Object> second = (List<Object>) result.get(1);
+      assertThat(second.get(0).toString()).isEqualTo("foo");
+      assertThat(Double.parseDouble(second.get(1).toString())).isEqualTo(3.0);
+
+      // ZINTER with AGGREGATE COUNT and WITHSCORES
+      result = redis.dispatch(CommandType.ZINTER, new ArrayOutput<>(codec),
+            new CommandArgs<>(codec).add(3)
+                  .add("s1").add("s2").add("s3")
+                  .add("AGGREGATE").add("COUNT").add("WITHSCORES"));
+      // Only foo is in all 3 sets -> score 3
+      assertThat(result).hasSize(1);
+      first = (List<Object>) result.get(0);
+      assertThat(first.get(0).toString()).isEqualTo("foo");
+      assertThat(Double.parseDouble(first.get(1).toString())).isEqualTo(3.0);
+
+      // Single set with AGGREGATE COUNT: each element gets score = 1 (default weight)
+      assertThat(redis.dispatch(CommandType.ZUNIONSTORE, new IntegerOutput<>(codec),
+            new CommandArgs<>(codec).addKey("out").add(1)
+                  .add("s1").add("AGGREGATE").add("COUNT"))).isEqualTo(2);
+      assertThat(redis.zrangeWithScores("out", 0, -1)).containsExactly(
+            just(1, "bar"),
+            just(1, "foo"));
+   }
+
    public void testZINTER() {
       // ZINTER 1 s1
       assertThat(redis.zinter("s1")).isEmpty();


### PR DESCRIPTION
Closes: #17271

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [ ] The PR includes new/modified documentation. Documentation not yet updated — will follow up separately once the Redis 8.8 command reference is finalized.
- [x] Log messages of level `INFO` and above have been internationalized.
- [ ] If the PR affects performance, include before/after benchmarks.
- [ ] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [ ] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

## Summary

Implements `AGGREGATE COUNT` as a fourth aggregation mode for sorted set union/intersection commands, matching Redis 8.8 ([redis/redis#14892](https://github.com/redis/redis/pull/14892)).

When `COUNT` is specified, scores are ignored — each set contributes its weight (default 1) per element, and contributions are summed. This enables counting set membership frequency directly at the command level.

### Changes

- **`SortedSetBucket.AggregateFunction`** — added `COUNT` enum value with `weightedScore()` method that returns just the weight (ignoring the score)
- **`BaseSetBucket`** — replaced `SetUtil.calculate()` with `function.weightedScore()` in `union()` and `inter()`, removed unused `SetUtil` inner class
- **`SortedSetCommandsTest`** — added `testAggregateCount()` covering ZUNIONSTORE, ZINTERSTORE, ZUNION, ZINTER with COUNT, with and without WEIGHTS

No changes needed in `AGGCommand` (parser already uses `valueOf()`) or `SortedSetAggregateFunction` (passes through generically).

### Example

```
> ZADD s1 1 foo 1 bar
> ZADD s2 2 foo 2 bar
> ZADD s3 3 foo
> ZUNIONSTORE out 3 s1 s2 s3 AGGREGATE COUNT
(integer) 2
> ZRANGE out 0 -1 WITHSCORES
1) "bar"
2) "2"
3) "foo"
4) "3"
```
