### PR TITLE
#17375 Update JacocoReport github action to run on nodejs24

### DIFF
--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -544,7 +544,7 @@ jobs:
 
       - name: Add coverage to PR
         id: jacoco
-        uses: vilmosnagy/jacoco-report@1.7.2-v2
+        uses: vilmosnagy/jacoco-report@1.8.0
         with:
           paths: |
             ${{ github.workspace }}/test_dir/infinispan/jacoco-report/jacoco.xml
@@ -586,7 +586,7 @@ jobs:
 
       - name: Add rolling upgrade coverage to PR
         id: jacoco-rolling-upgrade
-        uses: vilmosnagy/jacoco-report@1.7.2-v2
+        uses: vilmosnagy/jacoco-report@1.8.0
         with:
           paths: |
             ${{ github.workspace }}/test_dir/infinispan-rolling-upgrade/jacoco-report/jacoco.xml


### PR DESCRIPTION
I opened a separate PR so I don't spam #17375 too much with my questions, @rigazilla 🙂

Dependabot already opened two PRs for the update in #17482 and #17483. `vilmosnagy/jacoco-report@1.8.0` should solve the problem, although so far I've only tested it in other repositories. The updated action also needs to be on the `main` branch for it to run properly.

I tried to create a trial setup at https://github.com/vilmosnagy/infinispan/pull/1 (where the `main` branch contains the updated action, and I opened a PR to trigger the JaCoCo comment), but for some reason the GitHub Action did not run. I didn't have time to debug it yet, but my guess is that it has something to do with the environment setup, such as missing secrets or similar configuration.

@rigazilla, do you need me to run the updated action successfully in a fork of Infinispan, or would you be comfortable merging it based on runs from other repositories? For example:
https://github.com/p2-inc/keycloak-orgs/actions/runs/25909505580/job/76150770102

If I need to run it successfully in a fork, could you help me set up a working Actions pipeline there? Thanks!
