### PR TITLE
[#17662] Reduce excessive logging for lock timeout

### DIFF
--- a/commons/all/src/main/java/org/infinispan/commons/TimeoutException.java
+++ b/commons/all/src/main/java/org/infinispan/commons/TimeoutException.java
@@ -23,6 +23,10 @@ public class TimeoutException extends CacheException {
       super(msg);
    }
 
+   public TimeoutException(String msg, boolean writableStackTrace) {
+      super(msg, null, true, writableStackTrace);
+   }
+
    public TimeoutException(String msg, Throwable cause) {
       super(msg, cause);
    }

--- a/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.commands.tx.AbstractTransactionBoundaryCommand;
+import org.infinispan.commons.TimeoutException;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.commons.util.concurrent.CompletableFutures;
@@ -122,6 +123,16 @@ public class LockControlCommand extends AbstractTransactionBoundaryCommand imple
          return CompletableFutures.completedNull();
       }
       return registry.getInterceptorChain().running().invokeAsync(ctx, this);
+   }
+
+   @Override
+   public boolean logThrowable(Throwable t) {
+      Throwable cause = t;
+      do {
+         if (cause instanceof TimeoutException)
+            return false;
+      } while ((cause = t.getCause()) != null);
+      return true;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/impl/DefaultLockManager.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/impl/DefaultLockManager.java
@@ -322,7 +322,7 @@ public class DefaultLockManager implements LockManager {
       @Override
       public TimeoutException get() {
          return log.unableToAcquireLock(Util.prettyPrintTime(timeoutMillis), toStr(key), lockPromise.getRequestor(),
-               lockPromise.getOwner());
+               lockPromise.getOwner(), false);
       }
 
       KeyAwareExtendedLockPromise scheduleLockTimeoutTask(ScheduledExecutorService executorService) {

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/impl/DefaultPendingLockManager.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/impl/DefaultPendingLockManager.java
@@ -124,7 +124,7 @@ public class DefaultPendingLockManager implements PendingLockManager {
    private static TimeoutException timeout(KeyValuePair<CacheTransaction, Object> lockOwner,
                                            GlobalTransaction thisGlobalTransaction, long timeout, TimeUnit timeUnit) {
       return log.unableToAcquireLock(prettyPrintTime(timeout, timeUnit), lockOwner.getValue(), thisGlobalTransaction,
-                                     lockOwner.getKey().getGlobalTransaction() + " (pending)");
+                                     lockOwner.getKey().getGlobalTransaction() + " (pending)", false);
    }
 
    private Collection<PendingTransaction> getTransactionWithLockedKey(int transactionTopologyId, Object key,

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1097,7 +1097,7 @@ public interface Log extends BasicLogger {
 //   void authorizationEnabledWithoutSecurityManager();
 
    @Message(value = "Unable to acquire lock after %s for key %s and requestor %s. Lock is held by %s", id = 299)
-   TimeoutException unableToAcquireLock(String timeout, Object key, Object requestor, Object owner);
+   TimeoutException unableToAcquireLock(String timeout, Object key, Object requestor, Object owner, @Param boolean writableStackTrace);
 
 //   @Message(value = "There was an exception while processing retrieval of entry values", id = 300)
 //   CacheException exceptionProcessingEntryRetrievalValues(@Cause Throwable cause);


### PR DESCRIPTION
* Avoid capturing stack trace when throwing the TimeoutException when acquiring the locks.
* Skip logging the failed LockControlCommand.

The log will look something like:

```log
2026-06-18 00:50:59,033 ERROR (non-blocking-thread-ispn-2-1-4) [o.i.i.i.InvocationContextInterceptor] ISPN000136: Error executing command PutKeyValueCommand on Cache 'coordinator-failover.xml', writing keys [WrappedByteArray[\(00 (2 bytes)]]org.infinispan.commons.TimeoutException: ISPN000299: Unable to acquire lock after 9.98 seconds for key WrappedByteArray[\(00 (2 bytes)] and requestor GlobalTransaction{id=1950, addr=ispn-2, remote=false, xid=null, internalId=-1}. Lock is held by GlobalTransaction{id=2076, addr=ispn-3, remote=true, xid=null, internalId=-1}

2026-06-18 00:50:59,034 ERROR (non-blocking-thread-ispn-2-1-3) [o.i.i.i.InvocationContextInterceptor] ISPN000136: Error executing command PutKeyValueCommand on Cache 'coordinator-failover.xml', writing keys [WrappedByteArray[\(00 (2 bytes)]]org.infinispan.commons.TimeoutException: ISPN000299: Unable to acquire lock after 9.98 seconds for key WrappedByteArray[\(00 (2 bytes)] and requestor GlobalTransaction{id=1952, addr=ispn-2, remote=false, xid=null, internalId=-1}. Lock is held by GlobalTransaction{id=2076, addr=ispn-3, remote=true, xid=null, internalId=-1}

2026-06-18 00:50:59,033 ERROR (timeout-thread-ispn-2-p3-t1) [o.i.i.i.InvocationContextInterceptor] ISPN000136: Error executing command PutKeyValueCommand on Cache 'coordinator-failover.xml', writing keys [WrappedByteArray[\(00 (2 bytes)]]org.infinispan.commons.TimeoutException: ISPN000299: Unable to acquire lock after 10 seconds for key WrappedByteArray[\(00 (2 bytes)] and requestor GlobalTransaction{id=2128, addr=ispn-2, remote=false, xid=null, internalId=-1}. Lock is held by GlobalTransaction{id=2076, addr=ispn-3, remote=true, xid=null, internalId=-1} (pending)
```

Observe it skips logging the `LockControlCommand`, and only outputs the associated operation.

Closes: #17662

---

Author Checklist (all must be checked):
- [X] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [X] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [ ] ~The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.~
- [ ] ~The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.~
- [X] Log messages of level `INFO` and above have been internationalized.
- [ ] ~If the PR affects performance, include before/after benchmarks.~
- [X] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).
- [ ] ~If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.~

Reviewer Checklist (all must be checked):
- [ ] Code review
  - Are the changes reasonable?
  - Are there any use cases, integrations, inputs that haven't been considered in the implementation?
  - Is the code understandable? (KISS, comments)
  - Is there a better way to implement/write the functionality, code pieces?
  - Is formatting in line with the rest of the project? (checkstyle and spotless)
- [ ] Test review
  - Is the new test coverage rich enough to cover all the changes and considerations above?
  - Does the base functionality works as expected in the build project?
  - Does it behave as expected when given various inputs? (Valid and invalid, missing, partial)
  - Are there integrations to be considered? (Does the new functionality work well with the rest of the project, environment)
  -  Even if all above works as expected, are there weird behaviors to be improved on?
- [ ] Documentation review
  - Does the new/changed documentation cover the PR in sufficient matter?
  - For public API, are JavaDocs included for every new/changed class/method ?
  - For new features, does the documentation add/amend any usage examples ?
  - Grammar and syntax checks 
  - Does AsciiDoc generation report any WARN messages ?
