### PR TITLE
[#17209] Removes infinispan hotrod legacy from the bom

### DIFF
--- a/build/bom/pom.xml
+++ b/build/bom/pom.xml
@@ -112,11 +112,6 @@
          </dependency>
          <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-client-hotrod-legacy</artifactId>
-            <version>${project.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-rest</artifactId>
             <version>${project.version}</version>
          </dependency>


### PR DESCRIPTION
backport for 16.0