### PR TITLE
[#17517] Ignore Tomcat NIO connector threads in ThreadLeakChecker

### DIFF
--- a/testing/src/main/java/org/infinispan/testing/ThreadLeakChecker.java
+++ b/testing/src/main/java/org/infinispan/testing/ThreadLeakChecker.java
@@ -114,6 +114,8 @@ public class ThreadLeakChecker {
                       "|Timer-" +
                       // JVM internal reference cleaner
                       "|Cleaner-" +
+                      // Tomcat NIO connector threads
+                      "|http-nio-" +
                       ").*");
    private static final Pattern ARQUILLIAN_CONSOLE_CONSUMER_REGEX = Pattern.compile("org\\.jboss(\\.as)?\\.arquillian\\.container[^$]+\\$ConsoleConsumer");
    private static final boolean ENABLED =


### PR DESCRIPTION
## Summary
- Add `http-nio-` to the `ThreadLeakChecker` ignored threads regex to suppress false positive thread leak reports from Tomcat's NIO connector thread pool workers (`http-nio-8080-exec-*`).

Closes #17517

Created with the assistance of an AI tool