### PR TITLE
[#17071] Fix flaky NumOwnersNodeCrashInSequenceTest

### DIFF
--- a/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
@@ -32,6 +32,7 @@ import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -61,40 +62,22 @@ public class NumOwnersNodeCrashInSequenceTest extends MultipleCacheManagersTest 
       configBuilder.clustering().hash().numSegments(4).stateTransfer().timeout(30000);
    }
 
-   public void testNodeCrashedBeforeStFinished0() throws Exception {
-      testNodeCrashedBeforeStFinished(0, 1, 2, 3);
+   @DataProvider(name = "nodePermutations")
+   public Object[][] nodePermutations() {
+      return new Object[][] {
+            {0, 1, 2, 3},
+            {0, 2, 1, 3},
+            {0, 3, 1, 2},
+            {1, 2, 0, 3},
+            {1, 3, 0, 2},
+            {2, 3, 0, 1},
+            {1, 2, 3, 0},
+            {2, 3, 1, 0},
+      };
    }
 
-   public void testNodeCrashedBeforeStFinished1() throws Exception {
-      testNodeCrashedBeforeStFinished(0, 2, 1, 3);
-   }
-
-   public void testNodeCrashedBeforeStFinished2() throws Exception {
-      testNodeCrashedBeforeStFinished(0, 3, 1, 2);
-   }
-
-   public void testNodeCrashedBeforeStFinished3() throws Exception {
-      testNodeCrashedBeforeStFinished(1, 2, 0, 3);
-   }
-
-   public void testNodeCrashedBeforeStFinished4() throws Exception {
-      testNodeCrashedBeforeStFinished(1, 3, 0, 2);
-   }
-
-   public void testNodeCrashedBeforeStFinished5() throws Exception {
-      testNodeCrashedBeforeStFinished(2, 3, 0, 1);
-   }
-
-   public void testNodeCrashedBeforeStFinished6() throws Exception {
-      testNodeCrashedBeforeStFinished(1, 2, 3, 0);
-   }
-
-   public void testNodeCrashedBeforeStFinished7() throws Exception {
-      testNodeCrashedBeforeStFinished(2, 3, 1, 0);
-   }
-
-
-   private void testNodeCrashedBeforeStFinished(final int a0, final int a1, final int c0, final int c1) throws Exception {
+   @Test(dataProvider = "nodePermutations")
+   public void testNodeCrashedBeforeStFinished(final int a0, final int a1, final int c0, final int c1) throws Exception {
 
       cchf.setOwnerIndexes(new int[][]{{a0, a1}, {a1, c0}, {c0, c1}, {c1, a0}});
       configBuilder.addModule(PrivateCacheConfigurationBuilder.class).consistentHashFactory(cchf);

--- a/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
@@ -3,6 +3,7 @@ package org.infinispan.partitionhandling;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.fail;
 
@@ -180,6 +181,10 @@ public class NumOwnersNodeCrashInSequenceTest extends MultipleCacheManagersTest 
       }
 
       log.debug("Changing partition availability mode back to AVAILABLE");
+      // Reset the spy so it doesn't interfere with the recovery rebalance.
+      // Under CI load, the StateSequencer advance calls in the spy can timeout,
+      // leaving the sequencer in a broken state that blocks recovery responses.
+      reset(spyRequests);
       cchf.setOwnerIndexes(new int[][]{{a0, a1}, {a1, a0}, {a0, a1}, {a1, a0}});
       LocalTopologyManager ltm = TestingUtil.extractGlobalComponent(manager(a0), LocalTopologyManager.class);
       ltm.setCacheAvailability(TestingUtil.getDefaultCacheName(manager(a0)), AvailabilityMode.AVAILABLE);


### PR DESCRIPTION
Closes: #17071

## Root Cause

The Mockito spy on `RequestRepository.addResponse()` uses `StateSequencer.advance()` calls to coordinate the crash sequence. Under CI load, the `advance("main:cluster_degraded")` call can timeout (30s default), leaving the sequencer in a broken state where `cluster_degraded` is never signalled. During the recovery rebalance, the spy then blocks on `advance("main:after_cluster_degraded")` (which depends on the unsignalled checkpoint), preventing the `PublisherResponse` from being delivered, causing the rebalance to get stuck at `READ_OLD_WRITE_ALL`.

## Fix

Reset the Mockito spy on `RequestRepository` before triggering the recovery rebalance, so it no longer intercepts `addResponse()` calls during recovery.

## Duplicates

This fix also resolves the following duplicate issues:

**NumOwnersNodeCrashInSequenceTest:** #17025, #17036, #17039, #17040, #17044, #17062, #16892
**NumOwnersNodeStopInSequenceTest:** #13941, #14962, #14102, #14216, #14037, #14383, #14170

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - No new tests needed: this is a fix to an existing test's infrastructure (removing spy interference). All 8 test variants pass locally.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - No documentation needed: internal test fix only.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool