### PR TITLE
[#17016] Fix BlockHound allowlist for StateTransferTracker inner class

### DIFF
--- a/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/org/infinispan/util/CoreBlockHoundIntegration.java
@@ -77,7 +77,7 @@ public class CoreBlockHoundIntegration implements BlockHoundIntegration {
          builder.allowBlockingCallsInside(JGroupsTransport.class.getName(), "withView");
 
          // StateTransferTracker holds the lock briefly to update topology state and complete futures
-         builder.allowBlockingCallsInside(StateTransferTracker.class.getName(), "acquireLock");
+         builder.allowBlockingCallsInside(StateTransferTracker.CacheStateTransferTracker.class.getName(), "acquireLock");
       }
       // This invokes the actual runnable - we have to make sure it doesn't block as normal
       builder.disallowBlockingCallsInside(LimitedExecutor.class.getName(), "actualRun");


### PR DESCRIPTION
Closes: #17016 (related)

The refactoring in [#17016] moved `acquireLock()` from `StateTransferTracker` into the inner class `CacheStateTransferTracker`, but the BlockHound allowlist in `CoreBlockHoundIntegration` still referenced the outer class name. Since the outer class no longer has an `acquireLock` method, the allowlist entry was silently a no-op, causing sporadic `Blocking call! jdk.internal.misc.Unsafe#park` failures in tests like `RestMergeTest` during partition merge/rebalance.

The fix updates the allowlist to reference `StateTransferTracker.CacheStateTransferTracker`.

Stack trace from CI:
```
java.lang.AssertionError: Blocking call! jdk.internal.misc.Unsafe#park
  at reactor.blockhound.BlockHoundRuntime.checkBlocking(BlockHoundRuntime.java:89)
  at java.base/jdk.internal.misc.Unsafe.park(Unsafe.java)
  at java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:223)
  at java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(...)
  at java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:323)
  at o.i.statetransfer.StateTransferTracker$CacheStateTransferTracker.acquireLock(StateTransferTracker.java:100)
  at o.i.statetransfer.StateTransferTracker$CacheStateTransferTracker.cacheTopologyUpdated(StateTransferTracker.java:191)
  at o.i.statetransfer.StateTransferManagerImpl$1.onTopologyReceived(StateTransferManagerImpl.java:126)
  at o.i.topology.LocalTopologyManagerImpl.updateCacheTopology(...)
  at o.i.util.concurrent.ActionSequencer.safeNonBlockingCall(ActionSequencer.java:59)
```

CI reference: https://github.com/infinispan/infinispan/actions/runs/26647966953

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - No new tests needed: this is a one-line fix to a BlockHound allowlist entry. The existing `RestMergeTest` validates the fix.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - No documentation needed: internal test infrastructure change.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool