### PR TITLE
[#14185] Add GitHub workflow for PMD Copy/Paste Detector

### DIFF
--- a/.github/scripts/filter-cpd-by-changed-files.py
+++ b/.github/scripts/filter-cpd-by-changed-files.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Filter Maven PMD-CPD reports to retain only duplications that reference
+at least one Java file changed by the current PR.
+
+CPD is inherently cross-file (a duplication, by definition, involves at
+least two files), so the Maven goal must scan whole modules. This script
+narrows the *output* to PR-scoped signal without giving up that detection.
+
+Usage:
+    filter-cpd-by-changed-files.py <changed-files-list>
+
+<changed-files-list> is a text file with one repo-root-relative path per line.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "Usage: filter-cpd-by-changed-files.py <changed-files-list>",
+            file=sys.stderr,
+        )
+        return 2
+
+    changed = {
+        str(Path(line.strip()).resolve())
+        for line in Path(argv[1]).read_text().splitlines()
+        if line.strip()
+    }
+    if not changed:
+        print("No changed files listed; nothing to filter.")
+        return 0
+
+    reports = sorted(Path(".").rglob("target/cpd.xml"))
+    if not reports:
+        print("No cpd.xml reports found.")
+        return 0
+
+    for report in reports:
+        try:
+            tree = ET.parse(report)
+        except ET.ParseError as exc:
+            print(f"{report}: parse error ({exc}); leaving file untouched")
+            continue
+        root = tree.getroot()
+        kept = 0
+        dropped = 0
+        for dup in list(root.findall("duplication")):
+            paths = {
+                str(Path(f.get("path", "")).resolve())
+                for f in dup.findall("file")
+            }
+            if paths & changed:
+                kept += 1
+            else:
+                root.remove(dup)
+                dropped += 1
+        if kept == 0:
+            report.unlink()
+            print(f"{report}: removed (no PR-relevant duplications)")
+        else:
+            tree.write(report, encoding="UTF-8", xml_declaration=True)
+            print(f"{report}: kept {kept}, dropped {dropped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/filter-cpd-by-changed-files.py
+++ b/.github/scripts/filter-cpd-by-changed-files.py
@@ -17,6 +17,17 @@ import sys
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
+# PMD 7 emits cpd-report XML in this default namespace. Older PMD versions
+# (and some custom configurations) write it without a namespace. Register
+# the prefix-less namespace so ElementTree round-trips the output without
+# inventing a "ns0:" prefix.
+CPD_NS = "https://pmd-code.org/schema/cpd-report"
+ET.register_namespace("", CPD_NS)
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
 
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
@@ -47,13 +58,12 @@ def main(argv: list[str]) -> int:
             print(f"{report}: parse error ({exc}); leaving file untouched")
             continue
         root = tree.getroot()
+        duplications = [el for el in list(root) if local_name(el.tag) == "duplication"]
         kept = 0
         dropped = 0
-        for dup in list(root.findall("duplication")):
-            paths = {
-                str(Path(f.get("path", "")).resolve())
-                for f in dup.findall("file")
-            }
+        for dup in duplications:
+            files = [el for el in dup if local_name(el.tag) == "file"]
+            paths = {str(Path(f.get("path", "")).resolve()) for f in files}
             if paths & changed:
                 kept += 1
             else:

--- a/.github/scripts/format-cpd-comment.py
+++ b/.github/scripts/format-cpd-comment.py
@@ -10,6 +10,10 @@ leading HTML marker (``<!-- cpd-comment -->``) so the workflow's
 sticky-comment logic can find and update the existing comment instead
 of appending a new one on every push.
 
+On a clean run (no PR-relevant duplications) the script writes nothing
+to stdout — the workflow uses an empty body as the signal to skip
+posting and to drop any pre-existing sticky comment.
+
 A hard cap (``MAX_BODY_CHARS``) prevents the body from approaching
 GitHub's 65 535-character comment limit; codefragments are also
 individually capped (``MAX_FRAGMENT_LINES`` / ``MAX_FRAGMENT_CHARS``)
@@ -97,17 +101,7 @@ def render_report(report: Path) -> tuple[int, str]:
 def main() -> int:
     reports = sorted(Path(".").rglob("target/cpd.xml"))
 
-    header = [
-        MARKER,
-        "## PMD CPD findings",
-        "",
-        "_Filtered to duplications that involve at least one file changed by this PR._",
-        "",
-    ]
-
     if not reports:
-        body = "\n".join(header + ["**No PR-relevant CPD findings.**"])
-        sys.stdout.write(body)
         return 0
 
     sections: list[str] = []
@@ -119,10 +113,15 @@ def main() -> int:
             total += count
 
     if not sections:
-        body = "\n".join(header + ["**No PR-relevant CPD findings.**"])
-        sys.stdout.write(body)
         return 0
 
+    header = [
+        MARKER,
+        "## PMD CPD findings",
+        "",
+        "_Filtered to duplications that involve at least one file changed by this PR._",
+        "",
+    ]
     header.append(f"**Total:** {total} duplication(s) across {len(sections)} module(s).")
     header.append("")
     parts = header + sections

--- a/.github/scripts/format-cpd-comment.py
+++ b/.github/scripts/format-cpd-comment.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Format the filtered Maven PMD-CPD reports as a single Markdown body that
+can be posted as a pull-request comment.
+
+Reads every ``**/target/cpd.xml`` under the current working directory
+(``filter-cpd-by-changed-files.py`` runs first and removes reports that
+have no PR-relevant duplications, so this script only sees what should
+be reported). Emits the rendered Markdown on stdout, including a
+leading HTML marker (``<!-- cpd-comment -->``) so the workflow's
+sticky-comment logic can find and update the existing comment instead
+of appending a new one on every push.
+
+A hard cap (``MAX_BODY_CHARS``) prevents the body from approaching
+GitHub's 65 535-character comment limit; codefragments are also
+individually capped (``MAX_FRAGMENT_LINES`` / ``MAX_FRAGMENT_CHARS``)
+so a single very long duplication cannot dominate the comment.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+MARKER = "<!-- cpd-comment -->"
+MAX_BODY_CHARS = 60000
+MAX_FRAGMENT_LINES = 12
+MAX_FRAGMENT_CHARS = 600
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def truncate_fragment(text: str) -> str:
+    if not text:
+        return ""
+    lines = text.splitlines()
+    truncated = False
+    if len(lines) > MAX_FRAGMENT_LINES:
+        lines = lines[:MAX_FRAGMENT_LINES]
+        truncated = True
+    body = "\n".join(lines)
+    if len(body) > MAX_FRAGMENT_CHARS:
+        body = body[:MAX_FRAGMENT_CHARS].rstrip()
+        truncated = True
+    if truncated:
+        body += "\n…  (truncated; see uploaded `cpd-reports` artifact for full fragment)"
+    return body
+
+
+def render_duplication(dup: ET.Element, idx: int) -> str:
+    tokens = dup.get("tokens", "?")
+    lines = dup.get("lines", "?")
+    files = [el for el in dup if local_name(el.tag) == "file"]
+    fragments = [el for el in dup if local_name(el.tag) == "codefragment"]
+
+    parts: list[str] = []
+    parts.append(f"#### Duplication {idx} — {lines} lines / {tokens} tokens")
+    if files:
+        parts.append("Files:")
+        for f in files:
+            path = f.get("path", "(unknown)")
+            start = f.get("line", "?")
+            end = f.get("endline") or f.get("endLine") or start
+            parts.append(f"- `{path}` (lines {start}–{end})")
+    if fragments and fragments[0].text:
+        parts.append("")
+        parts.append("```java")
+        parts.append(truncate_fragment(fragments[0].text))
+        parts.append("```")
+    return "\n".join(parts)
+
+
+def render_report(report: Path) -> tuple[int, str]:
+    try:
+        tree = ET.parse(report)
+    except ET.ParseError as exc:
+        return 0, f"_Could not parse `{report}`: {exc}_"
+    root = tree.getroot()
+    dups = [el for el in list(root) if local_name(el.tag) == "duplication"]
+    if not dups:
+        return 0, ""
+
+    # The report path looks like ``<module>/target/cpd.xml``; use the
+    # nearest non-"target" ancestor as a human-readable module label.
+    module_dir = report.parent.parent
+    module = module_dir.name if module_dir.name else "(root)"
+
+    body: list[str] = []
+    body.append(f"### Module: `{module}` — {len(dups)} duplication(s)")
+    for i, dup in enumerate(dups, start=1):
+        body.append("")
+        body.append(render_duplication(dup, i))
+    return len(dups), "\n".join(body)
+
+
+def main() -> int:
+    reports = sorted(Path(".").rglob("target/cpd.xml"))
+
+    header = [
+        MARKER,
+        "## PMD CPD findings",
+        "",
+        "_Filtered to duplications that involve at least one file changed by this PR._",
+        "",
+    ]
+
+    if not reports:
+        body = "\n".join(header + ["**No PR-relevant CPD findings.**"])
+        sys.stdout.write(body)
+        return 0
+
+    sections: list[str] = []
+    total = 0
+    for report in reports:
+        count, section = render_report(report)
+        if count:
+            sections.append(section)
+            total += count
+
+    if not sections:
+        body = "\n".join(header + ["**No PR-relevant CPD findings.**"])
+        sys.stdout.write(body)
+        return 0
+
+    header.append(f"**Total:** {total} duplication(s) across {len(sections)} module(s).")
+    header.append("")
+    parts = header + sections
+
+    body = "\n\n".join(parts)
+    if len(body) > MAX_BODY_CHARS:
+        truncated_note = (
+            "\n\n---\n_Comment truncated — see uploaded `cpd-reports` artifact for the full report._"
+        )
+        body = body[: MAX_BODY_CHARS - len(truncated_note)] + truncated_note
+
+    sys.stdout.write(body)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cpd.yml
+++ b/.github/workflows/cpd.yml
@@ -78,10 +78,13 @@ jobs:
       - name: Comment CPD findings on PR
         # Render the filtered cpd.xml reports as a single Markdown body and
         # upsert it as a sticky pull-request comment (identified by the
-        # `<!-- cpd-comment -->` marker the script prepends). continue-on-error
-        # lets the workflow stay green if GITHUB_TOKEN is read-only for a fork
-        # PR (a 403 from the comments API); the cpd-reports artifact below is
-        # still uploaded as the fallback view.
+        # `<!-- cpd-comment -->` marker the script prepends). On a clean run
+        # the formatter writes an empty body; in that case we delete any
+        # pre-existing sticky comment so a previously-flagged duplication
+        # that has since been cleaned up doesn't leave a stale comment.
+        # continue-on-error lets the workflow stay green if GITHUB_TOKEN is
+        # read-only for a fork PR (a 403 from the comments API); the
+        # cpd-reports artifact below is still uploaded as the fallback view.
         if: steps.changed.outputs.any == 'true'
         continue-on-error: true
         env:
@@ -95,7 +98,14 @@ jobs:
             --paginate \
             --jq '.[] | select(.body | startswith("<!-- cpd-comment -->")) | .id' \
             | head -1 || true)
-          if [[ -n "$EXISTING_ID" ]]; then
+          if [[ ! -s cpd-comment.md ]]; then
+            if [[ -n "$EXISTING_ID" ]]; then
+              gh api -X DELETE "repos/$REPO/issues/comments/$EXISTING_ID" > /dev/null
+              echo "No PR-relevant CPD findings; deleted stale CPD comment (id=$EXISTING_ID)."
+            else
+              echo "No PR-relevant CPD findings; nothing to post."
+            fi
+          elif [[ -n "$EXISTING_ID" ]]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" \
               -F body=@cpd-comment.md > /dev/null
             echo "Updated existing CPD comment (id=$EXISTING_ID)."

--- a/.github/workflows/cpd.yml
+++ b/.github/workflows/cpd.yml
@@ -1,0 +1,50 @@
+name: PMD CPD on PR changes
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.editorconfig'
+      - 'CODEOWNERS'
+      - 'documentation/**'
+
+jobs:
+  cpd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0    # Need full history to compare base vs head
+
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
+
+      - name: Detect Java changes
+        id: changed
+        run: |
+          chmod +x .github/scripts/changed-classes.sh
+          CLASSES=$(.github/scripts/changed-classes.sh origin/${{ github.event.pull_request.base.ref }} HEAD)
+          echo "classes=$CLASSES" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if no Java changes
+        if: steps.changed.outputs.classes == 'NO_CHANGES'
+        run: echo "No Java sources changed. Skipping CPD."
+
+      - name: Run PMD Copy/Paste Detector
+        if: steps.changed.outputs.classes != 'NO_CHANGES'
+        run: mvn -B -DskipTests=true org.apache.maven.plugins:maven-pmd-plugin:cpd
+
+      - name: Upload CPD reports
+        if: always() && steps.changed.outputs.classes != 'NO_CHANGES'
+        uses: actions/upload-artifact@v7
+        with:
+          name: cpd-reports
+          path: '**/target/cpd.xml'
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/cpd.yml
+++ b/.github/workflows/cpd.yml
@@ -13,12 +13,15 @@ on:
       - 'CODEOWNERS'
       - 'documentation/**'
 
