### PR TITLE
[#17638] Add path containment check to MCP log-read endpoint

### DIFF
--- a/server/rest/src/main/java/org/infinispan/rest/resources/McpServerResource.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/McpServerResource.java
@@ -1095,7 +1095,11 @@ public class McpServerResource implements ResourceHandler {
             }
 
             String fileName = getLogFileName(logType);
-            java.nio.file.Path logFile = java.nio.file.Paths.get(logPath, fileName);
+            java.nio.file.Path base = java.nio.file.Paths.get(logPath).toAbsolutePath().normalize();
+            java.nio.file.Path logFile = base.resolve(fileName).normalize();
+            if (!logFile.startsWith(base)) {
+               throw new SecurityException("Log file path escapes log directory");
+            }
 
             // Read last N lines
             String content = readLastLines(logFile, lines);


### PR DESCRIPTION
## Summary
- Normalize and verify the resolved log file path stays within the configured log directory before reading
- Prevents path traversal if `getLogFileName` is ever relaxed to accept dynamic input

Closes #17638

Created with the assistance of an AI tool