### PR TITLE
[#17527] Fix NPE in ProtostreamTranscoder when unmarshalling produces null

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientReplicatedExpirationNullValueTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientReplicatedExpirationNullValueTest.java
@@ -1,0 +1,86 @@
+package org.infinispan.client.hotrod.event;
+
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OCTET_STREAM;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_PROTOSTREAM;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.commons.time.TimeService;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.encoding.DataConversion;
+import org.infinispan.expiration.impl.ExpiredCacheListener;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Reproducer for https://github.com/infinispan/infinispan/issues/17527
+ *
+ * When an entry with an empty protobuf value (byte[0]) expires via max-idle in a
+ * replicated SYNC cache, the ProtostreamTranscoder throws NPE while transcoding
+ * the value for a listener notification. This kills the JGroups thread on the
+ * backup node, causing the primary to hang waiting for a response.
+ */
+@Test(groups = "functional", testName = "client.hotrod.event.ClientReplicatedExpirationNullValueTest")
+public class ClientReplicatedExpirationNullValueTest extends MultiHotRodServersTest {
+
+   private static final int NUM_SERVERS = 2;
+
+   private ControlledTimeService ts0;
+   private ControlledTimeService ts1;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      builder.expiration().disableReaper();
+      createHotRodServers(NUM_SERVERS, hotRodCacheConfiguration(builder));
+      ts0 = new ControlledTimeService();
+      TestingUtil.replaceComponent(server(0).getCacheManager(), TimeService.class, ts0, true);
+      ts1 = new ControlledTimeService();
+      TestingUtil.replaceComponent(server(1).getCacheManager(), TimeService.class, ts1, true);
+   }
+
+   @Override
+   protected SerializationContextInitializer contextInitializer() {
+      return ClientEventSCI.INSTANCE;
+   }
+
+   public void testNullValueTranscoding() {
+      // Verify that transcoding empty protobuf bytes (which unmarshal to null)
+      // from APPLICATION_PROTOSTREAM to APPLICATION_OCTET_STREAM does not throw NPE.
+      // Without the fix, getCtxForMarshalling(null) throws NullPointerException.
+      AdvancedCache<?, ?> transcodingCache = cache(0).getAdvancedCache()
+            .withMediaType(APPLICATION_PROTOSTREAM, APPLICATION_OCTET_STREAM);
+      DataConversion valueConversion = transcodingCache.getValueDataConversion();
+      Object result = valueConversion.fromStorage(new byte[0]);
+      assertNull(result);
+   }
+
+   public void testNullValueMaxIdleExpiration() {
+      ExpiredCacheListener listener = new ExpiredCacheListener();
+      cache(0).getAdvancedCache().withMediaType(APPLICATION_PROTOSTREAM, APPLICATION_OCTET_STREAM)
+            .addListener(listener);
+
+      @SuppressWarnings("unchecked")
+      AdvancedCache<byte[], byte[]> rawCache =
+            (AdvancedCache<byte[], byte[]>) (AdvancedCache<?, ?>)
+            cache(0).getAdvancedCache().withStorageMediaType();
+      byte[] keyBytes = new byte[]{1, 2, 3, 4};
+      rawCache.put(keyBytes, new byte[0], -1, TimeUnit.MILLISECONDS, 10, TimeUnit.MINUTES);
+
+      ts0.advance(TimeUnit.MINUTES.toMillis(10) + 1);
+      ts1.advance(TimeUnit.MINUTES.toMillis(10) + 1);
+
+      // Accessing the expired entry triggers max-idle expiration.
+      // Without the fix, the NPE in ProtostreamTranscoder.getCtxForMarshalling
+      // could kill a JGroups thread on the backup, causing the primary to hang.
+      assertNull(rawCache.get(keyBytes));
+      eventually(() -> listener.getInvocationCount() > 0, 10_000);
+   }
+}

--- a/core/src/main/java/org/infinispan/encoding/ProtostreamTranscoder.java
+++ b/core/src/main/java/org/infinispan/encoding/ProtostreamTranscoder.java
@@ -74,7 +74,7 @@ public class ProtostreamTranscoder extends OneToManyTranscoder {
          }
          if (destinationType.match(MediaType.APPLICATION_OCTET_STREAM)) {
             Object unmarshalled = content instanceof byte[] ? unmarshall((byte[]) content, contentType, destinationType) : content;
-            if (unmarshalled instanceof byte[]) {
+            if (unmarshalled == null || unmarshalled instanceof byte[]) {
                return unmarshalled;
             }
             ImmutableSerializationContext ctx = getCtxForMarshalling(unmarshalled);
@@ -95,7 +95,7 @@ public class ProtostreamTranscoder extends OneToManyTranscoder {
          }
          if (destinationType.equals(APPLICATION_UNKNOWN)) {
             //TODO: Remove wrapping of byte[] into WrappedByteArray from the Hot Rod Multimap operations.
-            if (content instanceof WrappedByteArray) return content;
+            if (content == null || content instanceof WrappedByteArray) return content;
             ImmutableSerializationContext ctx = getCtxForMarshalling(content);
             return StandardConversions.convertJavaToProtoStream(content, MediaType.APPLICATION_OBJECT, ctx);
          }

--- a/core/src/test/java/org/infinispan/dataconversion/ProtostreamTranscoderTest.java
+++ b/core/src/test/java/org/infinispan/dataconversion/ProtostreamTranscoderTest.java
@@ -4,10 +4,12 @@ package org.infinispan.dataconversion;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_JSON;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OCTET_STREAM;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_PROTOSTREAM;
 import static org.infinispan.commons.dataconversion.MediaType.TEXT_PLAIN;
 import static org.infinispan.protostream.ProtobufUtil.toWrappedByteArray;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
@@ -181,6 +183,13 @@ public class ProtostreamTranscoderTest extends AbstractTranscoderTest {
       assertTrue(result instanceof String);
       assertJsonCorrect(result);
 
+   }
+
+   @Test
+   public void testTranscodeEmptyBytesToOctetStream() {
+      byte[] emptyBytes = new byte[0];
+      Object result = transcoder.transcode(emptyBytes, APPLICATION_PROTOSTREAM, APPLICATION_OCTET_STREAM);
+      assertNull(result);
    }
 
    private void assertJsonCorrect(Object json) {


### PR DESCRIPTION
Closes: #17527

When an expired entry with empty protobuf bytes is transcoded from `APPLICATION_PROTOSTREAM` to `APPLICATION_OCTET_STREAM`, `WrappedMessage` deserializes to `null`. The existing code path did not guard against this, causing a `NullPointerException` in `getCtxForMarshalling()`. This kills the JGroups thread on backup nodes, blocking SYNC replication and eventually making the cluster unresponsive.

The fix adds a `null` check in the `APPLICATION_OCTET_STREAM` branch of `doTranscode()`, consistent with the existing `null` guard in the `TEXT_PLAIN` branch.

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [ ] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - Bug fix with no user-facing behavior change; no documentation needed.
- [ ] Log messages of level `INFO` and above have been internationalized.
- [ ] If the PR affects performance, include before/after benchmarks.
- [ ] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [ ] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool