### PR TITLE
[#17355] Fix CMS.MERGE weight ordering in clustered mode

### DIFF
--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/countmin/CMSMERGE.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/countmin/CMSMERGE.java
@@ -6,8 +6,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.infinispan.AdvancedCache;
-import org.infinispan.commons.util.ProcessorInfo;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.infinispan.functional.FunctionalMap;
 import org.infinispan.server.resp.AclCategory;
@@ -17,10 +15,8 @@ import org.infinispan.server.resp.RespRequestHandler;
 import org.infinispan.server.resp.commands.ArgumentUtils;
 import org.infinispan.server.resp.commands.ProbabilisticErrors;
 import org.infinispan.server.resp.commands.Resp3Command;
-import org.infinispan.util.concurrent.WithinThreadExecutor;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * CMS.MERGE destKey numKeys src [src ...] [WEIGHTS weight [weight ...]]
@@ -88,9 +84,8 @@ public class CMSMERGE extends RespCommand implements Resp3Command {
 
       AdvancedCache<byte[], Object> cache = handler.typedCache(null);
 
-      CompletionStage<List<CountMinSketch>> sketches = CompletionStages.performConcurrently(
-            sourceKeys, ProcessorInfo.availableProcessors(),
-            Schedulers.from(new WithinThreadExecutor()),
+      CompletionStage<List<CountMinSketch>> sketches = CompletionStages.performSequentially(
+            sourceKeys.iterator(),
             srcKey -> cache.getAsync(srcKey)
                   .thenApply(obj -> {
                      if (obj == null) {
@@ -99,11 +94,7 @@ public class CMSMERGE extends RespCommand implements Resp3Command {
                      return (CountMinSketch) obj;
                   }), Collectors.toList());
 
-      CompletionStage<Boolean> result = CompletionStages.handleAndCompose(sketches, (sources, t) -> {
-         if (t != null) {
-            throw CompletableFutures.asCompletionException(t);
-         }
-
+      CompletionStage<Boolean> result = sketches.thenCompose(sources -> {
          FunctionalMap.ReadWriteMap<byte[], Object> rwCache =
                FunctionalMap.create(cache).toReadWriteMap();
 


### PR DESCRIPTION
Closes: #17355

`CMS.MERGE` used `CompletionStages.performConcurrently()` to fetch source sketches, which internally uses `Flowable.parallel()` and does not preserve input order. Since weights are positional (weight[i] corresponds to sourceKey[i]), sketches returned out of order get paired with wrong weights, producing incorrect merge results.

Replaced with sequential `thenCompose` chaining to guarantee correct weight-to-sketch ordering. The number of source keys is typically small (2-3), so sequential fetching has negligible performance impact.

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - No new tests needed: existing `CountMinSketchClusteredTest.testCmsMergeWithWeights` and `testCmsMergeNegativeWeights` cover this fix and were previously failing.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - Bug fix only, no documentation changes needed.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool