### PR TITLE
[#17630] Add CycloneDX SBOM generation and SLSA provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       version: ${{ steps.resolve-versions.outputs.RELEASE_VERSION }}
       nextVersion: ${{ steps.resolve-versions.outputs.NEXT_VERSION }}
@@ -147,6 +151,23 @@ jobs:
           gh release upload ${{ steps.resolve-versions.outputs.RELEASE_VERSION }} distribution/target/distribution/infinispan-server-${{ steps.resolve-versions.outputs.RELEASE_VERSION }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
+
+      - name: Attach SBOM
+        run: |
+          gh release upload ${{ steps.resolve-versions.outputs.RELEASE_VERSION }} "distribution/target/bom.json#infinispan-sbom-${{ steps.resolve-versions.outputs.RELEASE_VERSION }}.cdx.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
+
+      - name: Attest server distribution provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: distribution/target/distribution/infinispan-server-${{ steps.resolve-versions.outputs.RELEASE_VERSION }}.zip
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-path: distribution/target/distribution/infinispan-server-${{ steps.resolve-versions.outputs.RELEASE_VERSION }}.zip
+          sbom-path: distribution/target/bom.json
 
   published:
     needs: release

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -109,6 +109,33 @@
                </execution>
             </executions>
          </plugin>
+         <!-- Generate CycloneDX SBOM -->
+         <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+               <execution>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>makeAggregateBom</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <projectType>application</projectType>
+               <schemaVersion>1.6</schemaVersion>
+               <includeBomSerialNumber>true</includeBomSerialNumber>
+               <includeCompileScope>true</includeCompileScope>
+               <includeRuntimeScope>true</includeRuntimeScope>
+               <includeProvidedScope>false</includeProvidedScope>
+               <includeTestScope>false</includeTestScope>
+               <includeSystemScope>false</includeSystemScope>
+               <includeLicenseText>false</includeLicenseText>
+               <outputFormat>json</outputFormat>
+               <outputName>bom</outputName>
+            </configuration>
+         </plugin>
          <!-- Collect licenses -->
          <plugin>
             <groupId>org.wildfly.maven.plugins</groupId>

--- a/distribution/src/main/assemblies/server.xml
+++ b/distribution/src/main/assemblies/server.xml
@@ -12,6 +12,13 @@
 
    <fileSets>
       <fileSet>
+         <directory>target</directory>
+         <outputDirectory/>
+         <includes>
+            <include>bom.json</include>
+         </includes>
+      </fileSet>
+      <fileSet>
          <directory>target/classes</directory>
          <outputDirectory />
          <includes>


### PR DESCRIPTION
## Summary
- Add CycloneDX Maven plugin (2.9.1) to the distribution module to generate a JSON SBOM at package time
- Include the SBOM (`bom.json`) in the server distribution ZIP
- Upload the SBOM as a standalone release asset during the release workflow
- Add SLSA build provenance attestation for the server ZIP and SBOM attestation using GitHub's `attest-build-provenance` and `attest-sbom` actions

Closes #17630

Created with the assistance of an AI tool