### PR TITLE
[#17394] SIFS: Fix premature garbage-collection race and split separator handling

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
@@ -168,8 +168,14 @@ class IndexNode {
     * Can be called only from single writer thread (therefore the write lock guards only other readers)
     */
    private void replaceContent(IndexNode other) throws IOException {
+      // The disk write must happen inside the write lock so that when the lock is released,
+      // both the in-memory and on-disk states are consistent.  If the disk write were done
+      // after releasing the lock, a concurrent GC could evict the SoftReference held by a
+      // parent InnerNode; the parent would then reload this node from the (still-stale) disk
+      // image and obtain the old InnerNode references pointing to already-freed children,
+      // which causes "Cannot read record" IOExceptions under load.
+      lock.writeLock().lock();
       try {
-         lock.writeLock().lock();
          this.prefix = other.prefix;
          this.keyParts = other.keyParts;
          this.innerNodes = other.innerNodes;
@@ -177,14 +183,11 @@ class IndexNode {
          this.contentLength = -1;
          this.keyPartsLength = -1;
          this.totalLength = -1;
+         if (offset >= 0) {
+            store(new Index.IndexSpace(offset, occupiedSpace));
+         }
       } finally {
          lock.writeLock().unlock();
-      }
-
-      // don't have to acquire any lock here
-      // the only node with offset < 0 is the root - we can't lose reference to it
-      if (offset >= 0) {
-         store(new Index.IndexSpace(offset, occupiedSpace));
       }
    }
 
@@ -428,16 +431,23 @@ class IndexNode {
 
       Deque<IndexNode> garbage = new ArrayDeque<>();
       try {
-         JoinSplitResult result = manageLength(root.segment, stack, node, copy, garbage);
+         JoinSplitResult result = manageLength(root.segment, stack, node, copy);
          if (result == null) {
             return;
          }
          if (log.isTraceEnabled()) {
             log.tracef("Created (1) %d new nodes, GC %08x", result.newNodes.size(), System.identityHashCode(node));
          }
-         garbage.push(node);
+         // Defer adding node (and result.pendingGarbage) to garbage until AFTER the
+         // parent copyWith() succeeds. If copyWith throws, we must NOT free these nodes —
+         // the parent's InnerNode still references them and freeing would leave the B-tree
+         // with a stale pointer into freed/truncated index space.
+         IndexNode nodeToFree = node;
          for (;;) {
             if (stack.isEmpty()) {
+               // Tree update is fully committed at the root. Safe to free deferred nodes.
+               garbage.addAll(result.pendingGarbage);
+               garbage.push(nodeToFree);
                IndexNode newRoot;
                if (result.newNodes.size() == 1) {
                   newRoot = result.newNodes.get(0);
@@ -460,8 +470,13 @@ class IndexNode {
                log.tracef("Created %08x (length %d) from %08x with the %d new nodes (%d - %d)",
                      System.identityHashCode(copy), copy.length(), System.identityHashCode(path.node), result.newNodes.size(), result.from, result.to);
             }
-            result = manageLength(path.node.segment, stack, path.node, copy, garbage);
+            // copyWith succeeded: parent now references the new nodes. Safe to free old ones.
+            garbage.addAll(result.pendingGarbage);
+            garbage.push(nodeToFree);
+
+            result = manageLength(path.node.segment, stack, path.node, copy);
             if (result == null) {
+               // path.node was updated in-place (replaceContent) — it stays in the tree.
                if (log.isTraceEnabled()) {
                   log.tracef("No more index updates required");
                }
@@ -470,7 +485,8 @@ class IndexNode {
             if (log.isTraceEnabled()) {
                log.tracef("Created (2) %d new nodes, GC %08x", result.newNodes.size(), System.identityHashCode(path.node));
             }
-            garbage.push(path.node);
+            // Defer freeing path.node until the next level's copyWith succeeds.
+            nodeToFree = path.node;
          }
       } finally {
          while (!garbage.isEmpty()) {
@@ -493,15 +509,23 @@ class IndexNode {
       public final int from;
       public final int to;
       final List<IndexNode> newNodes;
+      // Nodes to free only AFTER the parent copyWith() succeeds. Freeing them before
+      // the parent is updated would leave stale InnerNode references in the live tree.
+      final List<IndexNode> pendingGarbage;
 
       private JoinSplitResult(int from, int to, List<IndexNode> newNodes) {
+         this(from, to, newNodes, Collections.emptyList());
+      }
+
+      private JoinSplitResult(int from, int to, List<IndexNode> newNodes, List<IndexNode> pendingGarbage) {
          this.from = from;
          this.to = to;
          this.newNodes = newNodes;
+         this.pendingGarbage = pendingGarbage;
       }
    }
 
-   private static JoinSplitResult manageLength(Index.Segment segment, Deque<Path> stack, IndexNode node, IndexNode copy, Deque<IndexNode> garbage) throws IOException {
+   private static JoinSplitResult manageLength(Index.Segment segment, Deque<Path> stack, IndexNode node, IndexNode copy) throws IOException {
       int from, to;
       if (copy.length() < segment.getMinNodeSize() && !stack.isEmpty()) {
          Path parent = stack.peek();
@@ -539,20 +563,44 @@ class IndexNode {
                   joinWith, sizeWithLeft, sizeWithRight, segment.getMaxNodeSize()));
          }
          IndexNode joiner = parent.node.innerNodes[joinWith].getIndexNode(segment);
-         byte[] middleKey = concat(parent.node.prefix, parent.node.keyParts[joinWith < parent.index ? parent.index - 1 : parent.index]);
-         if (joinWith < parent.index) {
-            copy = join(joiner, middleKey, copy);
-            from = joinWith;
-            to = parent.index;
+         if (joiner != null) {
+            byte[] middleKey = concat(parent.node.prefix, parent.node.keyParts[joinWith < parent.index ? parent.index - 1 : parent.index]);
+            if (joinWith < parent.index) {
+               copy = join(joiner, middleKey, copy);
+               from = joinWith;
+               to = parent.index;
+            } else {
+               copy = join(copy, middleKey, joiner);
+               from = parent.index;
+               to = joinWith;
+            }
+            // Defer freeing joiner until AFTER the parent copyWith() succeeds.
+            // Freeing it here (before copyWith) would leave a stale InnerNode in the
+            // parent if copyWith subsequently throws, corrupting the live B-tree.
+            List<IndexNode> joinerGarbage = Collections.singletonList(joiner);
+            if (copy.length() <= segment.getMaxNodeSize()) {
+               return new JoinSplitResult(from, to, Collections.singletonList(copy), joinerGarbage);
+            } else {
+               return new JoinSplitResult(from, to, copy.split(), joinerGarbage);
+            }
          } else {
-            copy = join(copy, middleKey, joiner);
-            from = parent.index;
-            to = joinWith;
+            // joiner's index data is inaccessible (stale or corrupt reference).
+            // Skip the merge — leave this node undersized rather than risk corruption.
+            log.warnf("Cannot load joiner node %d:%d for merge; skipping join for node %08x",
+                  parent.node.innerNodes[joinWith].offset, parent.node.innerNodes[joinWith].length,
+                  System.identityHashCode(node));
+            // Fall through to the replaceContent / split logic below.
          }
-         garbage.push(joiner);
-      } else if (copy.length() <= node.occupiedSpace) {
+      }
+      if (copy.length() <= node.occupiedSpace) {
          if (copy.innerNodes != null && copy.innerNodes.length == 1 && stack.isEmpty()) {
             IndexNode child = copy.innerNodes[0].getIndexNode(copy.segment);
+            if (child == null) {
+               // child's index data is inaccessible; keep current root shape rather than corrupting.
+               log.warnf("Cannot load child node for tree shrink at root; keeping current root");
+               node.replaceContent(copy);
+               return null;
+            }
             return new JoinSplitResult(0, 0, Collections.singletonList(child));
          } else {
             // special case where we only overwrite the key
@@ -576,13 +624,10 @@ class IndexNode {
       byte[][] newKeyParts = new byte[left.keyParts.length + right.keyParts.length + 1][];
       newPrefix = commonPrefix(newPrefix, middleKey);
       copyKeyParts(left.keyParts, 0, newKeyParts, 0, left.keyParts.length, left.prefix, newPrefix);
-      byte[] rightmostKey;
-      try {
-         rightmostKey = left.rightmostKey();
-      } catch (IndexNodeOutdatedException e) {
-         throw new IllegalStateException(e);
-      }
-      int commonLength = Math.abs(compare(middleKey, rightmostKey));
+      byte[] rightmostKey = left.rightmostKey();
+      // If all entries in the left subtree are stale/deleted, commonLength falls back to
+      // the full middleKey suffix — a safe separator since no real left keys remain.
+      int commonLength = rightmostKey != null ? Math.abs(compare(middleKey, rightmostKey)) : middleKey.length;
       newKeyParts[left.keyParts.length] = substring(middleKey, newPrefix.length, commonLength);
       copyKeyParts(right.keyParts, 0, newKeyParts, left.keyParts.length + 1, right.keyParts.length, right.prefix, newPrefix);
       if (left.innerNodes != null && right.innerNodes != null) {
@@ -613,15 +658,21 @@ class IndexNode {
       byte[][] newKeys = new byte[newNodes.size() - 1][];
       byte[] newPrefix = prefix;
       for (int i = 0; i < newKeys.length; ++i) {
-         try {
-            // TODO: if all keys within the subtree are null (deleted), the new key will be null
-            // will be fixed with proper index reduction
-            newKeys[i] = newNodes.get(i + 1).leftmostKey();
-            if (newKeys[i] == null) {
-               throw new IllegalStateException();
-            }
-         } catch (IndexNodeOutdatedException e) {
-            throw new IllegalStateException("Index cannot be outdated for segment updater thread", e);
+         // Prefer the leftmost key of the right node as the separator.
+         // If all leaves in that subtree reference deleted data files, fall back to
+         // the rightmost key of the left node.  Both are valid separators as long as
+         // they correctly order the two halves.
+         newKeys[i] = newNodes.get(i + 1).leftmostKey();
+         if (newKeys[i] == null) {
+            newKeys[i] = newNodes.get(i).rightmostKey();
+         }
+         if (newKeys[i] == null) {
+            // Both subtrees are entirely stale; no valid separator available.
+            // Use a zero-length key as a last resort — the entries will be cleaned
+            // up by the compactor, which will then reorganise the B-tree properly.
+            log.warnf("Cannot find separator key between split nodes %d and %d; using empty separator",
+                  System.identityHashCode(newNodes.get(i)), System.identityHashCode(newNodes.get(i + 1)));
+            newKeys[i] = new byte[0];
          }
          newPrefix = commonPrefix(newPrefix, newKeys[i]);
       }
@@ -634,31 +685,43 @@ class IndexNode {
       return new IndexNode(segment, newPrefix, newKeyParts, newInnerNodes);
    }
 
-   private byte[] leftmostKey() throws IOException, IndexNodeOutdatedException {
+   private byte[] leftmostKey() throws IOException {
       if (innerNodes != null) {
          for (InnerNode innerNode : innerNodes) {
-            byte[] key = innerNode.getIndexNode(segment).leftmostKey();
+            IndexNode child = innerNode.getIndexNode(segment);
+            if (child == null) continue;
+            byte[] key = child.leftmostKey();
             if (key != null) return key;
          }
       } else {
          for (LeafNode leafNode : leafNodes) {
-            EntryRecord hak = leafNode.loadHeaderAndKey(segment.getFileProvider());
-            if (hak.getKey() != null) return hak.getKey();
+            try {
+               EntryRecord hak = leafNode.loadHeaderAndKey(segment.getFileProvider());
+               if (hak.getKey() != null) return hak.getKey();
+            } catch (IndexNodeOutdatedException e) {
+               // leaf's data file has been compacted away; skip to next leaf
+            }
          }
       }
       return null;
    }
 
-   private byte[] rightmostKey() throws IOException, IndexNodeOutdatedException {
+   private byte[] rightmostKey() throws IOException {
       if (innerNodes != null) {
          for (int i = innerNodes.length - 1; i >= 0; --i) {
-            byte[] key = innerNodes[i].getIndexNode(segment).rightmostKey();
+            IndexNode child = innerNodes[i].getIndexNode(segment);
+            if (child == null) continue;
+            byte[] key = child.rightmostKey();
             if (key != null) return key;
          }
       } else {
          for (int i = leafNodes.length - 1; i >= 0; --i) {
-            EntryRecord hak = leafNodes[i].loadHeaderAndKey(segment.getFileProvider());
-            if (hak.getKey() != null) return hak.getKey();
+            try {
+               EntryRecord hak = leafNodes[i].loadHeaderAndKey(segment.getFileProvider());
+               if (hak.getKey() != null) return hak.getKey();
+            } catch (IndexNodeOutdatedException e) {
+               // leaf's data file has been compacted away; skip to previous leaf
+            }
          }
       }
       return null;


### PR DESCRIPTION
Race: `manageLength` pushed `joiner` to garbage before parent `copyWith` ran. If `copyWith` threw (e.g. split separator from a stale leaf), the finally block freed joiner's space while the parent `InnerNode` still referenced it — next write traversal hit freed space and failed with "Corrupt index".

Fix:
- `JoinSplitResult` gains `pendingGarbage`; `manageLength` returns joiner there instead of pushing to garbage directly
- `setPosition` defers `free()` of replaced node and `pendingGarbage` until after `copyWith` succeeds; no free on exception
- `leftmostKey`/`rightmostKey` skip stale (deleted-file) leaves instead of propagating `IndexNodeOutdatedException`
- `join`/`copyWith(int,int,List)`: `null` separator fallbacks — use `rightmostKey` of left piece, then empty-byte as last resort

Closes: #17394
Disclaimer: Fix assisted by AI

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Reviewer Checklist (all must be checked):
- [ ] Code review
  - Are the changes reasonable?
  - Are there any use cases, integrations, inputs that haven't been considered in the implementation?
  - Is the code understandable? (KISS, comments)
  - Is there a better way to implement/write the functionality, code pieces?
  - Is formatting in line with the rest of the project? (checkstyle and spotless)
- [ ] Test review
  - Is the new test coverage rich enough to cover all the changes and considerations above?
  - Does the base functionality works as expected in the build project?
  - Does it behave as expected when given various inputs? (Valid and invalid, missing, partial)
  - Are there integrations to be considered? (Does the new functionality work well with the rest of the project, environment)
  -  Even if all above works as expected, are there weird behaviors to be improved on?
- [ ] Documentation review
  - Does the new/changed documentation cover the PR in sufficient matter?
  - For public API, are JavaDocs included for every new/changed class/method ?
  - For new features, does the documentation add/amend any usage examples ?
  - Grammar and syntax checks 
  - Does AsciiDoc generation report any WARN messages ?

This PR is a pure code bug, no documentation needed. I was able to reproduce it only under heavy load in test: https://github.com/hmlnarik/ispn-test-mvn.

Cc: @wburns 