### PR TITLE
[#17473] Handle redundant AUTH on already-complete SASL mechanism

### DIFF
--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Authentication.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Authentication.java
@@ -100,6 +100,10 @@ public class Authentication extends BaseRequestProcessor {
             throw log.invalidMech(mech);
          }
       }
+      if (saslServer.isComplete()) {
+         authComplete(header, null);
+         return;
+      }
       byte[] serverChallenge = saslServer.evaluateResponse(response);
       if (saslServer.isComplete()) {
          authComplete(header, serverChallenge);


### PR DESCRIPTION
Closes: #17473

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [ ] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [ ] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
- [ ] Log messages of level `INFO` and above have been internationalized.
- [ ] If the PR affects performance, include before/after benchmarks.
- [ ] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [ ] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

## Summary
- When a client sends an AUTH message after the SASL mechanism has already completed, the server now responds with auth-complete instead of calling `evaluateResponse()` which throws ELY05001
- This is a defensive server-side fix; the root cause on the client side was fixed in infinispan/js-client#156
- No tests: this is a 4-line defensive guard against a race condition that is difficult to reproduce deterministically. The js-client CI was the only reliable reproducer and the client-side fix addresses the root cause
- No documentation changes needed: no user-visible behavior change

Created with the assistance of an AI tool