### PR TITLE
[#17341] Thread-safe lookup map for transactions

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -223,7 +224,7 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
    }
 
    private void initAffectedKeys() {
-      if (affectedKeys == null) affectedKeys = new HashSet<>(INITIAL_LOCK_CAPACITY);
+      if (affectedKeys == null) affectedKeys = ConcurrentHashMap.newKeySet(INITIAL_LOCK_CAPACITY);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
@@ -93,7 +94,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    public void putLookedUpEntry(Object key, CacheEntry e) {
       checkIfRolledBack();
       if (lookedUpEntries == null)
-         lookedUpEntries = new HashMap<>(4);
+         lookedUpEntries = new ConcurrentHashMap<>(4);
 
       lookedUpEntries.put(key, e);
    }
@@ -102,7 +103,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    public void putLookedUpEntries(Map<Object, CacheEntry> entries) {
       checkIfRolledBack();
       if (lookedUpEntries == null) {
-         lookedUpEntries = new HashMap<>(entries);
+         lookedUpEntries = new ConcurrentHashMap<>(entries);
       } else {
          lookedUpEntries.putAll(entries);
       }

--- a/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
@@ -2,10 +2,10 @@ package org.infinispan.transaction.impl;
 
 import static org.infinispan.commons.util.Util.toStr;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.infinispan.commands.write.WriteCommand;
@@ -42,13 +42,13 @@ public class RemoteTransaction extends AbstractCacheTransaction {
 
    public RemoteTransaction(List<WriteCommand> modifications, GlobalTransaction tx, int topologyId, long txCreationTime) {
       super(tx, topologyId, txCreationTime);
-      lookedUpEntries = new HashMap<>(modifications.size());
+      lookedUpEntries = new ConcurrentHashMap<>(modifications.size());
       setModifications(modifications);
    }
 
    public RemoteTransaction(GlobalTransaction tx, int topologyId, long txCreationTime) {
       super(tx, topologyId, txCreationTime);
-      lookedUpEntries = new HashMap<>(4);
+      lookedUpEntries = new ConcurrentHashMap<>(4);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/tx/ConcurrentRemoveAsyncTxTest.java
+++ b/core/src/test/java/org/infinispan/distribution/tx/ConcurrentRemoveAsyncTxTest.java
@@ -1,0 +1,88 @@
+package org.infinispan.distribution.tx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.concurrent.AggregateCompletionStage;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
+import org.infinispan.commons.util.concurrent.CompletionStages;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.LockingMode;
+import org.testng.annotations.Test;
+
+import jakarta.transaction.TransactionManager;
+
+@Test(groups = "functional", testName = "distribution.tx.ConcurrentRemoveAsyncTxTest")
+public class ConcurrentRemoveAsyncTxTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      cb.clustering().hash().numOwners(2);
+      cb.transaction().lockingMode(LockingMode.PESSIMISTIC);
+      createClusteredCaches(2, cb);
+   }
+
+   public void testConcurrentRemoveAsyncWithinTx() throws Exception {
+      int numClients = 10;
+      int numKeys = 30;
+      int iterations = 20;
+      Cache<String, String> cache = cache(0);
+
+      CyclicBarrier barrier = new CyclicBarrier(numClients);
+      AggregateCompletionStage<Void> acs = CompletionStages.aggregateCompletionStage();
+
+      for (int c = 0; c < numClients; c++) {
+         int clientId = c;
+         CompletableFuture<Void> cs = CompletableFuture.runAsync(() -> {
+            try {
+               barrier.await(30, TimeUnit.SECONDS);
+
+               for (int iter = 0; iter < iterations; iter++) {
+                  String[] keys = new String[numKeys];
+                  for (int i = 0; i < numKeys; i++) {
+                     String prefix = "c" + clientId + "-i" + iter + "-k" + i;
+                     Cache<?, ?> target = (i & 0b1) == 0 ? cache(1) : cache(0);
+                     String key = getStringKeyForCache(prefix, target);
+                     keys[i] = key;
+                  }
+
+                  for (String key : keys) {
+                     cache.put(key, "v");
+                  }
+
+                  execute(cache, keys);
+               }
+            } catch (Throwable t) {
+               throw CompletableFutures.asCompletionException(t);
+            }
+         }, testExecutor());
+         acs.dependsOn(cs);
+      }
+
+      assertThat(acs.freeze().toCompletableFuture().get(30, TimeUnit.SECONDS)).isNull();
+   }
+
+   private void execute(Cache<String, String> cache, String[] keys) throws Throwable {
+      TransactionManager tm = TestingUtil.getTransactionManager(cache);
+      tm.begin();
+
+      AggregateCompletionStage<Void> acs = CompletionStages.aggregateCompletionStage();
+      for (String key : keys) {
+         CompletionStage<Void> cs = cache.removeAsync(key)
+               .thenApply(CompletableFutures.toNullFunction());
+         acs.dependsOn(cs);
+      }
+
+      acs.freeze().toCompletableFuture().get(30, TimeUnit.SECONDS);
+      tm.commit();
+   }
+}


### PR DESCRIPTION
* Utilize a thread-safe map to looked up entries.
* Concurrent access could lose entries, leads to incorrectly reading values.

The issue was triggered by the RESP `DEL` command within a transaction. That command performs multiple `removeAsync` operations. But the problem can be triggered in core, too.

Closes: #17341

---

Author Checklist (all must be checked):
- [X] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [X] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [X] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [ ] ~The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.~
- [ ] ~Log messages of level `INFO` and above have been internationalized.~
- [ ] ~If the PR affects performance, include before/after benchmarks.~
- [ ] ~If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).~
- [ ] ~If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.~

---

Reviewer Checklist (all must be checked):
- [ ] Code review
  - Are the changes reasonable?
  - Are there any use cases, integrations, inputs that haven't been considered in the implementation?
  - Is the code understandable? (KISS, comments)
  - Is there a better way to implement/write the functionality, code pieces?
  - Is formatting in line with the rest of the project? (checkstyle and spotless)
- [ ] Test review
  - Is the new test coverage rich enough to cover all the changes and considerations above?
  - Does the base functionality works as expected in the build project?
  - Does it behave as expected when given various inputs? (Valid and invalid, missing, partial)
  - Are there integrations to be considered? (Does the new functionality work well with the rest of the project, environment)
  -  Even if all above works as expected, are there weird behaviors to be improved on?
- [ ] Documentation review
  - Does the new/changed documentation cover the PR in sufficient matter?
  - For public API, are JavaDocs included for every new/changed class/method ?
  - For new features, does the documentation add/amend any usage examples ?
  - Grammar and syntax checks 
  - Does AsciiDoc generation report any WARN messages ?
