### PR TITLE
Backport flaky test fixes to 16.0.x

### DIFF
--- a/.github/actions/comment-pr-flaky-test/action.yml
+++ b/.github/actions/comment-pr-flaky-test/action.yml
@@ -22,14 +22,39 @@ runs:
         PR="${{ inputs.pr-number }}"
         if [ "$PR" != "" ]; then
           shopt -s nullglob globstar
+
+          # Load flaky-test-issues mapping (written by track_flaky_tests.sh)
+          declare -A ISSUE_MAP
+          declare -A COMMENT_COUNT_MAP
+          if [ -f flaky-test-issues.map ]; then
+            while IFS=$'\t' read -r key number count; do
+              ISSUE_MAP["$key"]="$number"
+              COMMENT_COUNT_MAP["$key"]="$count"
+            done < flaky-test-issues.map
+          fi
+
           FLAKY_TEST_GLOB="**/target/*-reports*/**/TEST-*FLAKY.xml"
           TESTS=(${FLAKY_TEST_GLOB})
           for TEST in "${TESTS[@]}"
           do
-            FULL_TEST_NAME=$(xmlstarlet sel -T -t -m "/testsuite/testcase" -o '   - '\
+            RAW_NAMES=$(xmlstarlet sel -T -t -m "/testsuite/testcase" \
              -v "concat(@classname,'#',@name)" -n ${TEST} \
              | sed 's/(Flaky Test)//' | sed 's/\[[0-9]\]//')
-            FLAKES_PR_COMMENT="$FLAKES_PR_COMMENT$FULL_TEST_NAME\n"
+            while IFS= read -r LINE; do
+              [ -z "$LINE" ] && continue
+              # Strip leading/trailing whitespace
+              LINE=$(echo "$LINE" | xargs)
+              # Build lookup key by stripping parameters (same logic as track_flaky_tests.sh)
+              LOOKUP_KEY="${LINE%%\[*}"
+              LOOKUP_KEY="${LOOKUP_KEY%%(*}"
+              if [ -n "${ISSUE_MAP[$LOOKUP_KEY]+x}" ]; then
+                ISSUE_NUM="${ISSUE_MAP[$LOOKUP_KEY]}"
+                SEEN_COUNT=$(( ${COMMENT_COUNT_MAP[$LOOKUP_KEY]} + 1 ))
+                FLAKES_PR_COMMENT="$FLAKES_PR_COMMENT   - [${LINE}](https://github.com/${{ github.repository }}/issues/${ISSUE_NUM}) (seen ${SEEN_COUNT} times)\n"
+              else
+                FLAKES_PR_COMMENT="$FLAKES_PR_COMMENT   - ${LINE}\n"
+              fi
+            done <<< "$RAW_NAMES"
           done
           if [ "$FLAKES_PR_COMMENT" != "" ]; then
             pr_url=https://github.com/${{ github.repository }}/pull/$PR

--- a/bin/gh/track_flaky_tests.sh
+++ b/bin/gh/track_flaky_tests.sh
@@ -21,13 +21,17 @@ requiredEnv GH_JOB_URL FLAKY_TEST_GLOB TARGET_BRANCH GITHUB_REPOSITORY
 shopt -s nullglob globstar
 TESTS=(${FLAKY_TEST_GLOB})
 API_LIMIT_TIME=0
+declare -A SEEN_TESTS
 for TEST in "${TESTS[@]}"; do
-  TEST_CLASS_NAMES=$(xmlstarlet sel -t --value-of '/testsuite/testcase/@classname'  ${TEST})
-  declare -i i
-  for TEST_CLASS in $TEST_CLASS_NAMES; do
-    # just get the first testcase for now
-    i=1
-    TEST_NAME=$(xmlstarlet sel --template --value-of '/testsuite/testcase['$i']/@name' ${TEST})
+  # Extract all classname#testname pairs from the XML file
+  TEST_ENTRIES=$(xmlstarlet sel -T -t -m "/testsuite/testcase" \
+    -v "concat(@classname,'#',@name)" -n ${TEST})
+  i=0
+  while IFS= read -r ENTRY; do
+    [ -z "$ENTRY" ] && continue
+    (( i++ ))
+    TEST_CLASS="${ENTRY%%#*}"
+    TEST_NAME="${ENTRY#*#}"
     # Removing (Flaky Test) text
     TEST_NAME=${TEST_NAME% (Flaky Test)}
     # Some tests have arguments with backslash, ie testReplace\[NO_TX, P_TX\]. Removing
@@ -36,10 +40,15 @@ for TEST in "${TESTS[@]}"; do
     TEST_NAME=${TEST_NAME%%[*}
     # Some tests end with \(. Removing
     TEST_NAME_NO_PARAMS=${TEST_NAME%%\(*}
-    STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase/failure['$i']' ${TEST})
+    STACK_TRACE=$(xmlstarlet sel --template --value-of '/testsuite/testcase['$i']/failure' ${TEST})
 
     # Create Issue for Test Class+TestName
     SUMMARY="Flaky test: ${TEST_CLASS}#${TEST_NAME_NO_PARAMS}"
+    # Skip if we've already processed this test (e.g., same method with different parameters)
+    if [ -n "${SEEN_TESTS[$SUMMARY]+x}" ]; then
+      continue
+    fi
+    SEEN_TESTS[$SUMMARY]=1
     echo ${SUMMARY}
 
     # Search issues for existing github issue
@@ -82,5 +91,5 @@ for TEST in "${TESTS[@]}"; do
       gh issue comment ${ISSUE_NUMBER} --body "${BODY}"
     fi
     echo -e "${TEST_CLASS}#${TEST_NAME_NO_PARAMS}\t${ISSUE_NUMBER}\t${COMMENT_COUNT}" >> flaky-test-issues.map
-  done
+  done <<< "$TEST_ENTRIES"
 done

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
@@ -7,8 +7,6 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNull;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -22,6 +20,7 @@ import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.core.test.ServerTestingUtil;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -40,16 +39,7 @@ public class HotRodServerStartStopTest extends MultipleCacheManagersTest {
       cleanup =  CleanupPhase.AFTER_METHOD;
    }
 
-   private static int randomPort() {
-      try {
-         ServerSocket socket = new ServerSocket(0);
-         return socket.getLocalPort();
-      } catch (IOException e) {
-         return 56001;
-      }
-   }
-
-   private static final int FIRST_SERVER_PORT = randomPort();
+   private static final int FIRST_SERVER_PORT = ServerTestingUtil.findFreePort();
    private HotRodServer hotRodServer1;
    private HotRodServer hotRodServer2;
    private HotRodServer hotRodServer3;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheBloomTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheBloomTest.java
@@ -124,6 +124,9 @@ public class InvalidatedNearCacheBloomTest extends SingleHotRodServerTest {
       // This conflicts with our original key thus it will send a remove despite nothing being removed
       assertClient.put(conflictKey, "v2").expectNearRemove(conflictKey);
       assertClient.get(1, "v1").expectNearGetValue(1, "v1");
+      // The server may send additional async remove events due to bloom filter collision.
+      // Consume them here so they don't leak into the next test.
+      drainAsyncEvents();
    }
 
    public void testMultipleKeyFilterNoConflict() {
@@ -168,6 +171,11 @@ public class InvalidatedNearCacheBloomTest extends SingleHotRodServerTest {
 
       assertTrue("The server bloom filter was never updated and we got remove events every time",
             serverBloomFilterUpdated);
+   }
+
+   private void drainAsyncEvents() {
+      eventually("Expected all async near cache events to be drained",
+            () -> assertClient.events.poll(50, TimeUnit.MILLISECONDS) == null);
    }
 
    int findNextKey(BloomFilter<byte[]> filter, int originalValue, boolean present) {

--- a/commons-test/src/main/java/org/infinispan/commons/test/skip/StringLogAppender.java
+++ b/commons-test/src/main/java/org/infinispan/commons/test/skip/StringLogAppender.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.apache.logging.log4j.Level;
@@ -12,7 +13,6 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
@@ -25,13 +25,15 @@ import org.apache.logging.log4j.core.config.Property;
  */
 public class StringLogAppender extends AbstractAppender implements Iterable<String> {
 
+   private static final AtomicInteger COUNTER = new AtomicInteger();
+
    private final String category;
    private final Level level;
    private final List<String> logs;
    private final Predicate<Thread> threadFilter;
 
    public StringLogAppender(String category, Level level, Predicate<Thread> threadFilter, Layout<?> layout) {
-      super(StringLogAppender.class.getName(), null, layout, true, Property.EMPTY_ARRAY);
+      super(String.format("%s-%s-%d", StringLogAppender.class.getName(), category, COUNTER.incrementAndGet()), null, layout, true, Property.EMPTY_ARRAY);
       this.category = category;
       this.level = level;
       this.logs = Collections.synchronizedList(new ArrayList<>());
@@ -43,17 +45,33 @@ public class StringLogAppender extends AbstractAppender implements Iterable<Stri
       Configuration config = loggerContext.getConfiguration();
       this.start();
       config.addAppender(this);
-      AppenderRef ref = AppenderRef.createAppenderRef(this.getName(), level, null);
-      AppenderRef[] refs = new AppenderRef[]{ref};
-      LoggerConfig loggerConfig = LoggerConfig.newBuilder().withAdditivity(true).withLevel(level).withLoggerName(category).withRefs(refs).withConfig(config).build();
-      loggerConfig.addAppender(this, null, null);
-      config.addLogger(category, loggerConfig);
+
+      LoggerConfig loggerConfig = config.getLoggerConfig(category);
+      if (!loggerConfig.getName().equals(category)) {
+         synchronized (StringLogAppender.class) {
+            loggerConfig = config.getLoggerConfig(category);
+            if (!loggerConfig.getName().equals(category)) {
+               loggerConfig = LoggerConfig.newBuilder()
+                     .withAdditivity(true)
+                     .withLevel(level)
+                     .withLoggerName(category)
+                     .withConfig(config)
+                     .build();
+               config.addLogger(category, loggerConfig);
+            }
+         }
+      }
+      loggerConfig.addAppender(this, level, null);
       loggerContext.updateLoggers();
    }
 
    public void uninstall() {
       LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
-      loggerContext.getConfiguration().removeLogger(category);
+      Configuration config = loggerContext.getConfiguration();
+      LoggerConfig loggerConfig = config.getLoggerConfig(category);
+      if (loggerConfig.getName().equals(category)) {
+         loggerConfig.removeAppender(this.getName());
+      }
       loggerContext.updateLoggers();
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -597,12 +597,16 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       Iterator<List<Mutation<Object, Object, ?>>> mutationsIterator = mutations.iterator();
       for (; keysIterator.hasNext() && mutationsIterator.hasNext(); ) {
          Object key = keysIterator.next();
+         List<Mutation<Object, Object, ?>> currentMutations = mutationsIterator.next();
+         if (currentMutations.isEmpty())
+            continue;
+
          CompletionStage<Void> stage = entryFactory.wrapEntryForWriting(ctx, key, keyPartitioner.getSegment(key), false, true, CompletableFutures.completedNull());
          // We rely on the fact that when isOwner is false this never blocks
          assert CompletionStages.isCompletedSuccessfully(stage);
          MVCCEntry cacheEntry = (MVCCEntry) ctx.lookupEntry(key);
          EntryView.ReadWriteEntryView readWriteEntryView = EntryViews.readWrite(cacheEntry, DataConversionInternal.IDENTITY_KEY, DataConversionInternal.IDENTITY_VALUE);
-         for (Mutation mutation : mutationsIterator.next()) {
+         for (Mutation mutation : currentMutations) {
             mutation.apply(readWriteEntryView);
             cacheEntry.updatePreviousValue();
          }
@@ -643,6 +647,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       List<List<Mutation<Object, Object,?>>> mutations = new ArrayList<>(keys.size());
       for (int i = keys.size(); i > 0; --i) mutations.add(Collections.emptyList());
 
+      boolean hasMutations = false;
       for (WriteCommand write : txCtx.getCacheTransaction().getModifications()) {
          if (write == untilCommand) {
             // We've reached this command in the modifications list; this happens when we're replaying a prepared
@@ -659,6 +664,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
                      mutations.set(i, list);
                   }
                   list.add(((FunctionalCommand) write).toMutation(key));
+                  hasMutations = true;
                } else {
                   // Non-functional modification must have retrieved the value into context and we should not do any
                   // remote reads!
@@ -668,7 +674,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
             }
          }
       }
-      return mutations;
+      return hasMutations ? mutations : null;
    }
 
    private class TxReadOnlyManyHelper extends ReadOnlyManyHelper {
@@ -693,15 +699,21 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       public ReadOnlyManyCommand<?, ?, ?> copyForRemote(C cmd, List<Object> keys, InvocationContext ctx) {
          List<List<Mutation<Object, Object,?>>> mutations = getMutations(ctx, cmd, keys);
          // write command is always executed in transactional scope
-         assert mutations != null;
-
-         for (int i = 0; i < keys.size(); ++i) {
-            List<Mutation<Object, Object,?>> list = mutations.get(i);
-            Mutation mutation = cmd.toMutation(keys.get(i));
-            if (list.isEmpty()) {
-               mutations.set(i, Collections.singletonList(mutation));
-            } else {
-               list.add(mutation);
+         assert ctx.isInTxScope();
+         if (mutations == null) {
+            mutations = new ArrayList<>(keys.size());
+            for (Object key : keys) {
+               mutations.add(Collections.singletonList(cmd.toMutation(key)));
+            }
+         } else {
+            for (int i = 0; i < keys.size(); ++i) {
+               List<Mutation<Object, Object,?>> list = mutations.get(i);
+               Mutation mutation = cmd.toMutation(keys.get(i));
+               if (list.isEmpty()) {
+                  mutations.set(i, Collections.singletonList(mutation));
+               } else {
+                  list.add(mutation);
+               }
             }
          }
          return commandsFactory.buildTxReadOnlyManyCommand(keys, mutations, cmd.getParams(), cmd.getKeyDataConversion(), cmd.getValueDataConversion());

--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -480,6 +480,9 @@ class Index {
                   write(statsChannel, buffer);
                   buffer.flip();
                }
+
+               // Force the stats written since some tests may read it after shutting down
+               statsChannel.force(false);
             }
          } catch (IOException e) {
             throw CompletableFutures.asCompletionException(e);

--- a/core/src/main/java/org/infinispan/xsite/irac/DefaultIracManager.java
+++ b/core/src/main/java/org/infinispan/xsite/irac/DefaultIracManager.java
@@ -105,11 +105,16 @@ public class DefaultIracManager implements IracManager, JmxStatisticsExposer {
       return true;
    };
 
-   @Inject RpcManager rpcManager;
-   @Inject TakeOfflineManager takeOfflineManager;
-   @Inject ClusteringDependentLogic clusteringDependentLogic;
-   @Inject CommandsFactory commandsFactory;
-   @Inject IracTombstoneManager iracTombstoneManager;
+   @Inject
+   RpcManager rpcManager;
+   @Inject
+   TakeOfflineManager takeOfflineManager;
+   @Inject
+   ClusteringDependentLogic clusteringDependentLogic;
+   @Inject
+   CommandsFactory commandsFactory;
+   @Inject
+   IracTombstoneManager iracTombstoneManager;
 
    private final Map<Object, IracManagerKeyState> updatedKeys;
    private final Collection<IracXSiteBackup> asyncBackups;
@@ -405,7 +410,7 @@ public class DefaultIracManager implements IracManager, JmxStatisticsExposer {
       }
 
       AggregateCompletionStage<Void> aggregation = CompletionStages.aggregateCompletionStage();
-      for (IracXSiteBackup backup: asyncBackups) {
+      for (IracXSiteBackup backup : asyncBackups) {
          if (backup.isBackOffEnabled()) {
             for (IracStateData data : batch) {
                data.state.retry();

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -328,14 +328,14 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       checkPoint.triggerForever(Mocks.BEFORE_RELEASE);
       addCheckpointInterceptor(ownerCache, checkPoint, GetCacheEntryCommand.class,
             getL1InterceptorClass(), true);
-      addCheckpointInterceptor(backupOwnerCache, checkPoint, GetCacheEntryCommand.class,
-            getL1InterceptorClass(), true);
 
       try {
          Future<String> future = fork(() -> nonOwnerCache.get(key));
 
-         // Wait until get goes remote and retrieves value before going back into L1 interceptor
-         checkPoint.awaitStrict(Mocks.AFTER_INVOCATION, 2, 10, TimeUnit.SECONDS);
+         // Wait until get goes remote and retrieves value before going back into L1 interceptor.
+         // The staggered RPC sends to the primary owner first, then waits for a stagger delay before
+         // trying the backup. We only need one owner to have processed the command to proceed.
+         checkPoint.awaitStrict(Mocks.AFTER_INVOCATION, 10, TimeUnit.SECONDS);
 
          assertEquals(firstValue, ownerCache.put(key, secondValue));
 

--- a/core/src/test/java/org/infinispan/invalidation/NonTxInvalidationLockingTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/NonTxInvalidationLockingTest.java
@@ -39,19 +39,17 @@ public class NonTxInvalidationLockingTest extends MultipleCacheManagersTest {
    }
 
    private void defineCache(String cacheName) {
-      ConfigurationBuilder config = buildConfig();
-      manager(0).defineConfiguration(cacheName, config.build());
-      manager(1).defineConfiguration(cacheName, config.build());
+      manager(0).defineConfiguration(cacheName, buildConfig(0).build());
+      manager(1).defineConfiguration(cacheName, buildConfig(1).build());
    }
 
-   private ConfigurationBuilder buildConfig() {
+   private ConfigurationBuilder buildConfig(int nodeIndex) {
       ConfigurationBuilder cacheConfig = new ConfigurationBuilder();
       cacheConfig.clustering().cacheMode(CacheMode.INVALIDATION_SYNC)
                  .stateTransfer().fetchInMemoryState(false)
                  .transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL)
                  .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
-                 .storeName(NonTxInvalidationLockingTest.class.getName())
-                 .build();
+                 .storeName(NonTxInvalidationLockingTest.class.getName() + "_" + nodeIndex);
       return cacheConfig;
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionHandlingReleaseLockTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionHandlingReleaseLockTest.java
@@ -25,6 +25,7 @@ import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.conflict.MergePolicy;
+import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManagerImpl;
@@ -72,9 +73,15 @@ public class PessimisticTxPartitionHandlingReleaseLockTest extends MultipleCache
    public void testLockReleased() throws Exception {
       final AdvancedCache<MagicKey, String> cache0 = this.<MagicKey, String>cache(0).getAdvancedCache();
       final TransactionManager tm = cache0.getTransactionManager();
-      final ControlledInboundHandler handler1 = wrapInboundInvocationHandler(cache(1), ControlledInboundHandler::new);
       final ControlledLocalTopologyManager localTopologyManager0 = wrapGlobalComponent(cache0.getCacheManager(), LocalTopologyManager.class, ControlledLocalTopologyManager::new, true);
-      final MagicKey key = new MagicKey(cache0, cache(1));
+      final MagicKey key = new MagicKey(cache0);
+
+      // Find the actual backup owner dynamically instead of hardcoding cache(1),
+      // since the consistent hash may not place cache(1) as backup for any segment
+      // where cache(0) is primary.
+      DistributionInfo distributionInfo = cache0.getDistributionManager().getCacheTopology().getDistribution(key);
+      int backupIndex = managerIndex(distributionInfo.writeBackups().iterator().next());
+      final ControlledInboundHandler backupHandler = wrapInboundInvocationHandler(cache(backupIndex), ControlledInboundHandler::new);
 
       Future<GlobalTransaction> f = fork(() -> {
          tm.begin();
@@ -87,13 +94,13 @@ public class PessimisticTxPartitionHandlingReleaseLockTest extends MultipleCache
       });
 
       //make sure the PrepareCommand was sent
-      assertTrue(handler1.receivedLatch.await(30, TimeUnit.SECONDS));
+      assertTrue(backupHandler.receivedLatch.await(30, TimeUnit.SECONDS));
 
       //block stable topology update on originator
       localTopologyManager0.blockStableTopologyUpdate();
 
       //isolate backup owner
-      getDiscardForCache(manager(1)).discardAll(true);
+      getDiscardForCache(manager(backupIndex)).discardAll(true);
 
       //wait for the transaction to finish
       //after the view change, the transaction is handled by the PartitionHandlingManager which finishes the commit

--- a/core/src/test/java/org/infinispan/partitionhandling/PreferConsistencyRestartTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PreferConsistencyRestartTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 
 import org.infinispan.commons.test.Exceptions;
 import org.infinispan.configuration.cache.CacheMode;
@@ -45,7 +46,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
       stopManagers(2, 0);
 
       // The remaining node is the new coordinator.
-      assertThat(manager(0).isCoordinator()).isTrue();
+      eventuallyViewCoordinator(0);
       eventuallyClusterTopologyCoordinator(0);
 
       // The cache is now in degraded mode.
@@ -59,7 +60,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
 
       // The coordinator leaves, and only the extraneous node remains.
       stopManagers(0);
-      assertThat(manager(0).isCoordinator()).isTrue();
+      eventuallyViewCoordinator(0);
 
       // Cache still degraded.
       ctm = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
@@ -95,7 +96,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
       stopManagers(2, 0);
 
       // The remaining node is the new coordinator.
-      assertThat(manager(0).isCoordinator()).isTrue();
+      eventuallyViewCoordinator(0);
       eventuallyClusterTopologyCoordinator(0);
 
       // The cache is now in degraded mode.
@@ -109,7 +110,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
 
       // The coordinator leaves, and only the extraneous node remains.
       stopManagers(0);
-      assertThat(manager(0).isCoordinator()).isTrue();
+      eventuallyViewCoordinator(0);
 
       // Cache still degraded.
       ctm = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
@@ -130,7 +131,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
 
       // Force availability of cluster.
       await(ctm.forceAvailabilityMode(CACHE_NAME, AVAILABLE));
-      assertThat(ctm.getAvailabilityMode(CACHE_NAME)).isEqualTo(AVAILABLE);
+      eventuallyCacheAvailability(AVAILABLE);
 
       // Again, since the cluster is completely new, all data is gone.
       assertThat(cache(0, CACHE_NAME).size()).isZero();
@@ -154,7 +155,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
       stopManagers(2, 0);
 
       // The remaining node is the new coordinator.
-      assertThat(manager(0).isCoordinator()).isTrue();
+      eventuallyViewCoordinator(0);
 
       // The cache is now in degraded mode.
       ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
@@ -169,7 +170,7 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
 
       // The current coordinator leaves, yield control to previous coordinator.
       stopManagers(0);
-      assertThat(manager(0).isCoordinator()).isTrue();
+      eventuallyViewCoordinator(0);
 
       // And the cache is still in degraded mode.
       ctm = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
@@ -190,6 +191,16 @@ public class PreferConsistencyRestartTest extends BaseStatefulPartitionHandlingT
    private void eventuallyClusterTopologyCoordinator(int index) {
       ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager(index), ClusterTopologyManager.class);
       eventually(() -> ctm.getStatus() == ClusterTopologyManager.ClusterManagerStatus.COORDINATOR);
+   }
+
+   private void eventuallyViewCoordinator(int index) {
+      eventually(() -> manager(index).isCoordinator());
+   }
+
+   private void eventuallyCacheAvailability(AvailabilityMode mode) {
+      eventually(() -> Stream.of(managers())
+            .map(m -> TestingUtil.extractGlobalComponent(m, LocalTopologyManager.class))
+            .allMatch(ltm -> ltm.getCacheAvailability(CACHE_NAME) == mode));
    }
 
    public void testCrashBeforeRecover() throws Exception {

--- a/core/src/test/java/org/infinispan/persistence/manager/PersistenceManagerTest.java
+++ b/core/src/test/java/org/infinispan/persistence/manager/PersistenceManagerTest.java
@@ -225,7 +225,7 @@ public class PersistenceManagerTest extends SingleCacheManagerTest {
             .subscribe(subscriber);
       subscriber.request(Long.MAX_VALUE);
       assertTrue(persistenceManager.anyLocksHeld());
-      assertTrue("Subscriber should have completed with error", subscriber.await(EMIT_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS));
+      assertTrue("Subscriber should have completed with error", subscriber.await(15, TimeUnit.SECONDS));
 
       subscriber.assertError(org.infinispan.commons.TimeoutException.class);
       assertFalse(persistenceManager.anyLocksHeld());

--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -184,6 +184,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       d1.discardAll(false);
       d2.discardAll(false);
       d3.discardAll(false);
+      TestingUtil.installNewView(managers());
 
       // wait for the merged cluster to form
       long startTime = System.currentTimeMillis();
@@ -228,6 +229,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       log.debugf("Merging the cluster partitions");
       d2.discardAll(false);
       d3.discardAll(false);
+      TestingUtil.installNewView(manager(1), manager(2));
 
       // wait for the merged cluster to form
       long startTime = System.currentTimeMillis();
@@ -298,6 +300,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       d1.discardAll(false);
       d2.discardAll(false);
       d3.discardAll(false);
+      TestingUtil.installNewView(managers());
 
       // wait for the JGroups merge
       long startTime = System.currentTimeMillis();

--- a/core/src/test/java/org/infinispan/statetransfer/LeaveDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/LeaveDuringStateTransferTest.java
@@ -2,6 +2,7 @@ package org.infinispan.statetransfer;
 
 import static org.infinispan.util.BlockingLocalTopologyManager.confirmTopologyUpdate;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +74,13 @@ public class LeaveDuringStateTransferTest extends MultipleCacheManagersTest {
 
          log.debug("Isolating node " + cacheManagers.get(1));
          TestingUtil.getDiscardForCache(manager(1)).discardAll(true);
-         TestingUtil.blockUntilViewsReceived(60000, true, cacheManagers);
+         Future<Void> installViews = fork(() -> {
+            TestingUtil.installNewView(manager(0), manager(2), manager(3));
+            TestingUtil.installNewView(manager(1));
+         });
+         eventually(() -> manager(1).getMembers().size() == 1, 30, TimeUnit.SECONDS);
+         TestingUtil.blockUntilViewsReceived(60000, false, manager(0), manager(2), manager(3));
+         assertTrue(installViews.isDone());
 
          log.debug("Waiting for topology update from view change");
          // The coordinator sends a READ_NEW topology (+4), but doesn't wait for the confirmation

--- a/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
@@ -68,6 +68,8 @@ public class MergeDuringReplaceTest extends MultipleCacheManagersTest {
       ControlledRpcManager.BlockedRequest blockedReplace = controlledRpcManager.expectCommand(ReplaceCommand.class);
 
       discard[nonOwner].discardAll(true);
+      TestingUtil.installNewView(partition1.get(0).getCacheManager(), partition1.get(1).getCacheManager());
+      TestingUtil.installNewView(c.getCacheManager());
 
       // wait for the partitions to form
       TestingUtil.blockUntilViewsReceived(30000, false, partition1.get(0), partition1.get(1));

--- a/core/src/test/java/org/infinispan/topology/AsymmetricClusterTest.java
+++ b/core/src/test/java/org/infinispan/topology/AsymmetricClusterTest.java
@@ -50,6 +50,8 @@ public class AsymmetricClusterTest extends MultipleCacheManagersTest {
 
       if (crash) {
          d2.discardAll(true);
+         TestingUtil.installNewView(manager(0));
+         TestingUtil.installNewView(manager(1));
       }
       manager(1).stop();
 
@@ -62,9 +64,12 @@ public class AsymmetricClusterTest extends MultipleCacheManagersTest {
    }
 
    public void testCoordinatorCrashesDuringJoin() {
-      d2.discardAll(true);
-
       manager(1).defineConfiguration(CACHE_NAME, clusteredConfig.build());
+
+      d2.discardAll(true);
+      TestingUtil.installNewView(manager(0));
+      TestingUtil.installNewView(manager(1));
+
       fork((Callable<Object>) () -> cache(1, CACHE_NAME));
 
       TestingUtil.blockUntilViewsReceived(30000, false, manager(0));

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
     * Wait for all the site masters to see a specific list of sites.
     */
    public void waitForSites(long timeout, TimeUnit unit, String... siteNames) {
-      long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+      long timeoutNanos = unit.toNanos(timeout);
       Set<String> expectedSites = new HashSet<>(Arrays.asList(siteNames));
       sites.forEach(site -> {
          site.cacheManagers.forEach(manager -> {
@@ -159,6 +159,7 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
             RELAY2 relay2 = transport.getChannel().getProtocolStack().findProtocol(RELAY2.class);
             if (!relay2.isSiteMaster())
                return;
+            long deadlineNanos = System.nanoTime() + timeoutNanos;
             while (System.nanoTime() - deadlineNanos < 0) {
                if (expectedSites.equals(transport.getSitesView()))
                   break;

--- a/core/src/test/java/org/infinispan/xsite/irac/IracRestartWithoutGlobalStateTest.java
+++ b/core/src/test/java/org/infinispan/xsite/irac/IracRestartWithoutGlobalStateTest.java
@@ -29,6 +29,7 @@ import org.infinispan.container.versioning.InequalVersionComparisonResult;
 import org.infinispan.container.versioning.irac.IracEntryVersion;
 import org.infinispan.distribution.DistributionInfo;
 import org.infinispan.distribution.LocalizedCacheTopology;
+import org.infinispan.util.ExponentialBackOff;
 import org.infinispan.xsite.AbstractMultipleSitesTest;
 import org.infinispan.xsite.XSiteAdminOperations;
 import org.testng.AssertJUnit;
@@ -134,6 +135,7 @@ public class IracRestartWithoutGlobalStateTest extends AbstractMultipleSitesTest
 
       log.debug("Starting site_0");
       restartSite(0);
+      disableIracBackOff(0);
 
       if (!persistent) {
          XSiteAdminOperations operations = adminOperations();
@@ -190,6 +192,13 @@ public class IracRestartWithoutGlobalStateTest extends AbstractMultipleSitesTest
 
    private void eventuallyAssertData(String key, String value) {
       eventuallyAssertInAllSitesAndCaches(cache -> Objects.equals(value, cache.get(key)));
+   }
+
+   private void disableIracBackOff(int siteIndex) {
+      for (int i = 0; i < defaultNumberOfNodes(); i++) {
+         DefaultIracManager iracManager = (DefaultIracManager) extractComponent(cache(siteIndex, i), IracManager.class);
+         iracManager.setBackOff(ExponentialBackOff.NO_OP_BUILDER);
+      }
    }
 
    protected XSiteAdminOperations adminOperations() {

--- a/core/src/test/java/org/infinispan/xsite/offline/AsyncOfflineTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/AsyncOfflineTest.java
@@ -67,6 +67,7 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
 
    public void testSlowSFO(Method method) {
       createTestSite(SFO);
+      waitForSites(LON, NYC, SFO);
 
       String cacheName = method.getName();
       defineCache(LON, cacheName, getLONConfiguration());
@@ -97,6 +98,7 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
 
    public void testReset(Method method) {
       createTestSite(SFO);
+      waitForSites(LON, NYC, SFO);
 
       String cacheName = method.getName();
       defineCache(LON, cacheName, getLONConfiguration());

--- a/core/src/test/java/org/infinispan/xsite/offline/AsyncOfflineTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/AsyncOfflineTest.java
@@ -25,6 +25,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.InboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.Reply;
+import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.ExponentialBackOff;
 import org.infinispan.xsite.AbstractXSiteTest;
@@ -43,7 +44,7 @@ import org.testng.annotations.Test;
 public class AsyncOfflineTest extends AbstractXSiteTest {
 
    private static final int NUM_NODES = 3;
-   private static final int NUM_FAILURES = 6;
+   private static final int NUM_FAILURES = 3;
 
    private static final String LON = "LON-1";
    private static final String NYC = "NYC-2";
@@ -84,6 +85,16 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
 
       cache(LON, cacheName, 0).put("key", "value");
       eventuallyEquals("value", () -> cache(SFO, cacheName, 0).get("key"));
+
+      // Wait for IRAC to finish processing the initial put before installing DiscardHandler
+      eventually(() -> {
+         for (int i = 0; i < NUM_NODES; ++i) {
+            if (!iracManager(LON, cacheName, i).isEmpty()) {
+               return false;
+            }
+         }
+         return true;
+      }, 30, TimeUnit.SECONDS);
 
       assertEquals(0, takeOfflineManager(LON, cacheName, primaryOwner).getOfflineStatus(SFO).getFailureCount());
 
@@ -183,11 +194,13 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
          assertOnline(cacheName, index, NYC);
          assertEventuallyOffline(cacheName, index);
       } else {
-         assertOnline(cacheName, index, NYC);
-         assertEventuallyOffline(cacheName, index);
-
+         // Check primary owner first.
+         // It's the source of the distributed state update
          assertOnline(cacheName, primaryOwnerIndex, NYC);
          assertEventuallyOffline(cacheName, primaryOwnerIndex);
+
+         assertOnline(cacheName, index, NYC);
+         assertEventuallyOffline(cacheName, index);
       }
 
       assertBringSiteOnline(cacheName, primaryOwnerIndex);
@@ -202,18 +215,20 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
    private void assertEventuallyOffline(String cacheName, int index) {
       OfflineStatus status = takeOfflineManager(LON, cacheName, index).getOfflineStatus(SFO);
       assertTrue(status.isEnabled());
-      eventually(() -> "Site " + SFO + " is online. status=" + status, status::isOffline);
+      eventually(() -> "Site " + SFO + " is online. status=" + status, status::isOffline, 30, TimeUnit.SECONDS);
    }
 
    private void assertEventuallySFOOnline(String cacheName, int index) {
       OfflineStatus status = takeOfflineManager(LON, cacheName, index).getOfflineStatus(SFO);
       assertTrue(status.isEnabled());
-      eventually(() -> "Site " + SFO + " is offline. status=" + status, () -> !status.isOffline());
+      eventually(() -> "Site " + SFO + " is offline. status=" + status, () -> !status.isOffline(), 30, TimeUnit.SECONDS);
    }
 
    private void assertBringSiteOnline(String cacheName, int index) {
       OfflineStatus status = takeOfflineManager(LON, cacheName, index).getOfflineStatus(SFO);
       assertTrue("Unable to bring " + SFO + " online. status=" + status, CompletionStages.join(status.bringOnline()));
+      // Wait for any pending IRAC runs to process the offline to cleanup transition
+      eventually(() -> iracManager(LON, cacheName, index).isEmpty(), 30, TimeUnit.SECONDS);
    }
 
 
@@ -293,6 +308,7 @@ public class AsyncOfflineTest extends AbstractXSiteTest {
       @Override
       public void handleFromRemoteSite(String origin, XSiteRequest<?> command, Reply reply, DeliverOrder order) {
          if (discard) {
+            reply.reply(CacheNotFoundResponse.INSTANCE);
             return;
          }
          handler.handleFromRemoteSite(origin, command, reply, order);

--- a/core/src/test/java/org/infinispan/xsite/statetransfer/XSiteAutoStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/xsite/statetransfer/XSiteAutoStateTransferTest.java
@@ -208,7 +208,7 @@ public class XSiteAutoStateTransferTest extends AbstractMultipleSitesTest {
       SiteMasterController oldSiteMaster = findSiteMaster(null);
       //let the state command go through
       SiteMasterController newSiteMaster = getSiteMasterController(
-            oldSiteMaster.managerIndex + 1 % defaultNumberOfNodes(),
+            (oldSiteMaster.managerIndex + 1) % defaultNumberOfNodes(),
             XSiteStatePushCommand.class,
             StateTransferStartCommand.class, StateResponseCommand.class,
             StateTransferCancelCommand.class,

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/tx/EXEC.java
@@ -97,10 +97,10 @@ public class EXEC extends RespCommand implements Resp3Command, TransactionResp3C
                   ? TransactionDecorator.completeTransaction(resume, t == null)
                   : CompletableFutures.completedNull();
          });
-      }, ctx.executor()).thenCompose(o -> {
+      }, ctx.executor()).thenComposeAsync(o -> {
          curr.writer().arrayEnd();
          return o;
-      });
+      }, ctx.executor());
    }
 
    private CompletionStage<Void> orderlyExecution(Resp3Handler handler, ChannelHandlerContext ctx,

--- a/server/resp/src/main/java/org/infinispan/server/resp/logging/AccessLoggerManager.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/logging/AccessLoggerManager.java
@@ -36,8 +36,8 @@ import io.netty.channel.ChannelProgressivePromise;
 public class AccessLoggerManager implements IntConsumer {
    private final ChannelProgressivePromise promise;
    private final Tracker tracker;
-   private long start;
-   private long end;
+   private long start = 1;
+   private long end = 1;
 
    public AccessLoggerManager(ChannelHandlerContext ctx, TimeService timeService) {
       this.promise = ctx.newProgressivePromise();

--- a/server/resp/src/test/java/org/infinispan/server/resp/RespBxPOPTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/RespBxPOPTest.java
@@ -651,7 +651,8 @@ public class RespBxPOPTest extends SingleNodeRespBaseTest {
          LMPopArgs args = LMPopArgs.Builder.left().count(3);
          RedisFuture<KeyValue<String, List<String>>> rf = registerListener(() -> conn.async().blmpop(1, args, "whatever"));
          timeService.advance(TimeUnit.SECONDS.toMillis(2));
-         KeyValue<String, List<String>> response = rf.get(3, TimeUnit.SECONDS);
+         eventually(rf::isDone);
+         KeyValue<String, List<String>> response = rf.get();
 
          assertThat(response).isNull();
       } finally {

--- a/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAccessLoggingTest.java
+++ b/server/resp/src/test/java/org/infinispan/server/resp/logging/RespAccessLoggingTest.java
@@ -69,6 +69,12 @@ public class RespAccessLoggingTest extends SingleNodeRespBaseTest {
 
       server.getTransport().stop();
 
+      // Transport stop closes channels, but channelUnregistered (which flushes remaining
+      // access log entries) fires asynchronously after the close promise completes.
+      int expectedLogs = size + 7; // HELLO(1) + CLIENT(2) + SET(size) + INFO(1) + MGET(1) + MSET(1) + UNKNOWN(1)
+      eventually(() -> "Expected " + expectedLogs + " log entries, got " + logAppender.size(),
+            () -> logAppender.size() >= expectedLogs);
+
       assertThat(logAppender.get(0))
             .matches("^127\\.0\\.0\\.1 - \\[\\d+/\\w+/\\d+:\\d+:\\d+:\\d+ [+-]?\\d*] \"HELLO /\\[] RESP\" OK \\d+ \\d+ \\d+$");
 

--- a/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodClientMetrics.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/hotrod/HotRodClientMetrics.java
@@ -1,6 +1,6 @@
 package org.infinispan.server.functional.hotrod;
 
-import static org.infinispan.testing.Eventually.eventually;
+import static org.infinispan.commons.test.Eventually.eventually;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/LegacyRestMetricsResourceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/LegacyRestMetricsResourceIT.java
@@ -264,14 +264,11 @@ public class LegacyRestMetricsResourceIT {
       // 1 write
       assertEquals(1, Arrays.stream(writes).sum());
 
-      // The arrays must have the same position set
-      // If the request is sent to the primary owner, it is recorded as a hit.
-      // Because "IGNORE_RETURN_VALUES" flag is set, the back owner records it as a miss.
-      if (writes[0] == 1) {
-         assertArrayEquals(writes, rm_hits);
-      } else {
-         assertArrayEquals(writes, rm_misses);
-      }
+      // The arrays must have the same position set.
+      // Remove of an existing entry always returns the old value to the originator,
+      // even in non-primary. We'll always have a hit and no misses.
+      assertArrayEquals(writes, rm_hits);
+      assertEquals(0, Arrays.stream(rm_misses).sum());
    }
 
    private static void assertDetailedMetrics(List<Metric> allMetrics, String name, Consumer<AbstractDoubleAssert<?>> consumer) {

--- a/server/tests/src/test/java/org/infinispan/server/functional/rest/RestMetricsResourceIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/rest/RestMetricsResourceIT.java
@@ -267,13 +267,10 @@ public class RestMetricsResourceIT {
       assertEquals(1, Arrays.stream(writes).sum());
 
       // The arrays must have the same position set
-      // If the request is sent to the primary owner, it is recorded as a hit.
-      // Because "IGNORE_RETURN_VALUES" flag is set, the back owner records it as a miss.
-      if (writes[0] == 1) {
-         assertArrayEquals(writes, rm_hits);
-      } else {
-         assertArrayEquals(writes, rm_misses);
-      }
+      // Remove of an existing entry always returns the old value to the originator, even in non-primary.
+      // We'll always have a hit and no misses.
+      assertArrayEquals(writes, rm_hits);
+      assertEquals(0, Arrays.stream(rm_misses).sum());
    }
 
    private static void assertDetailedMetrics(List<Metric> allMetrics, String name, Consumer<AbstractDoubleAssert<?>> consumer) {


### PR DESCRIPTION
Backport of flaky test fixes from main to 16.0.x.

## Applied (33 commits)
- `[#16773]` Fix RemoteStoreTest flaky JGroups multicast bind failure
- `[#16552]` Fix flaky RespAccessLoggingTest
- `[#15212]` Fix flaky AsyncOfflineTest by waiting for SFO site discovery
- `[#16795]` Fix flaky HotRodClientMetrics.testCacheMetrics
- `[#16787]` Fix flaky MemcachedOperations.testConcurrentGets
- `[#13355]` Fix flaky LocalIndexSyncStateTransferTest
- `[#15940]` Flaky SoftIndexFileStoreRestartTest#testStatsUponRestart
- `[#16788]` Fix shared deadline in waitForSites causing flaky xsite tests
- `[#14190]` Fix XSiteAutoStateTransferTest flaky ControlledRpcManager timeout
- `[#15742]` Fix BaseDistSyncL1Test flaky tests
- `[#13535]` Fix flaky IracRestartWithoutGlobalStateTest
- `[#15753]` Fix flaky RemoteGetFailureTest
- `[#16813]` Linkify flaky test names and show occurrence count in PR comments
- `[#15776]` Fix flaky BlockingCommandsClusteredTest
- `[#15805]` Fix flaky AsyncOfflineTest.testReset
- `[#15776]` Fix flaky testBLMPOPListenerTimeout
- `[#14370]` Fix flaky TransactionClusteredTest
- `[#13521]` Fix flaky PessimisticTxPartitionHandlingReleaseLockTest
- `[#13367]` Fix flaky NonTxInvalidationLockingTest
- `[#15750]` Fix flaky TransactionalGracefulShutdownTest
- `[#14338]` Fix flaky MergeDuringReplaceTest
- `[#15890]` Fix flaky access log tests
- `[#15709]` Fix flaky ClusterTopologyManagerTest
- `[#15745]` Fix flaky LeaveDuringStateTransferTest
- `[#17081]` Fix flaky test tracking
- `[#17053]` Fix flaky HotRodServerStartStopTest
- `[#15212]` Fix flaky AsyncOfflineTest
- `[#14652]` Flaky PreferConsistencyRestartTest
- `[#15246]` Flaky PersistenceManagerTest
- `[#16169]` Flaky AsymmetricClusterTest
- `[#14956]` Fix flaky SingleOwnerAndAsyncMethodsWithTxTest
- `[#16158]` Fix flaky InvalidatedNearCacheBloomTest
- `[#17177]` Fix flaky RestMetricsResourceIT
- `[#17236]` Fix flaky LegacyRestMetricsResourceIT

## Already on 16.0.x (4 commits)
- `[#15688]` Fix flaky LockingTest — as `b88a7f4cd7e`
- `[#14248]` Fix flaky ExecTypedTest — as `c432b9400a7`
- `[#16855]` Flaky PooledConnectionIT test — as `4237218ef94`
- `[#13603]` Fix flaky SoftIndexFileStoreRestartTest — as `aaffa4b7e91`

## Skipped — conflicts (4 commits, need manual resolution)
- `[#15890]` Fix flaky access logging tests across all protocols — different log counts on 16.0.x
- `[#16815]` Fix flaky HotRodAuthAccessLoggingTest — same access logging area
- `[#13365]` Fix flaky StateTransferOverwritingValueTest — content conflict
- `[#17071]` Fix flaky NumOwnersNodeCrashInSequenceTest — content conflict
- `[#15762]` SyncLockingTest flaky fix — content conflict

## Skipped — N/A (2 commits, test doesn't exist on 16.0.x)
- `[#17404]` Flaky GracefulShutdownNetworkPartitionTest — file deleted on 16.0.x
- `[#17515]` DynamicMemoryResizerIntegrationTest fails intermittently — file deleted on 16.0.x

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - Cherry-picked test fixes from main.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - Test-only changes.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool