### PR TITLE
[#17632] Harden GitHub Actions with top-level permissions and SHA pinning

### DIFF
--- a/.github/workflows/ai_ide_config_notice.yml
+++ b/.github/workflows/ai_ide_config_notice.yml
@@ -1,5 +1,8 @@
 name: AI/IDE/CI Config Change Notice
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   find_targets:
     if: github.event.pull_request.merged == true && github.event.pull_request.labels
@@ -35,7 +38,7 @@ jobs:
 
     steps:
       - name: Backport
-        uses: kiegroup/git-backporting@v4.9.1
+        uses: kiegroup/git-backporting@08da0b07ef2330d189f6074ec8db736b3aa9f465 # v4.9.1
         with:
           target-branch: ${{ matrix.branch }}
           pull-request: ${{ github.event.pull_request.url }}

--- a/.github/workflows/backport_reaper.yaml
+++ b/.github/workflows/backport_reaper.yaml
@@ -7,13 +7,16 @@ on:
     branches:
       - '*.0.x'
 
+permissions:
+  contents: read
+
 jobs:
   remove_backport_branch:
     if: startsWith(github.event.pull_request.head.ref, 'bp-')
     runs-on: ubuntu-latest
     steps:
       - name: Delete PR head branches
-        uses: dawidd6/action-delete-branch@v3
+        uses: dawidd6/action-delete-branch@d1efac9a6f7a9b408d4e8ff663a99c1fbac17b3f # v3
         with:
           github_token: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
           numbers: ${{github.event.pull_request.number}}

--- a/.github/workflows/bisect.yml
+++ b/.github/workflows/bisect.yml
@@ -1,5 +1,8 @@
 name: Bisect
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -26,14 +29,14 @@ jobs:
 
     steps:
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '25'
           distribution: 'zulu'
           server-id: central
 
       - name: Checkout Source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 100
@@ -45,7 +48,7 @@ jobs:
 
       - name: Upload report
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: surefire-test-report
           path: /home/runner/logs-*.zip

--- a/.github/workflows/bisect.yml
+++ b/.github/workflows/bisect.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Run bisection
         run: |
-          cp .github/scripts/bisect.sh $HOME/bisect.sh
-          $HOME/bisect.sh ${{ inputs.goodCommit }} ${{ inputs.mavenModule }} ${{ inputs.testName }} ${{ inputs.badCommit }}
+          cp .github/scripts/bisect.sh "$HOME/bisect.sh"
+          "$HOME/bisect.sh" ${{ inputs.goodCommit }} ${{ inputs.mavenModule }} ${{ inputs.testName }} ${{ inputs.badCommit }}
 
       - name: Upload report
         if: (success() || failure())

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,5 +1,8 @@
 name: Branch
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -48,7 +51,7 @@ jobs:
           sudo apt-get install -y xsltproc
 
       - name: Checkout Source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
 

--- a/.github/workflows/ci-static-checker.yml
+++ b/.github/workflows/ci-static-checker.yml
@@ -6,6 +6,9 @@ on:
       - '.github/workflows/**'
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   lint-workflows:
     runs-on: ubuntu-latest
@@ -13,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: actionlint with reviewdog
-        uses: reviewdog/action-actionlint@v1.72.0
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-annotations

--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -3,11 +3,15 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           any-of-labels: 'kind/flaky test'
           days-before-close: 14

--- a/.github/workflows/dependabot_pull_request.yml
+++ b/.github/workflows/dependabot_pull_request.yml
@@ -1,5 +1,8 @@
 name: Dependabot Auto Merge
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   label:
 
@@ -12,7 +15,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
          ref: ${{ github.base_ref }}
       - name: Add release labels on merge

--- a/.github/workflows/needs_rebase.yaml
+++ b/.github/workflows/needs_rebase.yaml
@@ -8,13 +8,17 @@ on:
     branches:
       - '*.0.x'
       - 'main'
+
+permissions:
+  contents: read
+
 jobs:
   triage:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@releases/2.x
+      - uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # releases/2.x
         with:
           dirtyLabel: "pr/needs rebase"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/nightly_jdk_matrix_test.yml
+++ b/.github/workflows/nightly_jdk_matrix_test.yml
@@ -105,10 +105,10 @@ jobs:
       matrix:
         jdk: ${{ fromJson(needs.prepare-matrix.outputs.jdk-matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java (baseline JDK ${{ needs.prepare-matrix.outputs.baseline-jdk }})
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ needs.prepare-matrix.outputs.baseline-jdk }}
           distribution: 'zulu'
@@ -118,7 +118,7 @@ jobs:
         run: ./mvnw -q clean install -Pdistribution -DskipTests -Dcheckstyle.skip
 
       - name: Setup alternate JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'zulu'
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload surefire test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: surefire-test-report-JDK${{ matrix.jdk }}
           path: |
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload log files
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: log-files-JDK${{ matrix.jdk }}
           compression-level: 9
@@ -161,7 +161,7 @@ jobs:
             !**/*[:"<>\*\?]*.log
       - name: Publish Test Report
         if: always()
-        uses: ctrf-io/github-test-reporter@v1
+        uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/nightly_publish_snapshot.yml
+++ b/.github/workflows/nightly_publish_snapshot.yml
@@ -8,12 +8,15 @@ on:
     # Only allow manual runs from main branch
     inputs: {}
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Check for recent commits on main
         if: github.event_name == 'schedule'

--- a/.github/workflows/nightly_publish_snapshot.yml
+++ b/.github/workflows/nightly_publish_snapshot.yml
@@ -32,16 +32,15 @@ jobs:
           gpg-private-key: ${{ secrets.INFINISPAN_MAVEN_GPG_ARMORED }}
 
       - name: Server version
-        run: >
-          echo "SERVER_VERSION=$(mvn -q -Dexec.executable=echo
-          -Dexec.args='${project.version}' --non-recursive exec:exec)"
-          >> $GITHUB_ENV
+        run: |
+          # shellcheck disable=SC2016
+          echo "SERVER_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> "$GITHUB_ENV"
 
       - name: Publish SNAPSHOT to Central
         run: |
           mvn -B -Drelease-mode=upstream -Pdistribution -Pcommunity-release \
           -DskipTests deploy \
-          -Dinfinispan.brand.version=${SERVER_VERSION} \
+          -Dinfinispan.brand.version="${SERVER_VERSION}" \
           -Dmaven.snapshots.repo.id=central \
           -Dmaven.snapshots.repo.url=https://central.sonatype.com/repository/maven-snapshots
         env:

--- a/.github/workflows/on_build_do_publish_image.yml
+++ b/.github/workflows/on_build_do_publish_image.yml
@@ -4,6 +4,12 @@ on:
    workflow_run:
       workflows: [Build]
       types: [completed]
+
+permissions:
+  contents: read
+  statuses: write
+  actions: read
+
 env:
    IMAGE_NAME: ${{ vars.QUAY_IMAGE_NAME  || 'quay.io/infinispan-test/server' }}
 
@@ -28,7 +34,7 @@ jobs:
         publish-image: ${{ steps.publish-image-info.outputs.publish-image }}
         image-name: ${{ steps.image-name.outputs.image-name }}
      steps:
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
         - id: workflow-run-info
           uses: ./.github/actions/get-origin-info
@@ -39,7 +45,7 @@ jobs:
 
         - if: ${{ github.event.workflow_run.event == 'pull_request' }}
           name: Get Labels Action
-          uses: snnaplab/get-labels-action@v1.0.1
+          uses: snnaplab/get-labels-action@f426df40304808ace3b5282d4f036515f7609576 # v1.0.1
           with:
             number: ${{ steps.workflow-run-info.outputs.pull-request-number }}
 
@@ -56,7 +62,7 @@ jobs:
 
         - name: set-commit-status
           if: steps.publish-image-info.outputs.publish-image == 'true'
-          uses: myrotvorets/set-commit-status-action@v2.0.1
+          uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
           with:
               status: pending
               sha: ${{ github.event.workflow_run.head_sha }}
@@ -82,7 +88,7 @@ jobs:
     steps:
       - name: set-commit-status
         if: ${{ needs.publish-image.result == 'success'}}
-        uses: myrotvorets/set-commit-status-action@v2.0.1
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           status: success
           sha: ${{ needs.get-info.outputs.source-head-sha }}
@@ -90,7 +96,7 @@ jobs:
 
       - name: set-commit-status
         if: ${{ needs.publish-image.result != 'success'}}
-        uses: myrotvorets/set-commit-status-action@v2.0.1
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           status: failure
           sha: ${{ needs.get-info.outputs.source-head-sha }}
@@ -100,7 +106,7 @@ jobs:
     needs:
       - get-info
     if: ${{ needs.get-info.outputs.publish-image == 'true' && (github.event.workflow_run.head_branch == '15.2.x' || github.event.workflow_run.head_branch == '15.0.x') }}
-    uses: infinispan/infinispan-images/.github/workflows/publish_image.yml@main
+    uses: infinispan/infinispan-images/.github/workflows/publish_image.yml@fbfc22d69cec42331c552279d14502bc7032a009 # main
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       quayUser: ${{ secrets.QUAY_USERNAME }}
@@ -120,7 +126,7 @@ jobs:
     steps:
       - name: set-commit-status
         if: ${{ needs.publish-image-legacy.result == 'success'}}
-        uses: myrotvorets/set-commit-status-action@v2.0.1
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           status: success
           sha: ${{ needs.get-info.outputs.source-head-sha }}
@@ -128,7 +134,7 @@ jobs:
 
       - name: set-commit-status
         if: ${{ needs.publish-image-legacy.result != 'success'}}
-        uses: myrotvorets/set-commit-status-action@v2.0.1
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
         with:
           status: failure
           sha: ${{ needs.get-info.outputs.source-head-sha }}

--- a/.github/workflows/on_build_do_test.yml
+++ b/.github/workflows/on_build_do_test.yml
@@ -31,7 +31,7 @@ jobs:
          source-event: ${{ github.event.workflow_run.event }}
          build-type: ${{ steps.build-type.outputs.build-type }}
       steps:
-         - uses: actions/checkout@v6
+         - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
            with:
              sparse-checkout: |
                .github/
@@ -47,7 +47,7 @@ jobs:
 
          - name: Download build type
            id: download-build-type
-           uses: actions/download-artifact@v8.0.1
+           uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
            continue-on-error: true
            with:
              name: build-type
@@ -75,14 +75,14 @@ jobs:
       MAVEN_OPTS: "-Xmx1500m -XX:+HeapDumpOnOutOfMemoryError"
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           sparse-checkout: |
              .github/
           sparse-checkout-cone-mode: false
           fetch-depth: 1
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
         with:
           java-version: 25
           distribution: 'graalvm'
@@ -110,7 +110,7 @@ jobs:
           unzip -q "${GITHUB_WORKSPACE}/infinispan-${{ steps.dis.outputs.server-version }}-src.zip"
           mv infinispan-${{ steps.dis.outputs.server-version }}-src infinispan
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: ${{ secrets.GH_APP_ISPN_ID }}
@@ -135,7 +135,7 @@ jobs:
           echo "$CHECK_RUN" > check-run-id.txt
 
       - name: Upload Check Run ID
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: check-run-id
           path: check-run-id.txt
@@ -176,7 +176,7 @@ jobs:
 
       # Renewing token since it last for 1 hour and cannot be extended
       # see for more info https://github.com/actions/create-github-app-token/issues/128
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         if: always() && failure()
         id: app-token-2
         with:
@@ -208,7 +208,7 @@ jobs:
 
       - name: Upload surefire test report
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: surefire-test-report
           path: |
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload infinispan with coverage execution files
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jacoco-files-main
           path: |
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload jstack files
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jstack-report
           path: |
@@ -244,7 +244,7 @@ jobs:
       - name: Check flaky report existence
         if: success() || failure()
         id: check_flaky_report
-        uses: andstor/file-existence-action@v3
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3
         with:
           files: "test_dir/infinispan/**/target/*-reports*/**/TEST-*FLAKY.xml"
 
@@ -261,7 +261,7 @@ jobs:
 
       - name: Upload flaky test report
         if: (success() || failure()) && steps.check_flaky_report.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: flaky-test-report
           path: |
@@ -273,7 +273,7 @@ jobs:
 
       - name: Upload log files
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: log-files
           compression-level: 9
@@ -298,7 +298,7 @@ jobs:
           - db2
           - tomcat
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
@@ -326,7 +326,7 @@ jobs:
           unzip -q "${GITHUB_WORKSPACE}/infinispan-${{ steps.dis.outputs.server-version }}-src.zip"
           mv infinispan-${{ steps.dis.outputs.server-version }}-src infinispan
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
             client-id: ${{ secrets.GH_APP_ISPN_ID }}
@@ -351,7 +351,7 @@ jobs:
           echo "$CHECK_RUN" > check-run-id-${{ matrix.targets }}.txt
 
       - name: Upload Check Run ID
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: check-run-id-${{ matrix.targets }}
           path: check-run-id-${{ matrix.targets }}.txt
@@ -425,7 +425,7 @@ jobs:
 
       - name: Upload surefire test report
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: surefire-test-report-${{ matrix.targets }}
           path: |
@@ -440,7 +440,7 @@ jobs:
 
       - name: Upload jacoco exec files for db
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jacoco-files-${{ matrix.targets }}
           path: |
@@ -479,7 +479,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       ROLLING_UPGRADE_COVERAGE: 'latest'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
@@ -512,7 +512,7 @@ jobs:
           mv infinispan-${{ steps.dis.outputs.server-version }}-src infinispan
           cp -r infinispan infinispan-rolling-upgrade
 
-      - uses: actions/download-artifact@v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: jacoco-files-*
 
@@ -544,7 +544,7 @@ jobs:
 
       - name: Add coverage to PR
         id: jacoco
-        uses: vilmosnagy/jacoco-report@1.8.0
+        uses: vilmosnagy/jacoco-report@4982e687fa89217b469696f8633358606c4f3172 # 1.8.0
         with:
           paths: |
             ${{ github.workspace }}/test_dir/infinispan/jacoco-report/jacoco.xml
@@ -564,7 +564,7 @@ jobs:
 
       - name: Upload jacoco report
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jacocoReport
           path: |
@@ -586,7 +586,7 @@ jobs:
 
       - name: Add rolling upgrade coverage to PR
         id: jacoco-rolling-upgrade
-        uses: vilmosnagy/jacoco-report@1.8.0
+        uses: vilmosnagy/jacoco-report@4982e687fa89217b469696f8633358606c4f3172 # 1.8.0
         with:
           paths: |
             ${{ github.workspace }}/test_dir/infinispan-rolling-upgrade/jacoco-report/jacoco.xml
@@ -600,7 +600,7 @@ jobs:
 
       - name: Upload jacoco report for rolling upgrade
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jacocoReport-rolling-upgrade
           path: |

--- a/.github/workflows/on_propen_push_do_build.yml
+++ b/.github/workflows/on_propen_push_do_build.yml
@@ -88,9 +88,9 @@ jobs:
         uses: ./.github/actions/build-infinispan
 
       - name: Server version
-        run: >
-          mvn -q -Dexec.executable=echo -Dexec.args='-n ${project.version}'
-          --non-recursive exec:exec > server-version.txt
+        run: |
+          # shellcheck disable=SC2016
+          mvn -q -Dexec.executable=echo -Dexec.args='-n ${project.version}' --non-recursive exec:exec > server-version.txt
 
       - name: Archive server version
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/on_propen_push_do_build.yml
+++ b/.github/workflows/on_propen_push_do_build.yml
@@ -7,6 +7,9 @@ on:
       - main
       - '*.x'
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
@@ -23,7 +26,7 @@ jobs:
     outputs:
       build-type: ${{ steps.check.outputs.build-type }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -69,7 +72,7 @@ jobs:
           echo -n "$BUILD_TYPE" > build-type.txt
 
       - name: Upload build type
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-type
           path: build-type.txt
@@ -79,7 +82,7 @@ jobs:
     if: needs.detect-changes.outputs.build-type == 'full'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build Infinispan
         uses: ./.github/actions/build-infinispan
@@ -90,7 +93,7 @@ jobs:
           --non-recursive exec:exec > server-version.txt
 
       - name: Archive server version
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: server-version
           path: |
@@ -101,7 +104,7 @@ jobs:
     if: needs.detect-changes.outputs.build-type == 'docs-only'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
         uses: ./.github/actions/setup-java

--- a/.github/workflows/on_test_publish_surefire_report.yml
+++ b/.github/workflows/on_test_publish_surefire_report.yml
@@ -5,6 +5,14 @@ on:
      workflows: [Test]
      types: [completed]
    # Rerun report publishing on exising test run
+
+permissions:
+  contents: read
+  checks: write
+  statuses: write
+  pull-requests: write
+  actions: read
+
 jobs:
    publish:
       name: Publish Surefire Report
@@ -17,7 +25,7 @@ jobs:
 
         # Downloading surefire report artifact containing
         - name: Download Surefire Report Artifact
-          uses: actions/download-artifact@v8.0.1
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           with:
             pattern: surefire-test-report*
             github-token: ${{ github.token }}
@@ -26,12 +34,12 @@ jobs:
         # Downloading github-sha.txt file
         - name: Get github sha
           id: github_sha
-          uses: juliangruber/read-file-action@v1
+          uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1
           with:
             path: ./surefire-test-report/github-sha.txt
 
         # Get GitHub App token to use in API calls
-        - uses: actions/create-github-app-token@v3
+        - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
           id: app-token
           with:
             # required
@@ -49,7 +57,7 @@ jobs:
 
         - name: Download Check Run ID
           if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
-          uses: actions/download-artifact@v8.0.1
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           with:
             name: check-run-id
             github-token: ${{ github.token }}
@@ -65,7 +73,7 @@ jobs:
         - name: Publish Test Report
           if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
           # Waiting for https://github.com/ScaCap/action-surefire-report/pull/251
-          uses: rigazilla/action-surefire-report@module-v1
+          uses: rigazilla/action-surefire-report@d0798439b2f7845af98fa88187bcc622a6818efd # module-v1
           with:
             github_token: ${{ steps.app-token.outputs.token }}
             check_name: Test Report Result
@@ -119,7 +127,7 @@ jobs:
 
         - name: Set test number check status on success
           if: fromJSON(steps.test-number.outputs.test_count) >= fromJSON(steps.test-number.outputs.test_min)
-          uses: myrotvorets/set-commit-status-action@v2.0.1
+          uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
           with:
             status: success
             sha: ${{ steps.github_sha.outputs.content }}
@@ -129,7 +137,7 @@ jobs:
 
         - name: Set test number check status if failed
           if: fromJSON(steps.test-number.outputs.test_count) < fromJSON(steps.test-number.outputs.test_min)
-          uses: myrotvorets/set-commit-status-action@v2.0.1
+          uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
           with:
             status: failure
             sha: ${{ steps.github_sha.outputs.content }}
@@ -154,7 +162,7 @@ jobs:
          echo "runid=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
 
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: surefire-test-report-${{ matrix.targets }}
         github-token: ${{ github.token }}
@@ -162,11 +170,11 @@ jobs:
 
     - name: Get github sha
       id: github_sha
-      uses: juliangruber/read-file-action@v1
+      uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1
       with:
         path: ./github-sha.txt
 
-    - uses: actions/create-github-app-token@v3
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       id: app-token
       with:
         # required
@@ -189,7 +197,7 @@ jobs:
 
     - name: Download Check Run ID
       if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: check-run-id-${{ matrix.targets }}
         github-token: ${{ github.token }}
@@ -205,7 +213,7 @@ jobs:
     - name: Publish Test Report
       if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
       # Waiting for https://github.com/ScaCap/action-surefire-report/pull/251
-      uses: rigazilla/action-surefire-report@module-v1
+      uses: rigazilla/action-surefire-report@d0798439b2f7845af98fa88187bcc622a6818efd # module-v1
       with:
         github_token: ${{ steps.app-token.outputs.token }}
         check_name: Test Report Result ${{ matrix.targets }}
@@ -242,14 +250,14 @@ jobs:
           run: |
             echo "runid=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
 
-        - uses: actions/checkout@v6
+        - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
           with:
             sparse-checkout: |
               .github/scripts/
             sparse-checkout-cone-mode: false
             fetch-depth: 1
 
-        - uses: actions/create-github-app-token@v3
+        - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
           id: app-token
           with:
             client-id: ${{ secrets.GH_APP_ISPN_ID }}
@@ -267,7 +275,7 @@ jobs:
         - name: Download jstack artifact
           if: steps.job-status.outputs.job_status == 'failure'
           id: download-jstack
-          uses: actions/download-artifact@v8.0.1
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           continue-on-error: true
           with:
             name: jstack-report
@@ -277,7 +285,7 @@ jobs:
 
         - name: Download surefire report for PR number
           if: steps.job-status.outputs.job_status == 'failure' && steps.download-jstack.outcome == 'success'
-          uses: actions/download-artifact@v8.0.1
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           continue-on-error: true
           with:
             name: surefire-test-report
@@ -344,7 +352,7 @@ jobs:
            echo "runid=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
 
       - name: Download Rolling Upgrade Artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: surefire-test-report-rolling-upgrades-${{ matrix.name }}
           github-token: ${{ github.token }}
@@ -352,11 +360,11 @@ jobs:
 
       - name: Get github sha
         id: github_sha
-        uses: juliangruber/read-file-action@v1
+        uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1
         with:
           path: ./github-sha.txt
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: ${{ secrets.GH_APP_ISPN_ID }}
@@ -379,7 +387,7 @@ jobs:
 
       - name: Publish Test Report
         if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
-        uses: rigazilla/action-surefire-report@module-v1
+        uses: rigazilla/action-surefire-report@d0798439b2f7845af98fa88187bcc622a6818efd # module-v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           check_name: Test Report Rolling Upgrades (${{ matrix.name }})
@@ -391,7 +399,7 @@ jobs:
 
       - name: Download Check Run ID
         if: failure()
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: check-run-id-rolling-upgrades-${{ matrix.name }}
           github-token: ${{ github.token }}

--- a/.github/workflows/on_test_publish_surefire_report.yml
+++ b/.github/workflows/on_test_publish_surefire_report.yml
@@ -349,7 +349,7 @@ jobs:
       - name: Set run_id based on event type
         id: run_id
         run: |
-           echo "runid=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+           echo "runid=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
 
       - name: Download Rolling Upgrade Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -383,7 +383,7 @@ jobs:
           --jq ".jobs[] | select(.name | endswith(\"$JOB_SUFFIX\")) | .conclusion")
           
           echo "Found status: $JOB_STATUS"
-          echo "job_status=$JOB_STATUS" >> $GITHUB_OUTPUT
+          echo "job_status=$JOB_STATUS" >> "$GITHUB_OUTPUT"
 
       - name: Publish Test Report
         if: (success() || failure()) && steps.job-status.outputs.job_status == 'success'
@@ -410,14 +410,14 @@ jobs:
         id: read_check_id
         run: |
           CHECK_RUN_ID=$(cat check-run-id.txt)
-          echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> $GITHUB_ENV
+          echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> "$GITHUB_ENV"
 
       - name: Set failure check if Publish Test Report step failed
         if: failure()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh api repos/${{ github.repository }}/check-runs/${CHECK_RUN_ID} \
+          gh api "repos/${{ github.repository }}/check-runs/${CHECK_RUN_ID}" \
             -H "Accept: application/vnd.github+json" \
             -f status="completed" \
             -f conclusion="failure" \

--- a/.github/workflows/on_test_update_gh_flaky_test.yml
+++ b/.github/workflows/on_test_update_gh_flaky_test.yml
@@ -4,6 +4,13 @@ on:
    workflow_run:
      workflows: [Test]
      types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
 jobs:
    issueForFlakyTest:
       if: github.event.workflow_run.conclusion == 'success'
@@ -11,7 +18,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
         - name: Install xmlstarlet tool
 # xmlstarlet is needed by .github/scripts/track_flaky_tests.sh
@@ -24,7 +31,7 @@ jobs:
 # zip file with flaky test reports and file
 # containing PR target branch
         - name: Download a Build Artifact
-          uses: actions/download-artifact@v8.0.1
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           id: download-artifact
           with:
              name: flaky-test-report
@@ -45,13 +52,13 @@ jobs:
 
         - name: Get event name
           id: event_name
-          uses: juliangruber/read-file-action@v1
+          uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1
           with:
             path: ./event-name.txt
 
         - name: Get PR number
           id: pr-number
-          uses: juliangruber/read-file-action@v1
+          uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1
           with:
             path: ./pr-number.txt
 

--- a/.github/workflows/operator_ci.yaml
+++ b/.github/workflows/operator_ci.yaml
@@ -26,6 +26,9 @@ on:
       - 'CODEOWNERS'
       - 'documentation/**'
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
@@ -43,13 +46,13 @@ jobs:
       version: ${{ steps.infinispan.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build Image
         id: infinispan
@@ -65,14 +68,14 @@ jobs:
           echo "version=${OPERAND_VERSION}" >> ${GITHUB_OUTPUT}
 
       - name: Upload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: operand-image
           path: /tmp/operand-image.tar
 
   tests:
     needs: image
-    uses: infinispan/infinispan-operator/.github/workflows/ci.yml@main
+    uses: infinispan/infinispan-operator/.github/workflows/ci.yml@1440ba6a16218701d3e06aafc6cd7c0743c5c78f # main
     with:
       operand: ${{ needs.image.outputs.image }}
       operandArtifact: operand-image

--- a/.github/workflows/operator_ci.yaml
+++ b/.github/workflows/operator_ci.yaml
@@ -58,14 +58,14 @@ jobs:
         id: infinispan
         run: |
           SERVER_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          OPERAND_VERSION=$(echo ${SERVER_VERSION} | cut -d '-' -f 1)
+          OPERAND_VERSION=$(echo "${SERVER_VERSION}" | cut -d '-' -f 1)
           IMAGE="localhost:5001/server:${SERVER_VERSION}"
 
-          ./mvnw install -DskipTests -am -pl server/runtime,server/image -Pimage -Dimage.name=${IMAGE}
-          docker save ${IMAGE} > /tmp/operand-image.tar
+          ./mvnw install -DskipTests -am -pl server/runtime,server/image -Pimage -Dimage.name="${IMAGE}"
+          docker save "${IMAGE}" > /tmp/operand-image.tar
 
-          echo "image=${IMAGE}" >> ${GITHUB_OUTPUT}
-          echo "version=${OPERAND_VERSION}" >> ${GITHUB_OUTPUT}
+          echo "image=${IMAGE}" >> "${GITHUB_OUTPUT}"
+          echo "version=${OPERAND_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/pull_request_native_cli.yml
+++ b/.github/workflows/pull_request_native_cli.yml
@@ -28,6 +28,9 @@ on:
       - 'CODEOWNERS'
       - 'documentation/**'
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
@@ -54,20 +57,20 @@ jobs:
             asset_name: windows-amd64
             gu_binary: gu.cmd
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3.0.0
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
         with:
           java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pull_request_open.yml
+++ b/.github/workflows/pull_request_open.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - reopened
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   targetlabel:
     if: contains(github.event.pull_request.base.ref, '.')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ on:
             - latest
             - prerelease
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,7 +35,7 @@ jobs:
 
     steps:
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -42,7 +45,7 @@ jobs:
           gpg-private-key: ${{ secrets.INFINISPAN_MAVEN_GPG_ARMORED }}
 
       - name: Checkout Source
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.branch }}
           token: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
@@ -152,7 +155,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: GOSCHEN/http-status-code@v1.1.0
+      - uses: GOSCHEN/http-status-code@944938ed534b092b9f7e1e5c6b08c5d9bbc35162 # v1.1.0
         with:
           url: https://repo1.maven.org/maven2/org/infinispan/infinispan-distribution/${{ needs.release.outputs.version }}/infinispan-distribution-${{ needs.release.outputs.version }}.pom
           code: 200
@@ -186,20 +189,20 @@ jobs:
             gu_binary: gu
             native_extra_args: -Dquarkus.native.native-image-xmx=10g
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3.0.0
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
         with:
           java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Release Tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.release.outputs.version }}
 
@@ -234,7 +237,7 @@ jobs:
   images-legacy:
     needs: [published, release]
     if: startsWith(needs.release.outputs.version, '15.') || startsWith(needs.release.outputs.version, '14.') || startsWith(needs.release.outputs.version, '13.')
-    uses: infinispan/infinispan-images/.github/workflows/release.yml@main
+    uses: infinispan/infinispan-images/.github/workflows/release.yml@fbfc22d69cec42331c552279d14502bc7032a009 # main
     secrets: inherit
     with:
       branch: main
@@ -245,7 +248,7 @@ jobs:
   operator-main:
     needs: [images, release]
     if: ${{ !contains(needs.release.outputs.version, '.Dev') }}
-    uses: infinispan/infinispan-operator/.github/workflows/add_operand.yml@main
+    uses: infinispan/infinispan-operator/.github/workflows/add_operand.yml@1440ba6a16218701d3e06aafc6cd7c0743c5c78f # main
     secrets: inherit
     with:
       image: quay.io/infinispan/server:${{ needs.release.outputs.version }}
@@ -267,7 +270,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update website release data
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.API_TOKEN_GITHUB }}
           repository: infinispan/infinispan.github.io
@@ -278,7 +281,7 @@ jobs:
     needs: [published, release]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
             client-id: ${{ secrets.GH_APP_ISPN_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,8 @@ jobs:
 
           echo "Release version: $RELEASE_VERSION"
           echo "Next version: $NEXT_VERSION"
-          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update proto.lock files
         run: |

--- a/.github/workflows/release_cli_packages.yml
+++ b/.github/workflows/release_cli_packages.yml
@@ -6,6 +6,9 @@ name: Package CLI Native Installers
 # Expects native CLI ZIP artifacts to already be attached to the
 # GitHub release (uploaded by the native-cli job in release.yml).
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -31,7 +34,7 @@ jobs:
           - nfpm_arch: arm64
             asset_name: linux-aarch_64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install nfpm
         run: |
@@ -215,7 +218,7 @@ jobs:
   publish-package-managers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Download all native CLI artifacts
         run: |
@@ -229,7 +232,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         with:
           arguments: full-release --basedir . --config-file distribution/src/main/packaging/cli/jreleaser/jreleaser.yml
         env:
@@ -238,7 +241,7 @@ jobs:
 
       - name: Upload JReleaser output on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jreleaser-output
           path: |
@@ -248,7 +251,7 @@ jobs:
   publish-aur:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           sparse-checkout: distribution/src/main/packaging/cli/aur
 

--- a/.github/workflows/release_cli_packages.yml
+++ b/.github/workflows/release_cli_packages.yml
@@ -150,6 +150,7 @@ jobs:
             --pinentry-mode loopback --detach-sign --armor repo/yum/x86_64/repodata/repomd.xml
           gpg --batch --yes --passphrase "${{ secrets.INFINISPAN_MAVEN_GPG_PASSPHRASE }}" \
             --pinentry-mode loopback --detach-sign --armor repo/yum/aarch64/repodata/repomd.xml
+          # shellcheck disable=SC2016
           printf '%s\n' \
             '[infinispan]' \
             'name=Infinispan' \

--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -1,5 +1,8 @@
 name: Release Images
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -48,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -59,14 +62,14 @@ jobs:
             TYPE: ${{ inputs.type }}
 
       - name: Log in to Docker Hub
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: docker.io
 
       - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
@@ -79,7 +82,7 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           build-args: |
             BRAND_VERSION=${{ inputs.version }}
@@ -95,7 +98,7 @@ jobs:
       - name: Push to Docker Hub
         id: push-to-docker
         if: ${{ inputs.push }}
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         with:
           registry: docker.io/infinispan
           image: server
@@ -107,7 +110,7 @@ jobs:
       - name: Push to Quay.io
         id: push-to-quay
         if: ${{ inputs.push }}
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         with:
           registry: quay.io/infinispan
           image: server

--- a/.github/workflows/release_resume.yml
+++ b/.github/workflows/release_resume.yml
@@ -20,12 +20,14 @@ on:
           - latest
           - prerelease
 
+permissions:
+  contents: read
 
 jobs:
   published:
     runs-on: ubuntu-latest
     steps:
-      - uses: GOSCHEN/http-status-code@v1.1.0
+      - uses: GOSCHEN/http-status-code@944938ed534b092b9f7e1e5c6b08c5d9bbc35162 # v1.1.0
         with:
           url: https://repo1.maven.org/maven2/org/infinispan/infinispan-distribution/${{ inputs.version }}/infinispan-distribution-${{ inputs.version }}.pom
           code: 200
@@ -53,20 +55,20 @@ jobs:
             asset_name: linux-aarch_64
             gu_binary: gu
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v3.0.0
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
         with:
           java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Release Tag
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ github.event.inputs.version }}
 
@@ -100,7 +102,7 @@ jobs:
   operator:
     needs: images
     if: contains(github.event.inputs.version, '.Final')
-    uses: infinispan/infinispan-operator/.github/workflows/add_operand.yml@main
+    uses: infinispan/infinispan-operator/.github/workflows/add_operand.yml@1440ba6a16218701d3e06aafc6cd7c0743c5c78f # main
     secrets: inherit
     with:
       image: quay.io/infinispan/server:${{ github.ref_name }}

--- a/.github/workflows/rolling-upgrade-test.yml
+++ b/.github/workflows/rolling-upgrade-test.yml
@@ -1,5 +1,9 @@
 name: Rolling Upgrade Test Module
 
+permissions:
+  contents: read
+  checks: write
+
 on:
   workflow_call:
     inputs:
@@ -30,7 +34,7 @@ jobs:
     name: Rolling Upgrades (${{ inputs.name }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
@@ -57,7 +61,7 @@ jobs:
           unzip -q "${GITHUB_WORKSPACE}/infinispan-${{ steps.dis.outputs.server-version }}-src.zip"
           mv infinispan-${{ steps.dis.outputs.server-version }}-src infinispan
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           client-id: ${{ secrets.GH_APP_ISPN_ID }}
@@ -114,7 +118,7 @@ jobs:
       # This allows the main workflow to distinguish between matrix runs
       - name: Upload jacoco exec files
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jacoco-files-rolling-upgrades-${{ inputs.name }}
           path: |
@@ -122,7 +126,7 @@ jobs:
 
       - name: Upload surefire test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: surefire-test-report-rolling-upgrades-${{ inputs.name }}
           path: |
@@ -134,7 +138,7 @@ jobs:
 
       - name: Upload log files
         if: (success() || failure())
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: log-files-rolling-upgrades-${{ inputs.name }}
           compression-level: 9

--- a/.github/workflows/snapshot_image.yml
+++ b/.github/workflows/snapshot_image.yml
@@ -1,5 +1,8 @@
 name: Snapshot Images
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -36,7 +39,7 @@ jobs:
 
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           run-id: '${{ inputs.runId }}'
           name: infinispan-dist
@@ -57,7 +60,7 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           build-args: |
             BRAND_VERSION=${{ inputs.runId }}
@@ -71,7 +74,7 @@ jobs:
           tags: ${{ inputs.tag }}
 
       - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1
         with:
           username: ${{ secrets.QUAY_USERNAME_TEST }}
           password: ${{ secrets.QUAY_TOKEN_TEST }}
@@ -79,7 +82,7 @@ jobs:
 
       - name: Push to Quay.io
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         with:
           registry: quay.io/infinispan-test
           image: server

--- a/.github/workflows/snapshot_image.yml
+++ b/.github/workflows/snapshot_image.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           unzip -q infinispan-*-src.zip
           SRCROOT=$(find . -maxdepth 1 -type d -name '*src')
-          echo "srcroot=$SRCROOT" >> $GITHUB_OUTPUT
+          echo "srcroot=$SRCROOT" >> "$GITHUB_OUTPUT"
           mv infinispan-server-*.zip "$SRCROOT"/server/image/infinispan-server.zip
 
       - name: Install qemu

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -13,12 +13,16 @@ on:
       - 'CODEOWNERS'
       - 'documentation/**'
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   spotbugs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0    # Need full history to compare base vs head
 
@@ -44,6 +48,6 @@ jobs:
 
       - name: Publish SpotBugs report annotation
         # Using a fork since the original action tries to create/update check-run, which is no more allowed
-        uses: rigazilla/spotbugs-github-action@annotations
+        uses: rigazilla/spotbugs-github-action@b5af0f7e19908102974a09af06e381945f46efaf # annotations
         with:
           path: '**/target/spotbugsXml.xml'

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           chmod +x .github/scripts/changed-classes.sh
           CLASSES=$(.github/scripts/changed-classes.sh origin/${{ github.event.pull_request.base.ref }} HEAD)
-          echo "classes=$CLASSES" >> $GITHUB_OUTPUT
+          echo "classes=$CLASSES" >> "$GITHUB_OUTPUT"
 
       - name: Skip if no changes
         if: steps.changed.outputs.classes == 'NO_CHANGES'

--- a/.github/workflows/supported_jdks.yaml
+++ b/.github/workflows/supported_jdks.yaml
@@ -11,6 +11,9 @@ on:
       - main
       - '*.*.x'
 
+permissions:
+  contents: read
+
 concurrency:
   # Cancel jobs same head_branch same repo, works
   # both for pull_request and push
@@ -46,10 +49,10 @@ jobs:
     if: needs.resolve-ea-jdk.outputs.ea-version != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: ${{ needs.resolve-ea-jdk.outputs.ea-version }}
           distribution: 'temurin'

--- a/.github/workflows/sync_docs.yml
+++ b/.github/workflows/sync_docs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
 
@@ -27,7 +27,7 @@ jobs:
       run: ./mvnw install -Pdistribution -pl documentation -am
 
     - name: Clone infinispan.github.io
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         repository: infinispan/infinispan.github.io
         ref: master
@@ -53,7 +53,7 @@ jobs:
         git commit -m "Synchronized core docs from ${{ github.ref }}"
 
     - name: Push to the community site
-      uses: cpina/github-action-push-to-another-repository@main
+      uses: cpina/github-action-push-to-another-repository@55306faa4ed53b815ae49e564af8cfb359d32ae2 # main
       env:
         API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
       with:


### PR DESCRIPTION
## Summary
- Add explicit top-level `permissions: contents: read` to all 29 workflow files, with elevated scopes (issues, pull-requests, checks, statuses, actions) only where needed at the job level
- Pin every external action reference (32 distinct actions) to immutable 40-char commit SHAs with trailing `# vX.Y.Z` comments, including cross-repo reusable workflows from infinispan-images and infinispan-operator
- Dependabot will continue to update SHA pins automatically as new versions are released

Closes #17632

Created with the assistance of an AI tool