### PR TITLE
[#17617] Broken format specifiers in CachingSecurityRealm trace logging cause MissingFormatArgumentException + overall overhaul of log statements

### DIFF
--- a/cdi/common/src/main/java/org/infinispan/cdi/common/util/AbstractImmutableBean.java
+++ b/cdi/common/src/main/java/org/infinispan/cdi/common/util/AbstractImmutableBean.java
@@ -68,13 +68,13 @@ public abstract class AbstractImmutableBean<T> implements Bean<T> {
         this.name = name;
         if (qualifiers == null) {
             this.qualifiers = Collections.<Annotation>singleton(DefaultLiteral.INSTANCE);
-            log.trace("No qualifers provided for bean class " + beanClass + ", using singleton set of @Default");
+            log.tracef("No qualifiers provided for bean class %s, using singleton set of @Default", beanClass);
         } else {
             this.qualifiers = new HashSet<Annotation>(qualifiers);
         }
         if (scope == null) {
             this.scope = Dependent.class;
-            log.trace("No scope provided for bean class " + beanClass + ", using @Dependent");
+            log.tracef("No scope provided for bean class %s, using @Dependent", beanClass);
         } else {
             this.scope = scope;
         }
@@ -85,7 +85,7 @@ public abstract class AbstractImmutableBean<T> implements Bean<T> {
         }
         if (types == null) {
             this.types = Arrays2.<Type>asSet(Object.class, beanClass);
-            log.trace("No types provided for bean class " + beanClass + ", using [java.lang.Object.class, " + beanClass.getName() + ".class]");
+            log.tracef("No types provided for bean class %s, using [java.lang.Object.class, %s.class]", beanClass, beanClass.getName());
         } else {
             this.types = new HashSet<Type>(types);
         }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/SegmentKeyTracker.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/iteration/SegmentKeyTracker.java
@@ -62,7 +62,7 @@ class SegmentKeyTracker implements KeyTracker {
       }
       Set<WrappedByteArray> keys = keysPerSegment.get(segment);
       if (keys == null) {
-         if (log.isTraceEnabled()) log.tracef("Key %s maps to %d which is not present", Util.toStr(key), segment, segment);
+         if (log.isTraceEnabled()) log.tracef("Key %s maps to segment %d which is not present", Util.toStr(key), segment);
          throw new IllegalStateException("Segment " + segment + " already completed");
       }
       boolean result = keys.add(new WrappedByteArray(key));

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/HeaderDecoder.java
@@ -233,7 +233,7 @@ public class HeaderDecoder extends HintedReplayingDecoder<HeaderDecoder.State> {
                      if (operation != null && !(operation.isInstanceOf(AddClientListenerOperation.class))) {
                         throw HOTROD.operationIsNotAddClientListener(receivedMessageId, operation.toString());
                      } else if (log.isTraceEnabled()) {
-                        log.tracef("Received event for request %d", receivedMessageId, operation);
+                        log.tracef("Received event for request %d for %s", receivedMessageId, operation);
                      }
                      checkpoint(State.READ_CACHE_EVENT);
                      // the loop in HintedReplayingDecoder will call decode again

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationDispatcher.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/netty/OperationDispatcher.java
@@ -941,7 +941,7 @@ public class OperationDispatcher {
    public void handleChannelFailure(Channel channel, Throwable t) {
       assert channel.eventLoop().inEventLoop();
       if (!isRunning) {
-         log.tracef("Dispatcher is not running, ignoring received exception: " + t.toString());
+         log.tracef("Dispatcher is not running, ignoring received exception: %s", t);
          return;
       }
       SocketAddress unresolved = ChannelRecord.of(channel);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
@@ -28,7 +28,7 @@ public class RoundRobinBalancingStrategy implements FailoverRequestBalancingStra
    public void setServers(Collection<SocketAddress> servers) {
       this.servers = servers.toArray(new SocketAddress[0]);
       if (log.isTraceEnabled()) {
-         log.tracef("New server list is: " + Arrays.toString(this.servers));
+         log.tracef("New server list is: %s", Arrays.toString(this.servers));
       }
    }
 

--- a/core/src/main/java/org/infinispan/factories/impl/BasicComponentRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/factories/impl/BasicComponentRegistryImpl.java
@@ -718,7 +718,7 @@ public class BasicComponentRegistryImpl implements BasicComponentRegistry {
       }
 
       if (log.isTraceEnabled())
-         log.tracef("Changed status of " + name + " to " + state);
+         log.tracef("Changed status of %s to %s", name, state);
    }
 
    private void awaitWrapperState(ComponentWrapper wrapper, WrapperState expectedState) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -247,7 +247,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
             CacheEntry cacheEntry = rCtx.lookupEntry(key);
             if (cacheEntry == null) {
                // Data was lost
-               if (log.isTraceEnabled()) log.tracef(t, "Missing entry for " + key);
+               if (log.isTraceEnabled()) log.tracef(t, "Missing entry for %s", key);
             } else {
                cacheEntry.setSkipLookup(true);
             }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -805,7 +805,9 @@ public class DefaultCacheManager extends InternalCacheManager {
     * to ensure that they are safely terminated.
     */
    public void shutdownAllCaches() {
-      log.tracef("Attempting to shutdown cache manager: %s", getAddress());
+      if (log.isTraceEnabled()) {
+         log.tracef("Attempting to shutdown cache manager: %s", getAddress());
+      }
       authorizer.checkPermission(getSubject(), AuthorizationPermission.LIFECYCLE);
       try {
          performOnCaches(c -> {

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -805,7 +805,7 @@ public class DefaultCacheManager extends InternalCacheManager {
     * to ensure that they are safely terminated.
     */
    public void shutdownAllCaches() {
-      log.tracef("Attempting to shutdown cache manager: " + getAddress());
+      log.tracef("Attempting to shutdown cache manager: %s", getAddress());
       authorizer.checkPermission(getSubject(), AuthorizationPermission.LIFECYCLE);
       try {
          performOnCaches(c -> {

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -541,7 +541,7 @@ public class SingleFileStore<K, V> implements NonBlockingStore<K, V> {
             destChannel.write(bodyBuf, this.filePos + KEY_POS_LATEST);
             this.filePos += newFe.size;
             if (log.isTraceEnabled())
-               log.tracef("Recovered entry %s at %d:%d", key, newFe.size, newFe.offset, newFe.size);
+               log.tracef("Recovered entry %s at %d:%d", key, newFe.offset, newFe.size);
          }
       } catch (IOException e) {
          throw PERSISTENCE.persistedDataMigrationFailed(cacheName(), e);

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -1418,7 +1418,7 @@ public class SingleFileStore<K, V> implements NonBlockingStore<K, V> {
       if (newEntry != null)
          mergeAndLogEntry(newEntry, mergeCounter);
 
-      if (log.isTraceEnabled()) log.tracef("Total time taken for mergeFreeEntries: " + (timeService.wallClockTime() - startTime) + " (ms)");
+      if (log.isTraceEnabled()) log.tracef("Total time taken for mergeFreeEntries: %d (ms)", timeService.wallClockTime() - startTime);
    }
 
    private void mergeAndLogEntry(FileEntry entry, int mergeCounter) {

--- a/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Compactor.java
@@ -418,7 +418,7 @@ class Compactor {
 
    public void processRequest(CompletableFuture<Void> stageRequest) throws Throwable {
       if (terminateSignal) {
-         log.tracef("Compactor already terminated, ignoring request " + stageRequest);
+         log.tracef("Compactor already terminated, ignoring request %s", stageRequest);
          // Just ignore if terminated
          completeFuture(stageRequest);
          return;
@@ -467,7 +467,7 @@ class Compactor {
             completeFuture(request);
          }
       } catch (Throwable t) {
-         log.trace("Completing compaction for file: " + request.fileId + " due to exception!", t);
+         log.tracef(t, "Completing compaction for file: %s due to exception!", request.fileId);
          request.completeExceptionally(t);
       }
    }

--- a/core/src/main/java/org/infinispan/persistence/sifs/FileProvider.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/FileProvider.java
@@ -519,7 +519,7 @@ public class FileProvider {
             openFiles.remove(fileId, this);
             delete();
          } else {
-            log.debug("Marking file " + fileId + " for deletion");
+            log.debugf("Marking file %s for deletion", fileId);
             deleteOnClose = true;
          }
       }

--- a/core/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/core/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -174,8 +174,7 @@ class Index {
             }
             validCount = true;
          } else {
-            log.tracef("Previous index file cache segments " + cacheSegmentsCount + " doesn't match configured" +
-                  " cache segments " + cacheSegments);
+            log.tracef("Previous index file cache segments %d doesn't match configured cache segments %d", cacheSegmentsCount, cacheSegments);
          }
       } catch (IOException e) {
          log.tracef("Encountered IOException %s while reading index count file, assuming index dirty", e.getMessage());

--- a/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
+++ b/core/src/main/java/org/infinispan/reactive/publisher/impl/ClusterPublisherManagerImpl.java
@@ -709,7 +709,7 @@ public class ClusterPublisherManagerImpl<K, V> implements ClusterPublisherManage
          }
       }
       if (log.isTraceEnabled()) {
-         log.tracef("Targets determined to be %s on topology " + topology.getTopologyId(), targets);
+         log.tracef("Targets determined to be %s on topology %d", targets, topology.getTopologyId());
       }
       return targets;
    }

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -1352,7 +1352,7 @@ public class StateConsumerImpl implements StateConsumer {
       for (Map.Entry<Address, IntSet> e : sources.entrySet()) {
          addTransfer(e.getKey(), e.getValue());
       }
-      if (log.isTraceEnabled()) log.tracef("Finished adding inbound state transfer for segments %s", segments, cacheName);
+      if (log.isTraceEnabled()) log.tracef("Finished adding inbound state transfer for segments %s of cache %s", segments, cacheName);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/transaction/xa/TransactionXaAdapter.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/TransactionXaAdapter.java
@@ -130,7 +130,7 @@ public class TransactionXaAdapter extends AbstractEnlistmentAdapter implements X
          return RecoveryManager.RecoveryIterator.NOTHING;
       }
       if (log.isTraceEnabled())
-         log.trace("recover called: " + flag);
+         log.tracef("recover called: %s", flag);
 
       if (isFlag(flag, TMSTARTRSCAN)) {
          recoveryIterator = txTable.recoveryManager.getPreparedTransactionsFromCluster();

--- a/core/src/main/java/org/infinispan/util/concurrent/BlockingManagerImpl.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BlockingManagerImpl.java
@@ -385,7 +385,7 @@ public class BlockingManagerImpl implements BlockingManager {
       };
 
       var scheduledStage = new ScheduledBlockingFuture<>(supplier, traceId);
-      log.tracef("Scheduling supply operation %s for %s to run in %s %s", supplier, traceId, initialDelay, period, unit);
+      log.tracef("Scheduling supply operation %s for %s to run in %s %s %s", supplier, traceId, initialDelay, period, unit);
       scheduledStage.scheduledFuture = scheduledExecutorService.scheduleAtFixedRate(runnable, initialDelay, period, unit);
       return scheduledStage;
    }

--- a/gridfs/src/main/java/org/infinispan/gridfs/FileChunkMapper.java
+++ b/gridfs/src/main/java/org/infinispan/gridfs/FileChunkMapper.java
@@ -1,8 +1,8 @@
 package org.infinispan.gridfs;
 
 import org.infinispan.Cache;
-import org.jgroups.logging.Log;
-import org.jgroups.logging.LogFactory;
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
 
 /**
  * Takes care of properly storing and retrieving file chunks from/to cache.

--- a/gridfs/src/main/java/org/infinispan/gridfs/FileChunkMapper.java
+++ b/gridfs/src/main/java/org/infinispan/gridfs/FileChunkMapper.java
@@ -34,7 +34,7 @@ class FileChunkMapper {
       String key = getChunkKey(chunkNumber);
       byte[] val = cache.get(key);
       if (log.isTraceEnabled())
-         log.trace("fetching key=" + key + ": " + (val != null ? val.length + " bytes" : "null"));
+         log.tracef("fetching key=%s: %s", key, val != null ? val.length + " bytes" : "null");
       return val;
    }
 
@@ -43,7 +43,7 @@ class FileChunkMapper {
       byte[] val = trim(buffer, length);
       cache.put(key, val);
       if (log.isTraceEnabled())
-         log.trace("put(): key=" + key + ": " + val.length + " bytes");
+         log.tracef("put(): key=%s: %d bytes", key, val.length);
    }
 
    public void removeChunk(int chunkNumber) {

--- a/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java
+++ b/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java
@@ -410,7 +410,7 @@ public class PutFromLoadValidator {
     */
    public boolean beginInvalidatingRegion() {
       if (log.isTraceEnabled()) {
-         log.trace("Started invalidating region " + cache.getName());
+         log.tracef("Started invalidating region %s", cache.getName());
       }
       boolean ok = true;
       long now = timeSource.nextTimestamp();

--- a/hibernate/cache-v66/src/main/java/org/infinispan/hibernate/cache/v6/impl/BaseRegionImpl.java
+++ b/hibernate/cache-v66/src/main/java/org/infinispan/hibernate/cache/v6/impl/BaseRegionImpl.java
@@ -89,7 +89,7 @@ abstract class BaseRegionImpl implements Region, InfinispanBaseRegion, ExtendedS
    @Override
    public void beginInvalidation() {
       if (log.isTraceEnabled()) {
-         log.trace("Begin invalidating region: " + name);
+         log.tracef("Begin invalidating region: %s", name);
       }
       synchronized (this) {
          lastRegionInvalidation = Long.MAX_VALUE;
@@ -106,7 +106,7 @@ abstract class BaseRegionImpl implements Region, InfinispanBaseRegion, ExtendedS
          }
       }
       if (log.isTraceEnabled()) {
-         log.trace("End invalidating region: " + name);
+         log.tracef("End invalidating region: %s", name);
       }
    }
 

--- a/lock/src/main/java/org/infinispan/lock/impl/lock/ClusteredLockImpl.java
+++ b/lock/src/main/java/org/infinispan/lock/impl/lock/ClusteredLockImpl.java
@@ -349,7 +349,7 @@ public class ClusteredLockImpl implements ClusteredLock {
          }
          int viewChangeUnlockValue = viewChangeUnlockHappening.incrementAndGet();
          if (log.isTraceEnabled()) {
-            log.tracef("LOCK[%s] viewChangeUnlockHappening value in %s ", getName(), viewChangeUnlockValue, originator);
+            log.tracef("LOCK[%s] viewChangeUnlockHappening value %s from %s", getName(), viewChangeUnlockValue, originator);
          }
          unlock(null, possibleOwners)
                .whenComplete((unlockResult, ex) -> {
@@ -358,7 +358,7 @@ public class ClusteredLockImpl implements ClusteredLock {
                   }
                   int viewChangeUnlockValueAfterUnlock = viewChangeUnlockHappening.decrementAndGet();
                   if (log.isTraceEnabled()) {
-                     log.tracef("LOCK[%s] viewChangeUnlockHappening value in %s ", getName(), viewChangeUnlockValueAfterUnlock, originator);
+                     log.tracef("LOCK[%s] viewChangeUnlockHappening value %s from %s", getName(), viewChangeUnlockValueAfterUnlock, originator);
                   }
                   if (ex == null) {
                      if (log.isTraceEnabled()) {

--- a/server/core/src/main/java/org/infinispan/server/core/backup/resources/CacheResource.java
+++ b/server/core/src/main/java/org/infinispan/server/core/backup/resources/CacheResource.java
@@ -189,7 +189,7 @@ public class CacheResource extends AbstractContainerResource {
                try {
                   return is.available() > 0;
                } catch (IOException e) {
-                  log.errorf("Failed checking data available to recover %s", cacheName, e);
+                  log.errorf(e, "Failed checking data available to recover %s", cacheName);
                   return false;
                }
             }
@@ -199,7 +199,7 @@ public class CacheResource extends AbstractContainerResource {
                try {
                   return readMessageStream(serCtx, CacheBackupEntry.class, is);
                } catch (IOException e) {
-                  log.errorf("Failed reading entry to recover %s", cacheName, e);
+                  log.errorf(e, "Failed reading entry to recover %s", cacheName);
                   throw new CacheException(e);
                }
             }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ClientListenerRegistry.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ClientListenerRegistry.java
@@ -368,7 +368,7 @@ class ClientListenerRegistry {
       void init() {
          lockManager = ((AdvancedCache<?, ?>) cache).getLockManager();
          ch.closeFuture().addListener(f -> {
-            log.debug("Channel disconnected, removing event sender listener for id: " + Util.printArray(listenerId));
+            log.debugf("Channel disconnected, removing event sender listener for id: %s", Util.printArray(listenerId));
             unblockCommands();
             removeClientListener(listenerId, cache);
          });

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ClientListenerRegistry.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ClientListenerRegistry.java
@@ -368,7 +368,9 @@ class ClientListenerRegistry {
       void init() {
          lockManager = ((AdvancedCache<?, ?>) cache).getLockManager();
          ch.closeFuture().addListener(f -> {
-            log.debugf("Channel disconnected, removing event sender listener for id: %s", Util.printArray(listenerId));
+            if (log.isDebugEnabled()) {
+               log.debugf("Channel disconnected, removing event sender listener for id: %s", Util.printArray(listenerId));
+            }
             unblockCommands();
             removeClientListener(listenerId, cache);
          });

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Encoder2x.java
@@ -635,8 +635,8 @@ class Encoder2x implements VersionedEncoder {
             ch.getMembers().contains(e.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
       if (log.isTraceEnabled()) {
-         log.trace("Topology cache contains: " + h.serverEndpointsMap);
-         log.trace("After read consistent hash filter, members are: " + members);
+         log.tracef("Topology cache contains: %s", h.serverEndpointsMap);
+         log.tracef("After read consistent hash filter, members are: %s", members);
       }
 
       if (members.isEmpty()) {

--- a/server/insights/src/main/java/org/infinispan/server/insights/InsightsService.java
+++ b/server/insights/src/main/java/org/infinispan/server/insights/InsightsService.java
@@ -110,7 +110,7 @@ public class InsightsService {
       }
 
       if (log.isDebugEnabled()) {
-         log.debug("Starting Insights integration. Current Infinispan report: \n\r" + report.toPrettyString());
+         log.debugf("Starting Insights integration. Current Infinispan report: \n\r%s", report.toPrettyString());
       }
       Json nodeIdReport = report.at("node-id");
       String nodeId = (nodeIdReport.isNull()) ? UUID.randomUUID().toString() : nodeIdReport.asString();

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/list/blocking/AbstractBlockingPop.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/list/blocking/AbstractBlockingPop.java
@@ -81,7 +81,7 @@ public abstract class AbstractBlockingPop extends RespCommand implements Resp3Co
 
    private CompletableFuture<Collection<byte[]>> addSubscriber(PopConfiguration configuration, Resp3Handler handler) {
       if (log.isTraceEnabled()) {
-         log.tracef("Subscriber for keys: " + configuration.keys());
+         log.tracef("Subscriber for keys: %s", configuration.keys());
       }
       AdvancedCache<byte[], Object> cache = handler.typedCache(null);
       DataConversion vc = cache.getValueDataConversion();

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/pubsub/PSUBSCRIBE.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/pubsub/PSUBSCRIBE.java
@@ -53,7 +53,7 @@ public class PSUBSCRIBE extends RespCommand implements Resp3Command, PubSubResp3
       AggregateCompletionStage<Void> aggregateCompletionStage = CompletionStages.aggregateCompletionStage();
       for (byte[] patternArg : arguments) {
          if (log.isTraceEnabled()) {
-            log.tracef("Subscriber for pattern: " + CharsetUtil.UTF_8.decode(ByteBuffer.wrap(patternArg)));
+            log.tracef("Subscriber for pattern: %s", CharsetUtil.UTF_8.decode(ByteBuffer.wrap(patternArg)));
          }
          WrappedByteArray wrappedByteArray = new WrappedByteArray(patternArg);
          if (handler.patternSubscribers().get(wrappedByteArray) == null) {

--- a/server/resp/src/main/java/org/infinispan/server/resp/commands/pubsub/SUBSCRIBE.java
+++ b/server/resp/src/main/java/org/infinispan/server/resp/commands/pubsub/SUBSCRIBE.java
@@ -52,7 +52,7 @@ public class SUBSCRIBE extends RespCommand implements Resp3Command, PubSubResp3C
       AggregateCompletionStage<Void> aggregateCompletionStage = CompletionStages.aggregateCompletionStage();
       for (byte[] keyChannel : arguments) {
          if (log.isTraceEnabled()) {
-            log.tracef("Subscriber for channel: " + CharsetUtil.UTF_8.decode(ByteBuffer.wrap(keyChannel)));
+            log.tracef("Subscriber for channel: %s", CharsetUtil.UTF_8.decode(ByteBuffer.wrap(keyChannel)));
          }
          WrappedByteArray wrappedByteArray = new WrappedByteArray(keyChannel);
          if (handler.specificChannelSubscribers().get(wrappedByteArray) == null) {

--- a/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/Charset.java
+++ b/server/rest/src/main/java/org/infinispan/rest/operations/mediatypes/Charset.java
@@ -44,7 +44,7 @@ public class Charset {
          try {
             return new Charset(mediaType.substring(indexOfCharset + CHARSET_HEADER.length()));
          } catch (Exception e) {
-            logger.trace("Unrecognized charset from media type " + mediaType, e);
+            logger.tracef(e, "Unrecognized charset from media type %s", mediaType);
          }
       }
       return null;

--- a/server/runtime/src/main/java/org/infinispan/server/security/realm/CachingSecurityRealm.java
+++ b/server/runtime/src/main/java/org/infinispan/server/security/realm/CachingSecurityRealm.java
@@ -85,14 +85,14 @@ public class CachingSecurityRealm implements SecurityRealm {
          public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, final AlgorithmParameterSpec parameterSpec) throws RealmUnavailableException {
             if (credentials.contains(credentialType, algorithmName, parameterSpec)) {
                if (log.isTraceEnabled()) {
-                  log.tracef("getCredentialAcquireSupport credentialType='%s' with algorithmName='%' known for pincipal='%s'", credentialType.getName(), algorithmName, principal.getName());
+                  log.tracef("getCredentialAcquireSupport credentialType='%s' with algorithmName='%s' known for principal='%s'", credentialType.getName(), algorithmName, principal.getName());
                }
                return credentials.getCredentialAcquireSupport(credentialType, algorithmName, parameterSpec);
             }
             Credential credential = identity.getCredential(credentialType, algorithmName, parameterSpec);
             if (credential != null) {
                if (log.isTraceEnabled()) {
-                  log.tracef("getCredentialAcquireSupport Credential for credentialType='%s' with algorithmName='%' obtained from identity - caching for principal='%s'",
+                  log.tracef("getCredentialAcquireSupport Credential for credentialType='%s' with algorithmName='%s' obtained from identity - caching for principal='%s'",
                         credentialType.getName(), algorithmName, principal.getName());
                }
                credentials = credentials.withCredential(credential);
@@ -122,14 +122,14 @@ public class CachingSecurityRealm implements SecurityRealm {
          public <C extends Credential> C getCredential(Class<C> credentialType, String algorithmName) throws RealmUnavailableException {
             if (credentials.contains(credentialType, algorithmName)) {
                if (log.isTraceEnabled()) {
-                  log.tracef("getCredential credentialType='%s' with algorithmName='%' cached, returning cached credential for principal='%s'", credentialType.getName(), algorithmName, principal.getName());
+                  log.tracef("getCredential credentialType='%s' with algorithmName='%s' cached, returning cached credential for principal='%s'", credentialType.getName(), algorithmName, principal.getName());
                }
                return credentials.getCredential(credentialType, algorithmName);
             }
             Credential credential = identity.getCredential(credentialType, algorithmName);
             if (credential != null) {
                if (log.isTraceEnabled()) {
-                  log.tracef("getCredential credentialType='%s' with algorithmName='%' obtained from identity - caching.", credentialType.getName(), algorithmName);
+                  log.tracef("getCredential credentialType='%s' with algorithmName='%s' obtained from identity - caching.", credentialType.getName(), algorithmName);
                }
                credentials = credentials.withCredential(credential);
             }
@@ -171,14 +171,14 @@ public class CachingSecurityRealm implements SecurityRealm {
             if (PasswordGuessEvidence.class.isAssignableFrom(evidenceType)) {
                if (credentials.canVerify(evidenceType, algorithmName)) {
                   if (log.isTraceEnabled()) {
-                     log.tracef("getEvidenceVerifySupport evidenceType='%s' with algorithmName='%' can verify from cache for principal='%s'", evidenceType.getName(), algorithmName, principal.getName());
+                     log.tracef("getEvidenceVerifySupport evidenceType='%s' with algorithmName='%s' can verify from cache for principal='%s'", evidenceType.getName(), algorithmName, principal.getName());
                   }
                   return SupportLevel.SUPPORTED;
                }
                Credential credential = identity.getCredential(PasswordCredential.class);
                if (credential != null) {
                   if (log.isTraceEnabled()) {
-                     log.tracef("getEvidenceVerifySupport evidenceType='%s' with algorithmName='%' credential obtained from identity and cached for principal='%s'",
+                     log.tracef("getEvidenceVerifySupport evidenceType='%s' with algorithmName='%s' credential obtained from identity and cached for principal='%s'",
                            evidenceType.getName(), algorithmName, principal.getName());
                   }
                   credentials = credentials.withCredential(credential);

--- a/spring/embedded/src/main/java/org/infinispan/spring/embedded/support/InfinispanNamedEmbeddedCacheFactoryBean.java
+++ b/spring/embedded/src/main/java/org/infinispan/spring/embedded/support/InfinispanNamedEmbeddedCacheFactoryBean.java
@@ -167,7 +167,7 @@ public class InfinispanNamedEmbeddedCacheFactoryBean<K, V> implements FactoryBea
             this.infinispanEmbeddedCacheManager.defineConfiguration(cacheName, builder.build());
             break;
          case NAMED:
-            logger.debug("ConfigurationTemplateMode is NAMED: using a named Configuration [" + cacheName + "]");
+            logger.debugf("ConfigurationTemplateMode is NAMED: using a named Configuration [%s]", cacheName);
             break;
          case DEFAULT:
             logger.debug("ConfigurationTemplateMode is DEFAULT.");
@@ -193,12 +193,12 @@ public class InfinispanNamedEmbeddedCacheFactoryBean<K, V> implements FactoryBea
    private String obtainEffectiveCacheName() {
       if (StringUtils.hasText(this.cacheName)) {
          if (logger.isDebugEnabled()) {
-            logger.debug("Using custom cache name [" + this.cacheName + "]");
+            logger.debugf("Using custom cache name [%s]", this.cacheName);
          }
          return this.cacheName;
       } else {
          if (logger.isDebugEnabled()) {
-            logger.debug("Using bean name [" + this.beanName + "] as cache name");
+            logger.debugf("Using bean name [%s] as cache name", this.beanName);
          }
          return this.beanName;
       }

--- a/spring/remote/src/main/java/org/infinispan/spring/remote/AbstractRemoteCacheManagerFactory.java
+++ b/spring/remote/src/main/java/org/infinispan/spring/remote/AbstractRemoteCacheManagerFactory.java
@@ -60,16 +60,13 @@ public abstract class AbstractRemoteCacheManagerFactory {
       final Properties answer;
       if (this.configurationProperties != null) {
          answer = this.configurationPropertiesOverrides.override(this.configurationProperties);
-         logger.debug("Using user-defined properties [" + this.configurationProperties
-                                 + "] for configuring RemoteCacheManager");
+         logger.debugf("Using user-defined properties [%s] for configuring RemoteCacheManager", this.configurationProperties);
       } else if (this.configurationPropertiesFileLocation != null) {
          answer = loadPropertiesFromFile(this.configurationPropertiesFileLocation);
-         logger.debug("Loading properties from file [" + this.configurationProperties
-                                 + "] for configuring RemoteCacheManager");
+         logger.debugf("Loading properties from file [%s] for configuring RemoteCacheManager", this.configurationProperties);
       } else if (!this.configurationPropertiesOverrides.isEmpty()) {
          answer = this.configurationPropertiesOverrides.override(new Properties());
-         logger.debug("Using explicitly set configuration settings [" + answer
-                                 + "] for configuring RemoteCacheManager");
+         logger.debugf("Using explicitly set configuration settings [%s] for configuring RemoteCacheManager", answer);
       } else {
          logger.debug("No configuration properties. RemoteCacheManager will use default configuration.");
          RemoteCacheManager remoteCacheManager = new RemoteCacheManager(false);

--- a/spring/remote/src/main/java/org/infinispan/spring/remote/support/InfinispanNamedRemoteCacheFactoryBean.java
+++ b/spring/remote/src/main/java/org/infinispan/spring/remote/support/InfinispanNamedRemoteCacheFactoryBean.java
@@ -60,12 +60,12 @@ public class InfinispanNamedRemoteCacheFactoryBean<K, V> implements FactoryBean<
    private String obtainEffectiveCacheName() {
       if (StringUtils.hasText(this.cacheName)) {
          if (logger.isDebugEnabled()) {
-            logger.debug("Using custom cache name [" + this.cacheName + "]");
+            logger.debugf("Using custom cache name [%s]", this.cacheName);
          }
          return this.cacheName;
       } else {
          if (logger.isDebugEnabled()) {
-            logger.debug("Using bean name [" + this.beanName + "] as cache name");
+            logger.debugf("Using bean name [%s] as cache name", this.beanName);
          }
          return this.beanName;
       }

--- a/testing/src/main/java/org/infinispan/testing/TestSuiteProgress.java
+++ b/testing/src/main/java/org/infinispan/testing/TestSuiteProgress.java
@@ -73,11 +73,11 @@ public class TestSuiteProgress {
    }
 
    public void configurationStarted(String name) {
-      log.debug("Test configuration started: " + name);
+      log.debugf("Test configuration started: %s", name);
    }
 
    public void configurationFinished(String name) {
-      log.debug("Test configuration finished: " + name);
+      log.debugf("Test configuration finished: %s", name);
    }
 
    public void configurationFailed(String name, Throwable exception) {

--- a/testing/src/main/java/org/infinispan/testing/log4j/BoundedPurgePolicy.java
+++ b/testing/src/main/java/org/infinispan/testing/log4j/BoundedPurgePolicy.java
@@ -67,7 +67,7 @@ public class BoundedPurgePolicy extends AbstractLifeCycle implements PurgePolicy
          Iterator<String> iterator = appendersUsage.keySet().iterator();
          while (appendersUsage.size() > maxSize) {
             String key = iterator.next();
-            LOGGER.debug("Removing appender " + key);
+            LOGGER.debug("Removing appender {}", key);
             iterator.remove();
             routingAppender.getAppenders().get(key).getAppender().stop();
             routingAppender.deleteAppender(key);


### PR DESCRIPTION
We ran into some issues with infinispan logging while debugging WF clustering.
As a result I went and audited all log messages and found multiple issues.
Review per commit to see individual fixes, all grouped into each commit.
Note that with proper usage of e.g. tracef some of the guards are now not required; but decided to keep them in as there is no harm and next time somebody copies the block don't have to reason about whether it's expensive and needs to be guarded or not.

https://github.com/infinispan/infinispan/issues/17617