### PR TITLE
[16.0.x] [#17132] Get entry should add no-cache control header

### DIFF
--- a/integrationtests/endpoints-interop-it/src/test/java/org/infinispan/it/endpoints/EmbeddedRestHotRodTest.java
+++ b/integrationtests/endpoints-interop-it/src/test/java/org/infinispan/it/endpoints/EmbeddedRestHotRodTest.java
@@ -361,13 +361,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
 
       assertEquals(200, response.status());
       assertNotNull(response.header("Cache-Control"));
-      assertTrue(response.header("Cache-Control").contains("max-age"));
+      assertTrue(response.header("Cache-Control").contains("no-cache"));
       assertEquals("v1", response.body());
 
       // 6. GET with REST key2, short min-fresh
       response = join(cacheFactory.getRestCacheClient().get(key2, headers));
       assertEquals(200, response.status());
-      assertTrue(response.header("Cache-Control").contains("max-age"));
+      assertTrue(response.header("Cache-Control").contains("no-cache"));
       assertEquals("v2", response.body());
    }
 

--- a/server/rest/src/main/java/org/infinispan/rest/operations/CacheOperationsHelper.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/CacheOperationsHelper.java
@@ -9,7 +9,6 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
-import org.infinispan.rest.CacheControl;
 import org.infinispan.rest.configuration.RestServerConfiguration;
 
 public class CacheOperationsHelper {
@@ -56,17 +55,6 @@ public class CacheOperationsHelper {
          default:
             return false;
       }
-   }
-
-   public static CacheControl calcCacheControl(Date expires) {
-      if (expires == null) {
-         return null;
-      }
-      int maxAgeSeconds = calcFreshness(expires);
-      if (maxAgeSeconds > 0)
-         return CacheControl.maxAge(maxAgeSeconds);
-      else
-         return CacheControl.noCache();
    }
 
 

--- a/server/rest/src/main/java/org/infinispan/rest/resources/BaseCacheResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/BaseCacheResource.java
@@ -19,6 +19,7 @@ import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.rest.CacheControl;
 import org.infinispan.rest.DateUtils;
 import org.infinispan.rest.InvocationHelper;
 import org.infinispan.rest.NettyRestResponse;
@@ -209,7 +210,7 @@ public class BaseCacheResource {
                responseBuilder.status(HttpResponseStatus.OK)
                      .lastModified(lastMod)
                      .eTag(etag)
-                     .cacheControl(CacheOperationsHelper.calcCacheControl(expires))
+                     .cacheControl(CacheControl.noCache())
                      .expires(expires)
                      .timeToLive(meta.lifespan())
                      .maxIdle(meta.maxIdle())

--- a/server/rest/src/test/java/org/infinispan/rest/resources/BaseCacheResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/BaseCacheResourceTest.java
@@ -885,6 +885,31 @@ public abstract class BaseCacheResourceTest extends AbstractRestResourceTest {
       ResponseAssertion.assertThat(response).containsReturnedText("<string>foo</string>");
    }
 
+   @Test
+   public void shouldAlwaysSendNoCacheCacheControl() {
+      // Cache entries are mutable data. Cache-Control must always be no-cache so that
+      // browsers revalidate with the server on every request. Without this, browsers
+      // could serve stale cached responses and updated values are not visible.
+
+      // Entry with expiration
+      RestCacheClient expirationCache = client.cache("expiration");
+      CompletionStage<RestResponse> response = expirationCache.post("cacheControlKey", "value");
+      ResponseAssertion.assertThat(response).isOk();
+
+      RestResponse getResponse = join(expirationCache.get("cacheControlKey"));
+      ResponseAssertion.assertThat(getResponse).isOk();
+      ResponseAssertion.assertThat(getResponse).hasCacheControlHeaders("no-cache");
+
+      // Entry without expiration
+      RestCacheClient defaultCache = client.cache("default");
+      response = defaultCache.post("cacheControlKey", "value");
+      ResponseAssertion.assertThat(response).isOk();
+
+      getResponse = join(defaultCache.get("cacheControlKey"));
+      ResponseAssertion.assertThat(getResponse).isOk();
+      ResponseAssertion.assertThat(getResponse).hasCacheControlHeaders("no-cache");
+   }
+
    protected Map<String, String> createHeaders(RequestHeader header, String value) {
       Map<String, String> headers = new HashMap<>();
       headers.put(header.getValue(), value);


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/17215

Fixes #17132 

This issue affects browser behavior 