### PR TITLE
[#17310] Split JAVA_OPTS into granular category variables

### DIFF
--- a/documentation/src/main/asciidoc/topics/con_jvm-settings-for-server.adoc
+++ b/documentation/src/main/asciidoc/topics/con_jvm-settings-for-server.adoc
@@ -6,57 +6,201 @@
 [id="jvm-settings-for-server_{context}"]
 = JVM settings for {brandname}
 
-You can define Java Virtual Machine (JVM) settings for {brandname} either by editing the `server.conf` configuration file, or by setting the `JAVA_OPTS` and `JAVA_OPTIONS` environment variables. Set the `JAVA_OPTIONS` variable if you want to append JVM settings to those that are automatically set by the
-`server.conf` file. Set the `JAVA_OPTS` variable if you want to completely override the JVM settings.
-
-[IMPORTANT]
-====
-If you are running {brandname} in a container do not set `Xmx` or `Xms`  because the values are automatically calculated from the container settings to be 70% of the container size.
-====
+You can define Java Virtual Machine (JVM) settings for {brandname} either by editing the `server.conf` configuration file,
+or by setting specific environment variables.
 
 [discrete]
-== Editing the configuration file
+== JVM option categories
 
-You can edit the required values in the `server.conf` configuration file. For example, to set the options to pass to the JVM, edit the following lines:
+{brandname} splits JVM options into the following environment variables:
 
-----
-if [ "$JAVA_OPTS" = "" ]; then
-   JAVA_OPTS="..."
-else
-   echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
-fi
-----
+`JAVA_OPTS_BASE`::
+Essential JVM flags that you should rarely need to change.
+Includes `-Djava.awt.headless=true`, `-XX:+ExitOnOutOfMemoryError`, and `--add-modules jdk.incubator.vector`.
 
-You can uncomment the existing example settings as well. For example, to configure Java Platform Debugger Architecture (JPDA) settings for remote socket debugging, update the file as follows:
+`JAVA_OPTS_NETWORK`::
+Network-related settings.
+Defaults to `-Djava.net.preferIPv4Stack=true`.
+Override this variable if you need IPv6 support.
 
-----
-# Sample JPDA settings for remote socket debugging
-JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
-----
+`JAVA_OPTS_MEMORY`::
+Memory configuration including heap size, metaspace, and RAM percentages.
++
+In non-container environments, defaults to `-XX:MetaspaceSize=64M -Xms64m -Xmx512m`.
++
+In container environments, defaults to `-XX:MetaspaceSize=64M -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops`.
 
-Additionally, you can add more settings to `JAVA_OPTS` like this:
+`JAVA_OPTS_DEBUG`::
+Debug options such as JPDA settings.
+This variable is only applied when you enable debug mode with the `--debug` flag or the `DEBUG` environment variable.
+When debug mode is active, defaults to `-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n`.
+You can further control debug behavior with the following flags:
++
+`--debug <port>`:::
+Activate debug mode with an optional argument to override the default port (8787).
+`--debug-suspend`:::
+Activate debug mode and suspend the JVM until a debugger connects.
+`--debug-client`:::
+Activate debug mode in client mode, where the JVM connects to a listening debugger instead of waiting for incoming connections.
+`--debug-server`:::
+Activate debug mode in server mode (the default), where the JVM listens for incoming debugger connections.
 
-----
-JAVA_OPTS="$JAVA_OPTS <key_1>=<value_1>, ..., <key_N>=<value_N> "
-----
+`JAVA_OPTIONS`::
+Additional options that are appended __after__ all other options.
 
-[discrete]
-== Setting an environment variable
-
-You can override the settings in `server.conf` configuration file by setting the `JAVA_OPTS` environment variable. For example:
+Each variable is independently overridable.
+For example, to change only the memory settings without affecting the base or network configuration:
 
 .Linux
 [source,shell,options="nowrap",subs=attributes+,role="primary"]
 ----
-export JAVA_OPTS="-Xmx1024M"
+export JAVA_OPTS_MEMORY="-XX:MetaspaceSize=128M -Xms512m -Xmx2g"
 ----
 
 .Windows
 [source,shell,options="nowrap",subs=attributes+,role="secondary"]
 ----
-set JAVA_OPTS="-Xmx1024M"
+set "JAVA_OPTS_MEMORY=-XX:MetaspaceSize=128M -Xms512m -Xmx2g"
 ----
 
+[IMPORTANT]
+====
+If you are running {brandname} in a container, do not set `-Xmx` or `-Xms`, but use the `-XX:InitialRAMPercentage`, `-XX:MinRAMPercentage` and `-XX:MaxRAMPercentage` options instead, since the values are automatically calculated based on the container size.
+Override the `JAVA_OPTS_MEMORY` variable instead if you need to adjust memory settings in containers.
+====
+
+[discrete]
+== Overriding all JVM options
+
+Setting the `JAVA_OPTS` environment variable completely overrides all category variables and uses only the specified value.
+This provides backward compatibility but requires you to include all necessary JVM options.
+
+.Linux
+[source,shell,options="nowrap",subs=attributes+,role="primary"]
+----
+export JAVA_OPTS="-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError -Xmx1024M"
+----
+
+.Windows
+[source,shell,options="nowrap",subs=attributes+,role="secondary"]
+----
+set "JAVA_OPTS=-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError -Xmx1024M"
+----
+
+[discrete]
+== Editing the configuration file
+
+You can edit the default values for each category in the `server.conf` configuration file.
+The file checks each `JAVA_OPTS_*` variable independently:
+
+----
+if [ "$JAVA_OPTS" = "" ]; then
+   if [ "$JAVA_OPTS_BASE" = "" ]; then
+     JAVA_OPTS_BASE="..."
+   fi
+   if [ "$JAVA_OPTS_NETWORK" = "" ]; then
+     JAVA_OPTS_NETWORK="..."
+   fi
+   if [ "$JAVA_OPTS_MEMORY" = "" ]; then
+     JAVA_OPTS_MEMORY="..."
+   fi
+   JAVA_OPTS="$JAVA_OPTS_BASE $JAVA_OPTS_NETWORK $JAVA_OPTS_MEMORY $JAVA_OPTIONS"
+else
+   echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
+fi
+----
+
+To configure Java Platform Debugger Architecture (JPDA) settings for remote socket debugging, uncomment and customize the `JAVA_OPTS_DEBUG` variable:
+
+----
+JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+----
+
+Alternatively, you can use the debug flags directly when starting the server:
+
+.Start with debug mode on port 9797
+----
+bin/server.sh --debug 9797
+----
+
+.Start with debug mode, suspending until a debugger connects
+----
+bin/server.sh --debug --debug-suspend
+----
+
+.Start in client mode, connecting to a debugger listening on port 9797
+----
+bin/server.sh --debug 9797 --debug-client
+----
+
+== Garbage collector selection
+
+The JVM includes several garbage collectors suited to different workloads.
+You can select a garbage collector by including the appropriate flag in `JAVA_OPTS_MEMORY`.
+
+=== G1GC (default)
+
+G1 is the default garbage collector and provides a good balance of throughput and latency for most workloads.
+It targets pause times under 200ms by default, which you can adjust with `-XX:MaxGCPauseMillis`.
+G1 is a generational collector that works well for heaps up to tens of gigabytes.
+
+.Linux
+[source,shell,options="nowrap",subs=attributes+,role="primary"]
+----
+export JAVA_OPTS_MEMORY="-XX:+UseG1GC -XX:MaxGCPauseMillis=150 -XX:MetaspaceSize=64M -Xms512m -Xmx4g"
+----
+
+.Windows
+[source,shell,options="nowrap",subs=attributes+,role="secondary"]
+----
+set "JAVA_OPTS_MEMORY=-XX:+UseG1GC -XX:MaxGCPauseMillis=150 -XX:MetaspaceSize=64M -Xms512m -Xmx4g"
+----
+
+=== ZGC
+
+ZGC is a low-latency garbage collector designed for applications that require sub-millisecond pause times regardless of heap size.
+It handles heaps from hundreds of megabytes to multiple terabytes.
+As of JDK 24 (https://openjdk.org/jeps/490[JEP 490]), ZGC is always generational and the non-generational mode has been removed.
+You only need `-XX:+UseZGC` to enable it.
+
+Choose ZGC when your workload requires consistently low latency, such as latency-sensitive services or deployments with large heaps.
+
+.Linux
+[source,shell,options="nowrap",subs=attributes+,role="primary"]
+----
+export JAVA_OPTS_MEMORY="-XX:+UseZGC -XX:MetaspaceSize=64M -Xms1g -Xmx8g"
+----
+
+.Windows
+[source,shell,options="nowrap",subs=attributes+,role="secondary"]
+----
+set "JAVA_OPTS_MEMORY=-XX:+UseZGC -XX:MetaspaceSize=64M -Xms1g -Xmx8g"
+----
+
+=== Shenandoah
+
+Shenandoah is a low-latency garbage collector with sub-millisecond pause times, similar to ZGC.
+As of JDK 25 (https://openjdk.org/jeps/521[JEP 521]), generational Shenandoah is a production feature that you can enable with `-XX:ShenandoahGCMode=generational`.
+Generational mode reduces memory footprint and improves sustained throughput compared to the default non-generational mode.
+
+Choose Shenandoah for low-latency workloads, particularly on OpenJDK-based distributions.
+
+[NOTE]
+====
+Shenandoah is available in OpenJDK builds but is not included in Oracle JDK distributions.
+====
+
+.Linux
+[source,shell,options="nowrap",subs=attributes+,role="primary"]
+----
+export JAVA_OPTS_MEMORY="-XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:MetaspaceSize=64M -Xms1g -Xmx8g"
+----
+
+.Windows
+[source,shell,options="nowrap",subs=attributes+,role="secondary"]
+----
+set "JAVA_OPTS_MEMORY=-XX:+UseShenandoahGC -XX:ShenandoahGCMode=generational -XX:MetaspaceSize=64M -Xms1g -Xmx8g"
+----
 
 == Garbage Collection Logging
 

--- a/documentation/src/main/asciidoc/topics/ref_server_container.adoc
+++ b/documentation/src/main/asciidoc/topics/ref_server_container.adoc
@@ -151,8 +151,9 @@ include::cmd_examples/server_docker_jvm_properties.adoc[]
 include::cmd_examples/server_podman_jvm_properties.adoc[]
 ----
 
-NOTE: Using `JAVA_OPTIONS` will append the options to those determined by the server launch script, such as those that configure
-the JVM memory sizing. You can completely override these options by setting the `JAVA_OPTS` env variable.
+NOTE: Using `JAVA_OPTIONS` appends options to those determined by the server launch script.
+You can override specific categories of JVM settings by setting `JAVA_OPTS_BASE`, `JAVA_OPTS_NETWORK`, or `JAVA_OPTS_MEMORY`.
+Setting `JAVA_OPTS` completely overrides all default JVM settings.
 
 === Deploying artifacts to the server lib directory
 Deploy artifacts to the server lib directory using the `SERVER_LIBS` env variable.

--- a/server/image/src/main/docker/Dockerfile
+++ b/server/image/src/main/docker/Dockerfile
@@ -86,7 +86,9 @@ ADD src/main/docker/install-server.sh /tmp/
 RUN /tmp/install-server.sh ${NEWROOT} ${WORKDIR}
 # Build the AOT cache using a fixed memory configuration. This will work for heaps < 32GB
 ENV JAVA_HOME=${NEWROOT}/usr/lib/jvm/default-java
-ENV JAVA_OPTS="-XX:+ExitOnOutOfMemoryError -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Xms64m -Xmx512m"
+ENV JAVA_OPTS_BASE="-XX:+ExitOnOutOfMemoryError -Djava.awt.headless=true --add-modules jdk.incubator.vector"
+ENV JAVA_OPTS_NETWORK="-Djava.net.preferIPv4Stack=true"
+ENV JAVA_OPTS_MEMORY="-Xms64m -Xmx512m"
 # Temporarily disabled
 RUN ${NEWROOT}/${WORKDIR}/bin/server.sh --aot || true
 RUN rm -rf ${NEWROOT}/${WORKDIR}/server/data ${NEWROOT}/${WORKDIR}/server/log ${NEWROOT}/${WORKDIR}/server/cache
@@ -117,6 +119,10 @@ ENV HOME=${WORKDIR}
 ENV ISPN_HOME=/opt/infinispan
 ENV USER=infinispan
 ENV JAVA_HOME=/usr/lib/jvm/default-java
+ENV JAVA_OPTS_BASE=""
+ENV JAVA_OPTS_NETWORK=""
+ENV JAVA_OPTS_MEMORY=""
+ENV JAVA_OPTS_DEBUG=""
 ENV LANG=C.UTF-8
 USER 65532
 EXPOSE 11222 11221 11223 2157 46655 57800 7800 7900 8080 8443

--- a/server/runtime/src/main/java/org/infinispan/server/Bootstrap.java
+++ b/server/runtime/src/main/java/org/infinispan/server/Bootstrap.java
@@ -267,12 +267,9 @@ public class Bootstrap extends Main {
       out.printf("  -p, --bind-port=<port>        %s%n", MSG.serverHelpBindPort(Server.DEFAULT_BIND_PORT));
       out.printf("  -s, --server-root=<path>      %s%n", MSG.toolHelpServerRoot(Server.DEFAULT_SERVER_ROOT_DIR));
       out.printf("  -v, --version                 %s%n", MSG.toolHelpVersion());
+      out.printf("  --pre-start-batch=<file>      %s%n", MSG.serverHelpPreStartBatch());
       out.printf("  -D<name>=<value>              %s%n", MSG.serverHelpProperty());
       out.printf("  -P, --properties=<file>       %s%n", MSG.serverHelpProperties());
-      out.printf("  --aot                         %s%n", MSG.serverHelpAOT());
-      out.printf("  --debug <port>                %s%n", MSG.serverHelpDebug());
-      out.printf("  --jmx <port>                  %s%n", MSG.serverHelpJMX());
-      out.printf("  --pre-start-batch=<file>      %s%n", MSG.serverHelpPreStartBatch());
    }
 
    @Override

--- a/server/runtime/src/main/java/org/infinispan/server/loader/Loader.java
+++ b/server/runtime/src/main/java/org/infinispan/server/loader/Loader.java
@@ -26,6 +26,7 @@ import java.util.Properties;
  * @author Tristan Tarrant &lt;tristan@infinispan.org&gt;
  * @since 10.0
  **/
+@Deprecated(forRemoval = true, since = "16.0")
 public class Loader {
    /**
     * Property name indicating the path to the server installation. If unspecified, the current working directory will
@@ -45,7 +46,7 @@ public class Loader {
 
    public static final String DEFAULT_SERVER_ROOT_DIR = "server";
 
-   public static void main(String[] args) {
+   static void main(String[] args) {
       run(args, System.getProperties());
    }
 

--- a/server/runtime/src/main/java/org/infinispan/server/logging/Messages.java
+++ b/server/runtime/src/main/java/org/infinispan/server/logging/Messages.java
@@ -63,15 +63,6 @@ public interface Messages {
    @Message("Sets system properties from the specified file.")
    String serverHelpProperties();
 
-   @Message("Activate the JVM AOT mode to reduce startup time and initial memory footprint. Requires JDK 24 or greater.")
-   String serverHelpAOT();
-
-   @Message("Activate debug mode with an optional argument to override the default port (8787).")
-   String serverHelpDebug();
-
-   @Message("Activate JMX remoting with an optional argument to override the default port (9999).")
-   String serverHelpJMX();
-
    @Message("CLI batch script to execute before server startup. Can be specified multiple times.")
    String serverHelpPreStartBatch();
 }

--- a/server/runtime/src/main/server/bin/cli-conf.bat
+++ b/server/runtime/src/main/server/bin/cli-conf.bat
@@ -18,17 +18,26 @@ REM PRESERVE_JAVA_OPTS=true
 REM
 REM Specify options to pass to the Java VM.
 REM
+if "%JAVA_OPTS_BASE%" == "" (
+   set "JAVA_OPTS_BASE=-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError"
+)
+if "%JAVA_OPTS_NETWORK%" == "" (
+   set "JAVA_OPTS_NETWORK=-Djava.net.preferIPv4Stack=true"
+)
+if "%JAVA_OPTS_MEMORY%" == "" (
+   set "JAVA_OPTS_MEMORY=-XX:MetaspaceSize=32M -Xms32m -Xmx128m"
+)
 if "%JAVA_OPTS%" == "" (
-   set "JAVA_OPTS=-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=64M -Xms32m -Xmx128m %CLI_JAVA_OPTIONS%"
+   set "JAVA_OPTS=%JAVA_OPTS_BASE% %JAVA_OPTS_NETWORK% %JAVA_OPTS_MEMORY% %CLI_JAVA_OPTIONS%"
 ) else (
    echo "JAVA_OPTS already set in environment; overriding default settings with values: %JAVA_OPTS%"
 )
 
 REM Sample JPDA settings for remote socket debugging
-REM set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+REM set "JAVA_OPTS_DEBUG=-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 REM Sample JPDA settings for shared memory debugging
-REM set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
+REM set "JAVA_OPTS_DEBUG=-agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
 
 REM enable garbage collection logging if not set in environment differently
 if "%GC_LOG%" == "" (

--- a/server/runtime/src/main/server/bin/cli.bat
+++ b/server/runtime/src/main/server/bin/cli.bat
@@ -16,4 +16,11 @@ for %%J in ("%ISPN_HOME%\lib\infinispan-cli-client-*.jar") do (
    "-Dinfinispan.server.home.path=%ISPN_HOME%" ^
    -jar %%J %ARGUMENTS%
 )
+if "%HELP%" == "true" (
+   echo Script options:
+   echo   --debug ^<port^>                Activate debug mode with an optional argument to override the default port ^(8787^).
+   echo   --debug-client                Activate debug mode in client mode ^(defaults to server mode^).
+   echo   --debug-suspend               Activate debug mode and suspend the JVM.
+   echo   --jmx ^<port^>                  Activate JMX remoting with an optional argument to override the default port ^(9999^).
+)
 endlocal

--- a/server/runtime/src/main/server/bin/cli.conf
+++ b/server/runtime/src/main/server/bin/cli.conf
@@ -23,17 +23,26 @@
 #
 # Specify options to pass to the Java VM.
 #
-if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=32M -Xms32m -Xmx128m $CLI_JAVA_OPTIONS"
+if [ "$JAVA_OPTS" = "" ]; then
+   if [ "$JAVA_OPTS_BASE" = "" ]; then
+     JAVA_OPTS_BASE="-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError"
+   fi
+   if [ "$JAVA_OPTS_NETWORK" = "" ]; then
+     JAVA_OPTS_NETWORK="-Djava.net.preferIPv4Stack=true"
+   fi
+   if [ "$JAVA_OPTS_MEMORY" = "" ]; then
+     JAVA_OPTS_MEMORY="-XX:MetaspaceSize=32M -Xms32m -Xmx128m"
+   fi
+   JAVA_OPTS="$JAVA_OPTS_BASE $JAVA_OPTS_NETWORK $JAVA_OPTS_MEMORY $CLI_JAVA_OPTIONS"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
 
 # enable garbage collection logging if not set in environment differently
 if [ "x$GC_LOG" = "x" ]; then

--- a/server/runtime/src/main/server/bin/cli.sh
+++ b/server/runtime/src/main/server/bin/cli.sh
@@ -9,8 +9,11 @@ DIRNAME=$(dirname "$0")
 . "$DIRNAME/common.sh"
 
 # Execute the JVM
-   eval "$JAVA" $JAVA_OPTS \
-      -Dvisualvm.display.name="$PROCESS_NAME" \
-      -Dinfinispan.server.home.path=\""$ISPN_HOME"\" \
-      -jar "$ISPN_HOME"/lib/infinispan-cli-client-*.jar \
-      "$ARGUMENTS"
+eval "$JAVA" $JAVA_OPTS \
+  -Dvisualvm.display.name="$PROCESS_NAME" \
+  -Dinfinispan.server.home.path=\""$ISPN_HOME"\" \
+  -jar "$ISPN_HOME"/lib/infinispan-cli-client-*.jar \
+  "$ARGUMENTS"
+RC=$?
+help
+exit $RC

--- a/server/runtime/src/main/server/bin/common.bat
+++ b/server/runtime/src/main/server/bin/common.bat
@@ -54,8 +54,13 @@ if %JAVA_VERSION% geq 25 (
    set "JAVA_OPTS=-XX:+UseCompactObjectHeaders %JAVA_OPTS%"
 )
 
+set HELP=false
 set DEBUG_MODE=false
 set DEBUG_PORT=8787
+set DEBUG_SUSPEND=n
+set DEBUG_SERVER=y
+set JMX_REMOTING=false
+set JMX_PORT=9999
 set "JAVA_OPTS_EXTRA="
 :ARGS_LOOP_START
 set "ARG=%~1"
@@ -71,6 +76,31 @@ if "%ARG%" == "" (
       set DEBUG_PORT=%2
       shift
    )
+) else if "%ARG%" == "--debug-suspend" (
+   set DEBUG_MODE=true
+   set DEBUG_SUSPEND=y
+) else if "%ARG%" == "--debug-client" (
+   set DEBUG_MODE=true
+   set DEBUG_SERVER=n
+) else if "%ARG%" == "--debug-server" (
+   set DEBUG_MODE=true
+   set DEBUG_SERVER=y
+) else if "%ARG%" == "--jmx" (
+   set JMX_REMOTING=true
+   if "%~2"=="" goto ARGS_LOOP_END
+   set "var="&for /f "delims=0123456789" %%i in ("%~2") do set var=%%i
+   if defined var (
+      rem Use the default port
+   ) else (
+      set JMX_PORT=%2
+      shift
+   )
+) else if "%ARG%" == "-h" (
+   set HELP=true
+   set "ARGUMENTS=%ARGUMENTS% %ARG%"
+) else if "%ARG%" == "--help" (
+   set HELP=true
+   set "ARGUMENTS=%ARGUMENTS% %ARG%"
 ) else if "%ARG:~0,2%"=="-D" (
    set "JAVA_OPTS_EXTRA=%JAVA_OPTS_EXTRA% %ARG%=%2"
    shift
@@ -90,9 +120,19 @@ rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
    echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
   if errorlevel == 1 (
-     set "PREPEND_JAVA_OPTS=JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
+     if "%JAVA_OPTS_DEBUG%" == "" set "JAVA_OPTS_DEBUG=-agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=%DEBUG_SERVER%,suspend=%DEBUG_SUSPEND%"
+     call set "JAVA_OPTS=%%JAVA_OPTS%% %%JAVA_OPTS_DEBUG%%"
   ) else (
      echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
+  )
+)
+rem Enable JMX authenticator if needed
+if "%JMX_REMOTING%" == "true" (
+   echo "%JAVA_OPTS%" | findstr /I "\-Dcom.sun.management.jmxremote" > nul
+  if errorlevel == 1 (
+     set "JAVA_OPTS=%JAVA_OPTS% -Dcom.sun.management.jmxremote.port=%JMX_PORT% -Djava.security.auth.login.config=%DIRNAME%server-jaas.config -Dcom.sun.management.jmxremote.login.config=ServerJMXConfig -Dcom.sun.management.jmxremote.ssl=false"
+  ) else (
+     echo JMX already enabled in JAVA_OPTS, ignoring --jmx argument
   )
 )
 if "%GC_LOG%" == "true" (

--- a/server/runtime/src/main/server/bin/common.sh
+++ b/server/runtime/src/main/server/bin/common.sh
@@ -1,11 +1,26 @@
 #!/bin/sh
 
+HELP=false
+
+# Print help for options handled by the script
+help() {
+    if [ "$HELP" = "true" ]; then
+      echo "Script options:"
+      echo "  --debug <port>                Activate debug mode with an optional argument to override the default port (8787)."
+      echo "  --debug-client                Activate debug mode in client mode (defaults to server mode)."
+      echo "  --debug-suspend               Activate debug mode and suspend the JVM."
+      echo "  --jmx <port>                  Activate JMX remoting with an optional argument to override the default port (9999)."
+    fi
+}
+
 # Use --debug to activate debug mode with an optional argument to specify the port.
 # Usage: server.sh --debug
 #        server.sh --debug 9797
 # By default debug mode is disabled.
 DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"
+DEBUG_SUSPEND=n
+DEBUG_SERVER=y
 
 # Use --jmx to activate JMX remoting mode with an optional argument to specify the port.
 # Usage: server.sh --jmx
@@ -32,6 +47,18 @@ do
               DEBUG_PORT=$2
               shift
           fi
+          ;;
+      --debug-suspend)
+          DEBUG_MODE=true
+          DEBUG_SUSPEND=y
+          ;;
+      --debug-client)
+          DEBUG_MODE=true
+          DEBUG_SERVER=n
+          ;;
+      --debug-server)
+          DEBUG_MODE=true
+          DEBUG_SERVER=y
           ;;
       --jmx)
           JMX_REMOTING=true
@@ -61,6 +88,10 @@ do
           done < "$2"
           ARGUMENTS="$ARGUMENTS '$1' '$2'"
           shift
+          ;;
+      -h | --help)
+          HELP=true
+          ARGUMENTS="$ARGUMENTS '$1'"
           ;;
       *)
           ARGUMENTS="$ARGUMENTS '$1'"
@@ -148,7 +179,10 @@ JAVA_OPTS="$JAVA_OPTS_EXTRA $JAVA_OPTS"
 if [ "$DEBUG_MODE" = "true" ]; then
     DEBUG_OPT=$(echo "$JAVA_OPTS" | $GREP "\-agentlib:jdwp")
     if [ "$DEBUG_OPT" = "" ]; then
-        JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n"
+        if [ "$JAVA_OPTS_DEBUG" = "" ]; then
+            JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=$DEBUG_SERVER,suspend=$DEBUG_SUSPEND"
+        fi
+        JAVA_OPTS="$JAVA_OPTS $JAVA_OPTS_DEBUG"
     else
         echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
     fi

--- a/server/runtime/src/main/server/bin/gossip-router.conf
+++ b/server/runtime/src/main/server/bin/gossip-router.conf
@@ -38,23 +38,31 @@
 #
 # Specify options to pass to the Java VM.
 #
-if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=32M"
-   if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
-     JAVA_OPTS="$JAVA_OPTS -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
-   else
-     JAVA_OPTS="$JAVA_OPTS -Xms32m -Xmx128m"
+if [ "$JAVA_OPTS" = "" ]; then
+   if [ "$JAVA_OPTS_BASE" = "" ]; then
+     JAVA_OPTS_BASE="-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError"
    fi
-   JAVA_OPTS="$JAVA_OPTS $ROUTER_JAVA_OPTIONS"
+   if [ "$JAVA_OPTS_NETWORK" = "" ]; then
+     JAVA_OPTS_NETWORK="-Djava.net.preferIPv4Stack=true"
+   fi
+   if [ "$JAVA_OPTS_MEMORY" = "" ]; then
+     JAVA_OPTS_MEMORY="-XX:MetaspaceSize=32M"
+     if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
+       JAVA_OPTS_MEMORY="$JAVA_OPTS_MEMORY -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
+     else
+       JAVA_OPTS_MEMORY="$JAVA_OPTS_MEMORY -Xms32m -Xmx128m"
+     fi
+   fi
+   JAVA_OPTS="$JAVA_OPTS_BASE $JAVA_OPTS_NETWORK $JAVA_OPTS_MEMORY $ROUTER_JAVA_OPTIONS"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
 
 # enable garbage collection logging if not set in environment differently
 if [ "x$GC_LOG" = "x" ]; then

--- a/server/runtime/src/main/server/bin/gossip-router.sh
+++ b/server/runtime/src/main/server/bin/gossip-router.sh
@@ -49,6 +49,7 @@ while true; do
    if [ "$ISPN_STATUS" -eq 10 ]; then
       echo "Restarting Gossip Router..."
    else
+      help
       exit $ISPN_STATUS
    fi
 done

--- a/server/runtime/src/main/server/bin/probe.conf
+++ b/server/runtime/src/main/server/bin/probe.conf
@@ -38,23 +38,31 @@
 #
 # Specify options to pass to the Java VM.
 #
-if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=32M"
-   if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
-     JAVA_OPTS="$JAVA_OPTS -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
-   else
-     JAVA_OPTS="$JAVA_OPTS -Xms32m -Xmx64m"
+if [ "$JAVA_OPTS" = "" ]; then
+   if [ "$JAVA_OPTS_BASE" = "" ]; then
+     JAVA_OPTS_BASE="-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError"
    fi
-   JAVA_OPTS="$JAVA_OPTS $PROBE_JAVA_OPTIONS"
+   if [ "$JAVA_OPTS_NETWORK" = "" ]; then
+     JAVA_OPTS_NETWORK="-Djava.net.preferIPv4Stack=true"
+   fi
+   if [ "$JAVA_OPTS_MEMORY" = "" ]; then
+     JAVA_OPTS_MEMORY="-XX:MetaspaceSize=32M"
+     if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
+       JAVA_OPTS_MEMORY="$JAVA_OPTS_MEMORY -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
+     else
+       JAVA_OPTS_MEMORY="$JAVA_OPTS_MEMORY -Xms32m -Xmx64m"
+     fi
+   fi
+   JAVA_OPTS="$JAVA_OPTS_BASE $JAVA_OPTS_NETWORK $JAVA_OPTS_MEMORY $PROBE_JAVA_OPTIONS"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
 
 # enable garbage collection logging if not set in environment differently
 if [ "x$GC_LOG" = "x" ]; then

--- a/server/runtime/src/main/server/bin/probe.sh
+++ b/server/runtime/src/main/server/bin/probe.sh
@@ -16,3 +16,6 @@ eval "$JAVA" $JAVA_OPTS \
   -Dinfinispan.server.home.path=\""$ISPN_HOME"\" \
   -classpath "$ISPN_HOME"/boot/*:"$ISPN_HOME"/lib/*:"$ISPN_ROOT_DIR"/lib/* \
   "$MAIN_CLASS" "$ARGUMENTS"
+RC=$?
+help
+exit $RC

--- a/server/runtime/src/main/server/bin/server-conf.bat
+++ b/server/runtime/src/main/server/bin/server-conf.bat
@@ -18,17 +18,26 @@ REM PRESERVE_JAVA_OPTS=true
 REM
 REM Specify options to pass to the Java VM.
 REM
+if "%JAVA_OPTS_BASE%" == "" (
+   set "JAVA_OPTS_BASE=-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError --add-modules jdk.incubator.vector"
+)
+if "%JAVA_OPTS_NETWORK%" == "" (
+   set "JAVA_OPTS_NETWORK=-Djava.net.preferIPv4Stack=true"
+)
+if "%JAVA_OPTS_MEMORY%" == "" (
+   set "JAVA_OPTS_MEMORY=-XX:MetaspaceSize=64M -Xms64m -Xmx512m"
+)
 if "%JAVA_OPTS%" == "" (
-   set "JAVA_OPTS=-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=64M -Xms64m -Xmx512m --add-modules jdk.incubator.vector %JAVA_OPTIONS%"
+   set "JAVA_OPTS=%JAVA_OPTS_BASE% %JAVA_OPTS_NETWORK% %JAVA_OPTS_MEMORY% %JAVA_OPTIONS%"
 ) else (
    echo "JAVA_OPTS already set in environment; overriding default settings with values: %JAVA_OPTS%"
 )
 
 REM Sample JPDA settings for remote socket debugging
-REM set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+REM set "JAVA_OPTS_DEBUG=-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 REM Sample JPDA settings for shared memory debugging
-REM set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
+REM set "JAVA_OPTS_DEBUG=-agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
 
 REM enable garbage collection logging if not set in environment differently
 if "%GC_LOG%" == "" (

--- a/server/runtime/src/main/server/bin/server.bat
+++ b/server/runtime/src/main/server/bin/server.bat
@@ -15,4 +15,11 @@ for %%J in ("%ISPN_HOME%\lib\infinispan-server-runtime-*.jar") do (
    "-Dinfinispan.server.home.path=%ISPN_HOME%" ^
    -jar %%J %ARGUMENTS%
 )
+if "%HELP%" == "true" (
+   echo Script options:
+   echo   --debug ^<port^>                Activate debug mode with an optional argument to override the default port ^(8787^).
+   echo   --debug-client                Activate debug mode in client mode ^(defaults to server mode^).
+   echo   --debug-suspend               Activate debug mode and suspend the JVM.
+   echo   --jmx ^<port^>                  Activate JMX remoting with an optional argument to override the default port ^(9999^).
+)
 endlocal

--- a/server/runtime/src/main/server/bin/server.conf
+++ b/server/runtime/src/main/server/bin/server.conf
@@ -35,22 +35,30 @@
 # Specify options to pass to the Java VM.
 #
 if [ "$JAVA_OPTS" = "" ]; then
-   JAVA_OPTS="-Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -XX:+ExitOnOutOfMemoryError -XX:MetaspaceSize=64M --add-modules jdk.incubator.vector"
-   if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
-     JAVA_OPTS="$JAVA_OPTS -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
-   else
-     JAVA_OPTS="$JAVA_OPTS -Xms64m -Xmx512m"
+   if [ "$JAVA_OPTS_BASE" = "" ]; then
+     JAVA_OPTS_BASE="-Djava.awt.headless=true -XX:+ExitOnOutOfMemoryError --add-modules jdk.incubator.vector"
    fi
-   JAVA_OPTS="$JAVA_OPTS $JAVA_OPTIONS"
+   if [ "$JAVA_OPTS_NETWORK" = "" ]; then
+     JAVA_OPTS_NETWORK="-Djava.net.preferIPv4Stack=true"
+   fi
+   if [ "$JAVA_OPTS_MEMORY" = "" ]; then
+     JAVA_OPTS_MEMORY="-XX:MetaspaceSize=64M"
+     if [ -f "/.dockerenv" ] || [ -f "/run/.containerenv" ] || [ "$RUN_IN_CONTAINER" = "true" ]; then
+       JAVA_OPTS_MEMORY="$JAVA_OPTS_MEMORY -XX:InitialRAMPercentage=50 -XX:MinRAMPercentage=70 -XX:MaxRAMPercentage=70 -XX:+UseCompressedOops"
+     else
+       JAVA_OPTS_MEMORY="$JAVA_OPTS_MEMORY -Xms64m -Xmx512m"
+     fi
+   fi
+   JAVA_OPTS="$JAVA_OPTS_BASE $JAVA_OPTS_NETWORK $JAVA_OPTS_MEMORY $JAVA_OPTIONS"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
+#JAVA_OPTS_DEBUG="-agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=infinispan"
 
 # enable garbage collection logging if not set in environment differently
 if [ "$GC_LOG" = "" ]; then

--- a/server/runtime/src/main/server/bin/server.sh
+++ b/server/runtime/src/main/server/bin/server.sh
@@ -19,11 +19,11 @@ while true; do
       "$ARGUMENTS" "&"
    ISPN_PID=$!
    # Trap common signals and relay them to the server process
-   trap "kill -HUP  $ISPN_PID" HUP
-   trap "kill -TERM $ISPN_PID" INT
-   trap "kill -QUIT $ISPN_PID" QUIT
-   trap "kill -PIPE $ISPN_PID" PIPE
-   trap "kill -TERM $ISPN_PID" TERM
+   trap 'kill -HUP  $ISPN_PID' HUP
+   trap 'kill -TERM $ISPN_PID' INT
+   trap 'kill -QUIT $ISPN_PID' QUIT
+   trap 'kill -PIPE $ISPN_PID' PIPE
+   trap 'kill -TERM $ISPN_PID' TERM
    if [ "x$ISPN_PIDFILE" != "x" ]; then
       echo $ISPN_PID > "$ISPN_PIDFILE"
    fi
@@ -53,6 +53,7 @@ while true; do
    if [ "$ISPN_STATUS" -eq 10 ]; then
       echo "Restarting server..."
    else
+      help
       exit $ISPN_STATUS
    fi
 done


### PR DESCRIPTION
Closes: #17310

Split the monolithic `JAVA_OPTS` into independently overridable category variables so users can customize one aspect (e.g. memory) without re-specifying all mandatory JVM flags.

New variables: `JAVA_OPTS_BASE`, `JAVA_OPTS_NETWORK`, `JAVA_OPTS_MEMORY`, `JAVA_OPTS_DEBUG`.
Setting `JAVA_OPTS` directly still overrides everything for backward compatibility.

Applied across all startup configurations (server, CLI, gossip-router, probe) for both Unix and Windows.
Updated JVM settings documentation with the new variables and added a garbage collector selection guide (G1, ZGC, Shenandoah).

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [ ] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - Shell script and documentation changes only — no testable Java code modified.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
- [ ] Log messages of level `INFO` and above have been internationalized.
  - No log messages added or changed.
- [ ] If the PR affects performance, include before/after benchmarks.
  - No performance impact — only startup script variable organization.
- [ ] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
  - No output changes — the assembled `JAVA_OPTS` is identical to before when using defaults.
- [ ] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool