### PR TITLE
[#17285] Increase native-image heap for CLI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
           - os: ubuntu-24.04-arm
             asset_name: linux-aarch_64
             gu_binary: gu
+            native_extra_args: -Dquarkus.native.native-image-xmx=10g
     steps:
       - uses: actions/checkout@v6
 
@@ -207,7 +208,7 @@ jobs:
 
       - if: ${{ matrix.os != 'windows-2022' }}
         name: Build native executable
-        run: ./mvnw package -Pdistribution -Pnative -am -pl quarkus/cli
+        run: ./mvnw package -Pdistribution -Pnative -am -pl quarkus/cli ${{ matrix.native_extra_args }}
 
       - name: Upload CLI native executable
         id: upload-cli-native-executable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,12 +171,14 @@ jobs:
           - os: ubuntu-latest
             asset_name: linux-x86_64
             gu_binary: gu
+            native_extra_args: -Dquarkus.native.native-image-xmx=10g
           - os: macos-latest
             asset_name: osx-aarch_64
             gu_binary: gu
           - os: windows-2022
             asset_name: windows-x86_64
             gu_binary: gu.cmd
+            native_extra_args: -Dquarkus.native.native-image-xmx=10g
           - os: ubuntu-24.04-arm
             asset_name: linux-aarch_64
             gu_binary: gu
@@ -203,7 +205,7 @@ jobs:
         name: Build native executable
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-          mvnw.cmd package -Pdistribution -Pwindows -Pnative -am -pl quarkus/cli
+          mvnw.cmd package -Pdistribution -Pwindows -Pnative -am -pl quarkus/cli ${{ matrix.native_extra_args }}
         shell: cmd
 
       - if: ${{ matrix.os != 'windows-2022' }}


### PR DESCRIPTION
Closes: #17285

The ARM64 GitHub runner (`ubuntu-24.04-arm`) has 4 vCPUs and ~16 GB RAM. The default `-Xmx5g` is insufficient for native-image compilation, causing an OOM during the "Compiling methods" phase ([failed run](https://github.com/infinispan/infinispan/actions/runs/26866859967/job/79252736697)).

This adds a `native_extra_args` matrix property for the ARM64 entry that sets `-Dquarkus.native.native-image-xmx=10g`, passed through to the Maven build command. Other platforms are unaffected (no extra args by default).

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - CI-only change; no unit tests applicable.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - No documentation changes needed for a CI build parameter tweak.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool