### PR TITLE
[#17634] Add explicit permission gates to REST endpoints

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/resources/LoggingResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/LoggingResource.java
@@ -24,6 +24,8 @@ import org.infinispan.rest.framework.RestRequest;
 import org.infinispan.rest.framework.RestResponse;
 import org.infinispan.rest.framework.impl.Invocations;
 import org.infinispan.rest.logging.Log;
+import org.infinispan.security.AuditContext;
+import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.tasks.TaskContext;
 import org.infinispan.tasks.manager.TaskManager;
 
@@ -45,11 +47,21 @@ public final class LoggingResource implements ResourceHandler {
    @Override
    public Invocations getInvocations() {
       return new Invocations.Builder("logging", "REST resource to manage logging.")
-            .invocation().methods(GET).path("/v2/logging/loggers").handleWith(this::listLoggers)
-            .invocation().methods(GET).path("/v2/logging/appenders").handleWith(this::listAppenders)
-            .invocation().methods(DELETE).path("/v2/logging/loggers/{loggerName}").handleWith(this::deleteLogger)
-            .invocation().methods(PUT).path("/v2/logging/loggers/{loggerName}").handleWith(this::setLogger)
-            .invocation().methods(PUT).path("/v2/logging/loggers").handleWith(this::setLogger)
+            .invocation().methods(GET).path("/v2/logging/loggers")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::listLoggers)
+            .invocation().methods(GET).path("/v2/logging/appenders")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::listAppenders)
+            .invocation().methods(DELETE).path("/v2/logging/loggers/{loggerName}")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::deleteLogger)
+            .invocation().methods(PUT).path("/v2/logging/loggers/{loggerName}")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::setLogger)
+            .invocation().methods(PUT).path("/v2/logging/loggers")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::setLogger)
             .create();
    }
 

--- a/server/rest/src/main/java/org/infinispan/rest/resources/TasksResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/TasksResource.java
@@ -26,6 +26,8 @@ import org.infinispan.rest.framework.RestResponse;
 import org.infinispan.rest.framework.impl.Invocations;
 import org.infinispan.rest.logging.Log;
 import org.infinispan.scripting.ScriptingManager;
+import org.infinispan.security.AuditContext;
+import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.SecurityActions;
 import org.infinispan.tasks.TaskContext;
@@ -45,9 +47,15 @@ public class TasksResource implements ResourceHandler {
    public Invocations getInvocations() {
       return new Invocations.Builder("tasks", "REST endpoint to manage tasks.")
             .invocation().methods(GET).path("/v2/tasks/").handleWith(this::listTasks)
-            .invocation().methods(PUT, POST).path("/v2/tasks/{taskName}").handleWith(this::createScriptTask)
-            .invocation().methods(POST).path("/v2/tasks/{taskName}").withAction("exec").handleWith(this::runTask)
-            .invocation().methods(GET).path("/v2/tasks/{taskName}").withAction("script").handleWith(this::getScript)
+            .invocation().methods(PUT, POST).path("/v2/tasks/{taskName}")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::createScriptTask)
+            .invocation().methods(POST).path("/v2/tasks/{taskName}").withAction("exec")
+               .permission(AuthorizationPermission.EXEC).auditContext(AuditContext.SERVER)
+               .handleWith(this::runTask)
+            .invocation().methods(GET).path("/v2/tasks/{taskName}").withAction("script")
+               .permission(AuthorizationPermission.ADMIN).auditContext(AuditContext.SERVER)
+               .handleWith(this::getScript)
             .create();
    }
 

--- a/server/rest/src/test/java/org/infinispan/rest/resources/TasksResourceTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/resources/TasksResourceTest.java
@@ -90,12 +90,13 @@ public class TasksResourceTest extends AbstractRestResourceTest {
 
    @Test
    public void testTaskUpload() throws Exception {
+      RestTaskClient adminTaskClient = adminClient.tasks();
       RestTaskClient taskClient = client.tasks();
 
       String script = getResourceAsString("hello.js", getClass().getClassLoader());
       RestEntity scriptEntity = RestEntity.create(TEXT_JAVASCRIPT, script);
 
-      CompletionStage<RestResponse> response = taskClient.uploadScript("hello", scriptEntity);
+      CompletionStage<RestResponse> response = adminTaskClient.uploadScript("hello", scriptEntity);
       ResponseAssertion.assertThat(response).isOk();
 
       response = taskClient.exec("hello", Collections.singletonMap("greetee", "Friend"));
@@ -103,7 +104,7 @@ public class TasksResourceTest extends AbstractRestResourceTest {
       Json jsonNode = Json.read(join(response).body());
       assertEquals("Hello Friend", jsonNode.asString());
 
-      response = taskClient.downloadScript("hello");
+      response = adminTaskClient.downloadScript("hello");
       ResponseAssertion.assertThat(response).isOk();
       assertEquals(script, join(response).body());
    }


### PR DESCRIPTION
## Summary
- Add `AuthorizationPermission.ADMIN` and `AuditContext.SERVER` to all five LoggingResource endpoints (get/set log levels, list/set/delete loggers and appenders)
- Add `AuthorizationPermission.ADMIN` to TasksResource script upload (PUT/POST) and script retrieval (GET)
- Add `AuthorizationPermission.EXEC` to TasksResource task execution (POST)

Closes #17634

Created with the assistance of an AI tool