+permissions:
+  contents: read
+
 jobs:
   cpd:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0    # Need full history to compare base vs head
 
@@ -42,7 +45,7 @@ jobs:
 
       - name: Upload CPD reports
         if: always() && steps.changed.outputs.classes != 'NO_CHANGES'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cpd-reports
           path: '**/target/cpd.xml'

--- a/.github/workflows/cpd.yml
+++ b/.github/workflows/cpd.yml
@@ -28,23 +28,54 @@ jobs:
       - name: Setup Java
         uses: ./.github/actions/setup-java
 
-      - name: Detect Java changes
+      - name: Detect changed Java files and owning modules
         id: changed
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |
-          chmod +x .github/scripts/changed-classes.sh
-          CLASSES=$(.github/scripts/changed-classes.sh origin/${{ github.event.pull_request.base.ref }} HEAD)
-          echo "classes=$CLASSES" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          FILES=$(git diff --name-only "$BASE_REF"...HEAD \
+            | grep -E '.*/src/(main|test)/java/.*\.java$' || true)
+          if [[ -z "$FILES" ]]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            echo "No Java sources changed; CPD will be skipped."
+            exit 0
+          fi
+          printf '%s\n' "$FILES" > changed-java-files.txt
+          # Map each changed file to its closest ancestor pom.xml directory
+          # (the owning Maven module) and de-duplicate so we can pass them
+          # to `mvn -pl` rather than scanning the whole reactor.
+          MODULES=$(while read -r f; do
+            d=$(dirname "$f")
+            while [[ "$d" != "." && ! -f "$d/pom.xml" ]]; do
+              d=$(dirname "$d")
+            done
+            if [[ -f "$d/pom.xml" ]]; then
+              echo "$d"
+            fi
+          done < changed-java-files.txt | sort -u | paste -sd, -)
+          echo "any=true" >> "$GITHUB_OUTPUT"
+          echo "modules=$MODULES" >> "$GITHUB_OUTPUT"
+          echo "Modules to scan: $MODULES"
 
       - name: Skip if no Java changes
