### PR TITLE
[#17267] Fix test workflow skipping builds for older branches

### DIFF
--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -46,7 +46,9 @@ jobs:
             event: ${{ github.event.workflow_run.event }}
 
          - name: Download build type
+           id: download-build-type
            uses: actions/download-artifact@v8.0.1
+           continue-on-error: true
            with:
              name: build-type
              run-id: ${{ github.event.workflow_run.id }}
@@ -55,7 +57,12 @@ jobs:
          - name: Read build type
            id: build-type
            run: |
-             BUILD_TYPE=$(cat build-type.txt)
+             if [ -f build-type.txt ]; then
+               BUILD_TYPE=$(cat build-type.txt)
+             else
+               BUILD_TYPE="full"
+               echo "build-type artifact not found (older branch?), defaulting to full build"
+             fi
              echo "build-type=$BUILD_TYPE" >> "$GITHUB_OUTPUT"
              echo "Build type: $BUILD_TYPE"
 


### PR DESCRIPTION
## Summary
- The `workflow_run` trigger always uses the workflow file from the default branch (`main`). Older version branches (e.g. `16.1.x`, `16.0.x`) don't have the `detect-changes` job and don't produce the `build-type` artifact introduced by #17268.
- When the Test workflow tries to download this missing artifact, the step fails, the `get-info` job fails, and all test jobs are skipped.
- Fix: use `continue-on-error: true` on the download step and default to `full` when the artifact is absent.

## Test plan
- [x] Verify that PRs against `main` with the `build-type` artifact work as before
- [ ] Verify that PRs against older branches (e.g. `16.1.x`) no longer have their tests skipped

Created with the assistance of an AI tool