### PR TITLE
[#17285] Fix CLI native package workflow

### DIFF
--- a/.github/workflows/release_cli_packages.yml
+++ b/.github/workflows/release_cli_packages.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Build deb package
         working-directory: artifacts/infinispan-cli-${{ inputs.version }}-${{ matrix.asset_name }}
         run: |
+          cp ../../distribution/src/main/packaging/cli/postinstall.sh .
+          cp ../../distribution/src/main/packaging/cli/preremove.sh .
           nfpm package \
             --config ../../distribution/src/main/packaging/cli/nfpm.yaml \
             --packager deb \
@@ -227,9 +229,10 @@ jobs:
       - name: Run JReleaser
         uses: jreleaser/release-action@v2
         with:
-          arguments: full-release --config-file distribution/src/main/packaging/cli/jreleaser/jreleaser.yml --project-version ${{ inputs.version }}
+          arguments: full-release --config-file distribution/src/main/packaging/cli/jreleaser/jreleaser.yml
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
+          JRELEASER_PROJECT_VERSION: ${{ inputs.version }}
 
       - name: Upload JReleaser output on failure
         if: failure()


### PR DESCRIPTION
Closes: #17285

Fixes two issues in the `release_cli_packages.yml` workflow that caused all three packaging jobs to fail during the 16.2.1 release ([run](https://github.com/infinispan/infinispan/actions/runs/26953345239)):

**nfpm: `postinstall.sh` not found**
nfpm resolves script paths in `nfpm.yaml` relative to the working directory, not the config file. Since the build step runs from the extracted artifact directory, the scripts need to be copied there first.

**JReleaser: `--project-version` unknown option**
The `--project-version` flag is only available on the `release` subcommand (auto-config mode), not `full-release`. Replaced with the `JRELEASER_PROJECT_VERSION` environment variable.

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
  - CI-only workflow fix; no unit tests applicable. Can be verified by re-running `workflow_dispatch` with version `16.2.1`.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.
  - No documentation changes needed.
- [x] Log messages of level `INFO` and above have been internationalized.
- [x] If the PR affects performance, include before/after benchmarks.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.

Created with the assistance of an AI tool