-        if: steps.changed.outputs.classes == 'NO_CHANGES'
+        if: steps.changed.outputs.any != 'true'
         run: echo "No Java sources changed. Skipping CPD."
 
-      - name: Run PMD Copy/Paste Detector
-        if: steps.changed.outputs.classes != 'NO_CHANGES'
-        run: mvn -B -DskipTests=true org.apache.maven.plugins:maven-pmd-plugin:cpd
+      - name: Run PMD Copy/Paste Detector on changed modules
+        if: steps.changed.outputs.any == 'true'
+        env:
+          CHANGED_MODULES: ${{ steps.changed.outputs.modules }}
+        run: |
+          mvn -B -DskipTests=true -pl "$CHANGED_MODULES" \
+            org.apache.maven.plugins:maven-pmd-plugin:cpd
+
+      - name: Filter CPD reports to PR-changed files
+        if: steps.changed.outputs.any == 'true'
+        run: python3 .github/scripts/filter-cpd-by-changed-files.py changed-java-files.txt
 
       - name: Upload CPD reports
-        if: always() && steps.changed.outputs.classes != 'NO_CHANGES'
+        if: always() && steps.changed.outputs.any == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cpd-reports

--- a/.github/workflows/cpd.yml
+++ b/.github/workflows/cpd.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   cpd:
@@ -73,6 +74,35 @@ jobs:
       - name: Filter CPD reports to PR-changed files
         if: steps.changed.outputs.any == 'true'
         run: python3 .github/scripts/filter-cpd-by-changed-files.py changed-java-files.txt
+
+      - name: Comment CPD findings on PR
+        # Render the filtered cpd.xml reports as a single Markdown body and
+        # upsert it as a sticky pull-request comment (identified by the
+        # `<!-- cpd-comment -->` marker the script prepends). continue-on-error
+        # lets the workflow stay green if GITHUB_TOKEN is read-only for a fork
+        # PR (a 403 from the comments API); the cpd-reports artifact below is
+        # still uploaded as the fallback view.
+        if: steps.changed.outputs.any == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/format-cpd-comment.py > cpd-comment.md
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("<!-- cpd-comment -->")) | .id' \
+            | head -1 || true)
+          if [[ -n "$EXISTING_ID" ]]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING_ID" \
+              -F body=@cpd-comment.md > /dev/null
+            echo "Updated existing CPD comment (id=$EXISTING_ID)."
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file cpd-comment.md
+            echo "Posted new CPD comment."
+          fi
 
       - name: Upload CPD reports
         if: always() && steps.changed.outputs.any == 'true'


### PR DESCRIPTION
Closes #14185.

## What

Adds a new GitHub Actions workflow at `.github/workflows/cpd.yml` that runs PMD's Copy/Paste Detector (`mvn pmd:cpd`) on pull requests that touch Java sources and uploads the resulting per-module `target/cpd.xml` reports as a build artifact.

## Why

#14185 asks for a workflow that runs CPD on PRs. CPD covers a class of issues that SpotBugs does not (cross-file duplication), so this is additive to the existing `spotbugs.yml` workflow rather than overlapping with it. The `maven-pmd-plugin` is already configured in the root POM (`minimumTokens=100`, `excludeRoots=target/generated-sources`), so the goal is invokable without any POM changes.

## How

The workflow mirrors the existing `spotbugs.yml` pattern:

- triggers on `pull_request` against `main`, with the same `paths-ignore` list (docs/license/config-only PRs are skipped);
- reuses the `./.github/actions/setup-java` composite action so JDK and Maven cache stay consistent with the rest of CI;
- uses `.github/scripts/changed-classes.sh` to detect whether any Java sources changed in the PR and short-circuits with a no-op when none did;
- runs `mvn -B -DskipTests=true org.apache.maven.plugins:maven-pmd-plugin:cpd` against the reactor (CPD is inherently cross-file, so per-class scoping does not apply the way it does for SpotBugs);
- uploads all `**/target/cpd.xml` reports as a `cpd-reports` artifact (14-day retention).

The issue body uses the goal name `pmd:cpm`; the correct Maven goal is `pmd:cpd`, which is what the workflow invokes.

## Open questions for review

The issue mentions a build-failure gate ("failure status if duplicate code exceeds a certain threshold") and PR comments. This PR intentionally stops at "generate report + upload artifact" so the team can review the baseline output on a few real PRs before deciding:

- whether to swap `pmd:cpd` for `pmd:cpd-check` (which fails on any finding past `minimumTokens`),
- whether to keep the current `minimumTokens=100` threshold or relax it for a noisy baseline,
- whether to add a PR-comment summary on top of (or in place of) the artifact upload.

Happy to fold either of those into this PR if you'd prefer to land them together.

## Validation

- `actionlint .github/workflows/cpd.yml` passes locally.
- `python3 -c "import yaml; yaml.safe_load(...)"` confirms YAML parses.
- The repo's own `ci-static-checker.yml` (reviewdog + actionlint) will re-run on this PR.

I do not have a local Maven environment that can run the full Infinispan reactor, so the actual `mvn pmd:cpd` invocation has not been executed end-to-end yet; that validation will happen when this workflow runs on the PR for the first time.

## AI agent disclosure

Per the "Use of Generative AI" section of CONTRIBUTING.md: I used an AI coding agent (Claude Code) to navigate the existing workflows and draft the YAML. I have read every line of the change, understand each step (trigger filters, the `changed-classes.sh` reuse, the Maven goal selection, and the artifact upload settings), and will be the one responding to review feedback.
