### PR TITLE
[#17687] Reduce allocation in DefaultPendingLockManager

### DIFF
--- a/core/src/main/java/org/infinispan/util/concurrent/locks/PendingLockPromise.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/PendingLockPromise.java
@@ -1,7 +1,10 @@
 package org.infinispan.util.concurrent.locks;
 
 
+import java.util.concurrent.CompletionStage;
+
 import org.infinispan.commons.TimeoutException;
+import org.infinispan.commons.util.concurrent.CompletableFutures;
 import org.infinispan.interceptors.InvocationStage;
 
 /**
@@ -43,6 +46,11 @@ public interface PendingLockPromise {
       }
 
       @Override
+      public CompletionStage<Void> toCompletionStage() {
+         return CompletableFutures.completedNull();
+      }
+
+      @Override
       public String toString() {
          return "NO_OP";
       }
@@ -81,4 +89,11 @@ public interface PendingLockPromise {
     * @return an {@link InvocationStage} for this lock.
     */
    InvocationStage toInvocationStage();
+
+   /**
+    * Transforms this promise into a {@link CompletionStage}.
+    *
+    * @return the transformed promise into a {@link CompletionStage}, never <code>null</code>.
+    */
+   CompletionStage<Void> toCompletionStage();
 }

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/impl/DefaultPendingLockManager.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/impl/DefaultPendingLockManager.java
@@ -6,10 +6,14 @@ import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXEC
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.Objects;
+import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -17,6 +21,8 @@ import java.util.function.Consumer;
 
 import org.infinispan.commons.TimeoutException;
 import org.infinispan.commons.time.TimeService;
+import org.infinispan.commons.util.concurrent.AggregateCompletionStage;
+import org.infinispan.commons.util.concurrent.CompletionStages;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.ComponentName;
@@ -56,6 +62,8 @@ public class DefaultPendingLockManager implements PendingLockManager {
    @Inject @ComponentName(TIMEOUT_SCHEDULE_EXECUTOR)
    ScheduledExecutorService timeoutExecutor;
 
+   private final Map<Object, SharedPendingSignal> activeSignals = new ConcurrentHashMap<>();
+
    public DefaultPendingLockManager() {
    }
 
@@ -69,8 +77,35 @@ public class DefaultPendingLockManager implements PendingLockManager {
          }
          return PendingLockPromise.NO_OP;
       }
-      return createPromise(getTransactionWithLockedKey(txTopologyId, key, globalTransaction), globalTransaction, time,
-                           unit);
+
+      SharedPendingSignal signal = activeSignals.get(key);
+      if (signal != null && signal.isDone()) {
+         activeSignals.remove(key, signal);
+         signal = null;
+      }
+
+      if (signal == null) {
+         signal = activeSignals.computeIfAbsent(key, k-> {
+            Collection<PendingTransaction> transactions = getTransactionWithLockedKey(txTopologyId, k, globalTransaction);
+            if (transactions.isEmpty())
+               return null;
+
+            return createSharedSignal(transactions);
+         });
+
+         if (signal != null) {
+            final SharedPendingSignal s = signal;
+            signal.onComplete(() -> activeSignals.remove(key, s));
+         }
+      }
+
+      if (signal == null || signal.isDone() || signal.isOnlyPendingFor(globalTransaction)) {
+         return PendingLockPromise.NO_OP;
+      }
+
+      PendingLockPromiseImpl pendingLockPromise = new PendingLockPromiseImpl(globalTransaction, time, unit);
+      signal.addWaiter(pendingLockPromise);
+      return pendingLockPromise;
    }
 
    @Override
@@ -84,26 +119,35 @@ public class DefaultPendingLockManager implements PendingLockManager {
          }
          return PendingLockPromise.NO_OP;
       }
-      return createPromise(getTransactionWithAnyLockedKey(txTopologyId, keys, globalTransaction), globalTransaction,
-                           time, unit);
+
+      if (keys.size() == 1)
+         return checkPendingTransactionsForKey(ctx, keys.iterator().next(), time, unit);
+
+      List<PendingLockPromise> pending = null;
+      for (Object key : keys) {
+         PendingLockPromise promise = checkPendingTransactionsForKey(ctx, key, time, unit);
+         if (promise == PendingLockPromise.NO_OP)
+            continue;
+
+         if (pending == null)
+            pending = new ArrayList<>();
+
+         pending.add(promise);
+      }
+
+      if (pending == null)
+         return PendingLockPromise.NO_OP;
+
+      if (pending.size() == 1)
+         return pending.get(0);
+
+      return new CompositePendingLockPromise(pending, time, unit);
    }
 
-   private PendingLockPromise createPromise(Collection<PendingTransaction> transactions,
-                                            GlobalTransaction globalTransaction, long time, TimeUnit unit) {
-      if (transactions.isEmpty()) {
-         if (log.isTraceEnabled()) {
-            log.tracef("No transactions pending for transaction %s", globalTransaction);
-         }
-         return PendingLockPromise.NO_OP;
-      }
-
-      if (log.isTraceEnabled()) {
-         log.tracef("Transactions pending for transaction %s are %s", globalTransaction, transactions);
-      }
-      PendingLockPromiseImpl pendingLockPromise = new PendingLockPromiseImpl(globalTransaction, time, unit, transactions);
-      pendingLockPromise.scheduleTimeoutTask();
-      pendingLockPromise.registerListenerInCacheTransactions();
-      return pendingLockPromise;
+   private SharedPendingSignal createSharedSignal(Collection<PendingTransaction> transactions) {
+      SharedPendingSignal signal = new SharedPendingSignal(transactions);
+      signal.registerListeners();
+      return signal;
    }
 
    private int getTopologyId(TxInvocationContext<?> context) {
@@ -137,27 +181,8 @@ public class DefaultPendingLockManager implements PendingLockManager {
          if (transaction.getTopologyId() < transactionTopologyId &&
                !transaction.getGlobalTransaction().equals(globalTransaction)) {
             CompletableFuture<Void> keyReleasedFuture = transaction.getReleaseFutureForKey(key);
-            if (keyReleasedFuture != null) {
+            if (keyReleasedFuture != null && !keyReleasedFuture.isDone()) {
                pendingTransactions.add(new PendingTransaction(transaction, Collections.singletonMap(key, keyReleasedFuture)));
-            }
-         }
-      });
-      return pendingTransactions.isEmpty() ? Collections.emptyList() : pendingTransactions;
-   }
-
-   private Collection<PendingTransaction> getTransactionWithAnyLockedKey(int transactionTopologyId,
-                                                                         Collection<Object> keys,
-                                                                         GlobalTransaction globalTransaction) {
-      if (keys.isEmpty()) {
-         return Collections.emptyList();
-      }
-      final Collection<PendingTransaction> pendingTransactions = new ArrayList<>();
-      forEachTransaction(transaction -> {
-         if (transaction.getTopologyId() < transactionTopologyId &&
-               !transaction.getGlobalTransaction().equals(globalTransaction)) {
-            Map<Object, CompletableFuture<Void>> keyReleaseFuture = transaction.getReleaseFutureForKeys(keys);
-            if (keyReleaseFuture != null) {
-               pendingTransactions.add(new PendingTransaction(transaction, keyReleaseFuture));
             }
          }
       });
@@ -180,16 +205,6 @@ public class DefaultPendingLockManager implements PendingLockManager {
       }
    }
 
-   private static long awaitOn(PendingLockPromise pendingLockPromise, GlobalTransaction globalTransaction, long timeout, TimeUnit timeUnit)
-         throws InterruptedException {
-      if (pendingLockPromise == PendingLockPromise.NO_OP) {
-         return timeUnit.toMillis(timeout);
-      }
-      assert pendingLockPromise instanceof PendingLockPromiseImpl;
-      ((PendingLockPromiseImpl) pendingLockPromise).await();
-      return pendingLockPromise.getRemainingTimeout();
-   }
-
    private static class PendingTransaction {
       private final CacheTransaction cacheTransaction;
       private final Map<Object, CompletableFuture<Void>> keyReleased;
@@ -208,7 +223,13 @@ public class DefaultPendingLockManager implements PendingLockManager {
       }
 
       void afterCompleted(Runnable runnable) {
-         keyReleased.values().forEach(voidCompletableFuture -> voidCompletableFuture.thenRun(runnable));
+         for (CompletableFuture<Void> cf : keyReleased.values()) {
+            if (!cf.isDone()) {
+               cf.thenRun(runnable);
+            }
+         }
+
+         runnable.run();
       }
 
       KeyValuePair<CacheTransaction, Object> findUnreleasedKey() {
@@ -221,21 +242,147 @@ public class DefaultPendingLockManager implements PendingLockManager {
       }
    }
 
-   private class PendingLockPromiseImpl implements PendingLockPromise, Callable<Void>, Runnable {
-      private final GlobalTransaction globalTransaction;
-      private final long timeoutNanos;
+   private class SharedPendingSignal implements Runnable {
 
       private final Collection<PendingTransaction> pendingTransactions;
+      private final Queue<PendingLockPromiseImpl> waiters;
+
+      // All the values are read/written by different "requester" threads and by the timeout cleanup.
+      private volatile Runnable onComplete = null;
+      private volatile ScheduledFuture<?> timeoutTask;
+      private volatile boolean completed;
+
+      public SharedPendingSignal(Collection<PendingTransaction> pendingTransactions) {
+         this.pendingTransactions = pendingTransactions;
+         this.waiters = new ConcurrentLinkedDeque<>();
+      }
+
+      public void addWaiter(PendingLockPromiseImpl waiter) {
+         waiters.add(waiter);
+         if (completed) {
+            waiter.complete();
+            return;
+         }
+         scheduleNextTimeout();
+      }
+
+      public void onComplete(Runnable runnable) {
+         this.onComplete = runnable;
+         if (isDone())
+            onComplete.run();
+      }
+
+      private void scheduleNextTimeout() {
+         // Waiters have the same timeout and arrive in any order.
+         // The first one to arrive is most likely one to timeout next.
+         // We schedule a single timeout for the first one, then we timeout everything until the un-expired waiter.
+         PendingLockPromiseImpl head = waiters.peek();
+         if (head == null)
+            return;
+
+         ScheduledFuture<?> curr = timeoutTask;
+         if (curr != null && !curr.isDone())
+            return;
+
+         scheduleNextTimeout(head);
+      }
+
+      private void checkTimeouts() {
+         if (completed)
+            return;
+
+         PendingLockPromiseImpl head;
+         while ((head = waiters.peek()) != null) {
+
+            // If not expired yet, we schedule the timeout operation only for the head and leave.
+            if (!timeService.isTimeExpired(head.expectedEndTime)) {
+               scheduleNextTimeout(head);
+               return;
+            }
+
+            // If the head has expired, we consume the queue until finding the first non-expired entry.
+            waiters.poll();
+            if (!head.notifier.isDone()) {
+               KeyValuePair<CacheTransaction, Object> unreleased = findUnreleasedKey();
+               if (unreleased != null) {
+                  head.timeout(unreleased);
+               } else {
+                  head.complete();
+               }
+            }
+         }
+      }
+
+      public boolean isOnlyPendingFor(GlobalTransaction gtx) {
+         for (PendingTransaction tx : pendingTransactions) {
+            if (tx.findUnreleasedKey() != null && !Objects.equals(gtx, tx.cacheTransaction.getGlobalTransaction()))
+               return false;
+         }
+
+         return true;
+      }
+
+      private void scheduleNextTimeout(PendingLockPromiseImpl head) {
+         long remaining = timeService.remainingTime(head.expectedEndTime, TimeUnit.NANOSECONDS);
+         timeoutTask = timeoutExecutor.schedule(this::checkTimeouts, remaining, TimeUnit.NANOSECONDS);
+      }
+
+      @Override
+      public void run() {
+         if (completed)
+            return;
+
+         for (PendingTransaction tx : pendingTransactions) {
+            if (tx.findUnreleasedKey() != null)
+               return;
+         }
+
+         completed = true;
+
+         ScheduledFuture<?> t = timeoutTask;
+         if (t != null)
+            t.cancel(false);
+
+         PendingLockPromiseImpl plpi;
+         while ((plpi = waiters.poll()) != null) {
+            plpi.complete();
+         }
+
+         if (onComplete != null)
+            onComplete.run();
+      }
+
+      public boolean isDone() {
+         return completed;
+      }
+
+      public KeyValuePair<CacheTransaction, Object> findUnreleasedKey() {
+         for (PendingTransaction tx : pendingTransactions) {
+            KeyValuePair<CacheTransaction, Object> waiting = tx.findUnreleasedKey();
+            if (waiting != null)
+               return waiting;
+         }
+
+         return null;
+      }
+
+      public void registerListeners() {
+         for (PendingTransaction tx : pendingTransactions) {
+            tx.afterCompleted(this);
+         }
+      }
+   }
+
+   private class PendingLockPromiseImpl implements PendingLockPromise {
+
+      private final GlobalTransaction globalTransaction;
+      private final long timeoutNanos;
       private final long expectedEndTime;
       private final CompletableFuture<Void> notifier;
-      private ScheduledFuture<Void> timeoutTask;
 
-      private PendingLockPromiseImpl(GlobalTransaction globalTransaction,
-                                     long timeout, TimeUnit timeUnit,
-                                     Collection<PendingTransaction> pendingTransactions) {
+      private PendingLockPromiseImpl(GlobalTransaction globalTransaction, long timeout, TimeUnit timeUnit) {
          this.globalTransaction = globalTransaction;
          this.timeoutNanos = timeUnit.toNanos(timeout);
-         this.pendingTransactions = pendingTransactions;
          this.expectedEndTime = timeService.expectedEndTime(timeoutNanos, TimeUnit.NANOSECONDS);
          this.notifier = new CompletableFuture<>();
       }
@@ -266,70 +413,64 @@ public class DefaultPendingLockManager implements PendingLockManager {
       }
 
       @Override
-      public Void call() throws Exception {
-         //invoked when the timeout kicks.
-         onRelease();
-         return null;
+      public CompletionStage<Void> toCompletionStage() {
+         return notifier;
+      }
+
+      public void timeout(KeyValuePair<CacheTransaction, Object> unreleased) {
+         log.tracef("Timed out waiting for pending unreleased %s for TX=%s", unreleased, globalTransaction);
+         notifier.completeExceptionally(DefaultPendingLockManager.timeout(unreleased, globalTransaction, timeoutNanos, TimeUnit.NANOSECONDS));
+      }
+
+      public void complete() {
+         log.tracef("All pending transactions have finished for TX=%s", globalTransaction);
+         notifier.complete(null);
+      }
+   }
+
+   private class CompositePendingLockPromise implements PendingLockPromise {
+
+      private final CompletableFuture<Void> notifier;
+      private final long expectedEndTimeNs;
+
+      public CompositePendingLockPromise(Collection<PendingLockPromise> promises, long time, TimeUnit unit) {
+         this.expectedEndTimeNs = timeService.expectedEndTime(unit.toNanos(time), TimeUnit.NANOSECONDS);
+
+         AggregateCompletionStage<Void> aggregate = CompletionStages.aggregateCompletionStage();
+         for (PendingLockPromise promise : promises) {
+            aggregate.dependsOn(promise.toCompletionStage());
+         }
+         this.notifier = aggregate.freeze().toCompletableFuture();
       }
 
       @Override
-      public void run() {
-         //invoked when a pending backup lock is released
-         onRelease();
+      public boolean isReady() {
+         return notifier.isDone();
       }
 
-      private void onRelease() {
-         KeyValuePair<CacheTransaction, Object> timedOutTransaction = null;
-         for (PendingTransaction transaction : pendingTransactions) {
-            KeyValuePair<CacheTransaction, Object> waiting = transaction.findUnreleasedKey();
-            if (waiting != null) {
-               // Found a pending transaction
-               if (timeService.isTimeExpired(expectedEndTime)) {
-                  // Timed out, complete the promise
-                  timedOutTransaction = waiting;
-                  break;
-               } else {
-                  // Not timed out, wait some more
-                  return;
-               }
-            }
-         }
-
-         if (timeoutTask != null) {
-            timeoutTask.cancel(false);
-         }
-         if (timedOutTransaction == null) {
-            if (log.isTraceEnabled()) log.tracef("All pending transactions have finished for transaction %s", globalTransaction);
-            notifier.complete(null);
-         } else {
-            if (log.isTraceEnabled()) log.tracef("Timed out waiting for pending transaction %s for transaction %s", timedOutTransaction, globalTransaction);
-            notifier.completeExceptionally(timeout(timedOutTransaction, globalTransaction, timeoutNanos, TimeUnit.NANOSECONDS));
-         }
+      @Override
+      public void addListener(PendingLockListener listener) {
+         notifier.whenComplete((v, t) -> listener.onReady());
       }
 
-      void registerListenerInCacheTransactions() {
-         for (PendingTransaction transaction : pendingTransactions) {
-            transaction.afterCompleted(this);
-         }
-         // Maybe one of the transactions has finished or removed a backup lock before we added the listener
-         onRelease();
+      @Override
+      public boolean hasTimedOut() {
+         return notifier.isCompletedExceptionally();
       }
 
-      void scheduleTimeoutTask() {
-         if (!notifier.isDone()) {
-            // schedule(Runnable) creates an extra Callable wrapper object
-            timeoutTask = timeoutExecutor.schedule((Callable<Void>) this, timeoutNanos, TimeUnit.NANOSECONDS);
-         }
+      @Override
+      public long getRemainingTimeout() {
+         return timeService.remainingTime(expectedEndTimeNs, TimeUnit.MILLISECONDS);
       }
 
-      void await() throws InterruptedException {
-         try {
-            notifier.get(timeService.remainingTime(expectedEndTime, TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
-         } catch (ExecutionException e) {
-            throw new IllegalStateException("Should never happen.", e);
-         } catch (java.util.concurrent.TimeoutException e) {
-            //ignore
-         }
+      @Override
+      public InvocationStage toInvocationStage() {
+         return new SimpleAsyncInvocationStage(notifier);
+      }
+
+      @Override
+      public CompletionStage<Void> toCompletionStage() {
+         return notifier;
       }
    }
 }

--- a/core/src/test/java/org/infinispan/util/concurrent/locks/impl/DefaultPendingLockManagerTest.java
+++ b/core/src/test/java/org/infinispan/util/concurrent/locks/impl/DefaultPendingLockManagerTest.java
@@ -1,0 +1,515 @@
+package org.infinispan.util.concurrent.locks.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.infinispan.factories.KnownComponentNames.TIMEOUT_SCHEDULE_EXECUTOR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commons.TimeoutException;
+import org.infinispan.commons.time.ControlledTimeService;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.LocalizedCacheTopology;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.transaction.xa.CacheTransaction;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.concurrent.locks.PendingLockPromise;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "util.concurrent.locks.impl.DefaultPendingLockManagerTest")
+public class DefaultPendingLockManagerTest extends AbstractInfinispanTest {
+
+   private static final int CURRENT_TOPOLOGY = 10;
+   private static final int OLD_TOPOLOGY = 5;
+   private static final long LOCK_TIMEOUT = 10_000;
+
+   private DefaultPendingLockManager manager;
+   private ControlledTimeService timeService;
+   private List<CacheTransaction> transactions;
+   private Queue<Runnable> scheduledTimeouts;
+
+   @BeforeMethod
+   public void setUp() {
+      manager = new DefaultPendingLockManager();
+      timeService = new ControlledTimeService();
+      transactions = new ArrayList<>();
+      scheduledTimeouts = new ConcurrentLinkedDeque<>();
+
+      TransactionTable transactionTable = mock(TransactionTable.class);
+      when(transactionTable.getMinTopologyId()).thenReturn(OLD_TOPOLOGY);
+      when(transactionTable.getLocalTransactions()).thenReturn(Collections.emptyList());
+      when(transactionTable.getRemoteTransactions()).thenAnswer(inv -> transactions);
+
+      LocalizedCacheTopology cacheTopology = mock(LocalizedCacheTopology.class);
+      when(cacheTopology.getTopologyId()).thenReturn(CURRENT_TOPOLOGY);
+      DistributionManager distributionManager = mock(DistributionManager.class);
+      when(distributionManager.getCacheTopology()).thenReturn(cacheTopology);
+
+      TestingUtil.inject(manager,
+            transactionTable,
+            timeService,
+            distributionManager,
+            TestingUtil.named(TIMEOUT_SCHEDULE_EXECUTOR, createMockTimeoutExecutor()));
+   }
+
+   @AfterMethod
+   public void tearDown() {
+      transactions.clear();
+      scheduledTimeouts.clear();
+   }
+
+   public void testNoPendingCheckWhenMinTopologyMatchesCurrent() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      TransactionTable table = mock(TransactionTable.class);
+      when(table.getMinTopologyId()).thenReturn(CURRENT_TOPOLOGY);
+      when(table.getLocalTransactions()).thenReturn(Collections.emptyList());
+      when(table.getRemoteTransactions()).thenAnswer(inv -> transactions);
+
+      LocalizedCacheTopology topology = mock(LocalizedCacheTopology.class);
+      when(topology.getTopologyId()).thenReturn(CURRENT_TOPOLOGY);
+      DistributionManager dm = mock(DistributionManager.class);
+      when(dm.getCacheTopology()).thenReturn(topology);
+
+      DefaultPendingLockManager noCheckManager = new DefaultPendingLockManager();
+      TestingUtil.inject(noCheckManager, table, timeService, dm,
+            TestingUtil.named(TIMEOUT_SCHEDULE_EXECUTOR, createMockTimeoutExecutor()));
+
+      PendingLockPromise promise = noCheckManager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testNoPendingTransactions() {
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testNoMatchingTransactionsAtCurrentTopology() {
+      GlobalTransaction txGtx = newGlobalTransaction();
+      transactions.add(transactionAt(txGtx, CURRENT_TOPOLOGY, "key-1", new CompletableFuture<>()));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testCompletedFutureFilteredFromScan() {
+      CompletableFuture<Void> alreadyDone = CompletableFuture.completedFuture(null);
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", alreadyDone));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testOwnTransactionFilteredFromScan() {
+      GlobalTransaction requestingGtx = newGlobalTransaction();
+      transactions.add(pendingTransaction(requestingGtx, "key-1", new CompletableFuture<>()));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(requestingGtx), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testPendingTransactionCompletesNormally() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isNotSameAs(PendingLockPromise.NO_OP);
+      assertThat(promise.isReady()).isFalse();
+      assertThat(promise.hasTimedOut()).isFalse();
+
+      releaseFuture.complete(null);
+      assertThat(promise.isReady()).isTrue();
+      assertThat(promise.hasTimedOut()).isFalse();
+   }
+
+   public void testSignalReusedForSameKey() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      GlobalTransaction requester1 = newGlobalTransaction();
+      GlobalTransaction requester2 = newGlobalTransaction();
+
+      PendingLockPromise promise1 = manager.checkPendingTransactionsForKey(
+            context(requester1), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      PendingLockPromise promise2 = manager.checkPendingTransactionsForKey(
+            context(requester2), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      assertThat(promise1.isReady()).isFalse();
+      assertThat(promise2.isReady()).isFalse();
+
+      releaseFuture.complete(null);
+      assertThat(promise1.isReady()).isTrue();
+      assertThat(promise2.isReady()).isTrue();
+   }
+
+   public void testSignalReplacedAfterCompletion() {
+      CompletableFuture<Void> releaseFuture1 = new CompletableFuture<>();
+      GlobalTransaction blockerGtx1 = newGlobalTransaction();
+      transactions.add(pendingTransaction(blockerGtx1, "key-1", releaseFuture1));
+
+      PendingLockPromise promise1 = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise1.isReady()).isFalse();
+
+      releaseFuture1.complete(null);
+      assertThat(promise1.isReady()).isTrue();
+
+      transactions.clear();
+      CompletableFuture<Void> releaseFuture2 = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture2));
+
+      PendingLockPromise promise2 = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise2).isNotSameAs(PendingLockPromise.NO_OP);
+      assertThat(promise2.isReady()).isFalse();
+
+      releaseFuture2.complete(null);
+      assertThat(promise2.isReady()).isTrue();
+   }
+
+   public void testIsOnlyPendingForSameGtxReturnsNoOp() {
+      GlobalTransaction blockerGtx = newGlobalTransaction();
+      transactions.add(pendingTransaction(blockerGtx, "key-1", new CompletableFuture<>()));
+
+      GlobalTransaction differentRequester = newGlobalTransaction();
+      PendingLockPromise firstPromise = manager.checkPendingTransactionsForKey(
+            context(differentRequester), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(firstPromise).isNotSameAs(PendingLockPromise.NO_OP);
+
+      PendingLockPromise selfPromise = manager.checkPendingTransactionsForKey(
+            context(blockerGtx), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(selfPromise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testIsOnlyPendingForMixedGtxReturnsPendingPromise() {
+      GlobalTransaction blocker1 = newGlobalTransaction();
+      GlobalTransaction blocker2 = newGlobalTransaction();
+      transactions.add(pendingTransaction(blocker1, "key-1", new CompletableFuture<>()));
+      transactions.add(pendingTransaction(blocker2, "key-1", new CompletableFuture<>()));
+
+      GlobalTransaction differentRequester = newGlobalTransaction();
+      PendingLockPromise firstPromise = manager.checkPendingTransactionsForKey(
+            context(differentRequester), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(firstPromise).isNotSameAs(PendingLockPromise.NO_OP);
+
+      PendingLockPromise selfPromise = manager.checkPendingTransactionsForKey(
+            context(blocker1), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(selfPromise).isNotSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testIsOnlyPendingForAfterPartialCompletion() {
+      GlobalTransaction blocker1 = newGlobalTransaction();
+      GlobalTransaction blocker2 = newGlobalTransaction();
+      CompletableFuture<Void> release1 = new CompletableFuture<>();
+      CompletableFuture<Void> release2 = new CompletableFuture<>();
+      transactions.add(pendingTransaction(blocker1, "key-1", release1));
+      transactions.add(pendingTransaction(blocker2, "key-1", release2));
+
+      GlobalTransaction differentRequester = newGlobalTransaction();
+      manager.checkPendingTransactionsForKey(
+            context(differentRequester), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      release1.complete(null);
+
+      PendingLockPromise selfPromise = manager.checkPendingTransactionsForKey(
+            context(blocker2), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(selfPromise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testTimeout() {
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", new CompletableFuture<>()));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise.isReady()).isFalse();
+
+      timeService.advance(LOCK_TIMEOUT + 1);
+      fireLastScheduledTimeout();
+
+      assertThat(promise.isReady()).isTrue();
+      assertThat(promise.hasTimedOut()).isTrue();
+      assertThatThrownBy(() -> promise.toInvocationStage().toCompletableFuture()
+            .get(1, TimeUnit.SECONDS))
+            .hasCauseInstanceOf(TimeoutException.class);
+   }
+
+   public void testMultipleWaitersHeadTimesOutNextSurvives() {
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", new CompletableFuture<>()));
+
+      PendingLockPromise head = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      timeService.advance(1_000);
+
+      PendingLockPromise tail = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      timeService.advance(LOCK_TIMEOUT - 1);
+      fireLastScheduledTimeout();
+
+      assertThat(head.hasTimedOut()).isTrue();
+      assertThat(tail.isReady()).isFalse();
+      assertThat(tail.hasTimedOut()).isFalse();
+   }
+
+   public void testWaiterAfterCompletionIsImmediatelyReady() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      PendingLockPromise first = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      releaseFuture.complete(null);
+      assertThat(first.isReady()).isTrue();
+
+      PendingLockPromise late = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(late.isReady()).isTrue();
+   }
+
+   public void testMultiKeyComposite() {
+      CompletableFuture<Void> release1 = new CompletableFuture<>();
+      CompletableFuture<Void> release2 = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", release1));
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-2", release2));
+
+      GlobalTransaction requester = newGlobalTransaction();
+      Collection<Object> keys = List.of("key-1", "key-2");
+      PendingLockPromise composite = manager.checkPendingTransactionsForKeys(
+            context(requester), keys, LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      assertThat(composite).isNotSameAs(PendingLockPromise.NO_OP);
+      assertThat(composite.isReady()).isFalse();
+
+      release1.complete(null);
+      assertThat(composite.isReady()).isFalse();
+
+      release2.complete(null);
+      assertThat(composite.isReady()).isTrue();
+      assertThat(composite.hasTimedOut()).isFalse();
+   }
+
+   public void testMultiKeyTimeoutPropagation() {
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", new CompletableFuture<>()));
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-2", new CompletableFuture<>()));
+
+      Collection<Object> keys = List.of("key-1", "key-2");
+      PendingLockPromise composite = manager.checkPendingTransactionsForKeys(
+            context(newGlobalTransaction()), keys, LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      timeService.advance(LOCK_TIMEOUT + 1);
+      scheduledTimeouts.forEach(Runnable::run);
+
+      assertThat(composite.isReady()).isTrue();
+      assertThat(composite.hasTimedOut()).isTrue();
+   }
+
+   public void testMultiKeySingleKeyOptimization() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKeys(
+            context(newGlobalTransaction()), List.of("key-1"), LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isNotSameAs(PendingLockPromise.NO_OP);
+
+      releaseFuture.complete(null);
+      assertThat(promise.isReady()).isTrue();
+   }
+
+   public void testMultiKeyMixedPendingAndNoPending() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      Collection<Object> keys = List.of("key-1", "key-no-pending");
+      PendingLockPromise promise = manager.checkPendingTransactionsForKeys(
+            context(newGlobalTransaction()), keys, LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      assertThat(promise).isNotSameAs(PendingLockPromise.NO_OP);
+      assertThat(promise.isReady()).isFalse();
+
+      releaseFuture.complete(null);
+      assertThat(promise.isReady()).isTrue();
+   }
+
+   public void testMultiKeyAllNoOp() {
+      PendingLockPromise promise = manager.checkPendingTransactionsForKeys(
+            context(newGlobalTransaction()), List.of("key-1", "key-2"), LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      assertThat(promise).isSameAs(PendingLockPromise.NO_OP);
+   }
+
+   public void testListenerNotifiedOnCompletion() {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      PendingLockPromise promise = manager.checkPendingTransactionsForKey(
+            context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      CompletableFuture<Void> listenerFired = new CompletableFuture<>();
+      promise.addListener(() -> listenerFired.complete(null));
+      assertThat(listenerFired).isNotDone();
+
+      releaseFuture.complete(null);
+      assertThat(listenerFired).isDone();
+   }
+
+   public void testConcurrentCheckOnSameKey() throws Exception {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      int threadCount = 10;
+      CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+      List<Future<PendingLockPromise>> futures = new ArrayList<>(threadCount);
+
+      for (int i = 0; i < threadCount; i++) {
+         futures.add(fork(() -> {
+            barrier.await(10, TimeUnit.SECONDS);
+            return manager.checkPendingTransactionsForKey(
+                  context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+         }));
+      }
+
+      barrier.await(10, TimeUnit.SECONDS);
+
+      List<PendingLockPromise> promises = new ArrayList<>(threadCount);
+      for (Future<PendingLockPromise> f : futures) {
+         promises.add(f.get(10, TimeUnit.SECONDS));
+      }
+
+      for (PendingLockPromise promise : promises) {
+         assertThat(promise).isNotSameAs(PendingLockPromise.NO_OP);
+         assertThat(promise.isReady()).isFalse();
+      }
+
+      releaseFuture.complete(null);
+
+      for (PendingLockPromise promise : promises) {
+         assertThat(promise.isReady()).isTrue();
+         assertThat(promise.hasTimedOut()).isFalse();
+      }
+   }
+
+   public void testConcurrentCheckOnSameKeyDuringCompletion() throws Exception {
+      CompletableFuture<Void> releaseFuture = new CompletableFuture<>();
+      transactions.add(pendingTransaction(newGlobalTransaction(), "key-1", releaseFuture));
+
+      int threadCount = 10;
+      CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+      List<Future<PendingLockPromise>> futures = new ArrayList<>(threadCount);
+
+      for (int i = 0; i < threadCount; i++) {
+         futures.add(fork(() -> {
+            barrier.await(10, TimeUnit.SECONDS);
+            return manager.checkPendingTransactionsForKey(
+                  context(newGlobalTransaction()), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+         }));
+      }
+
+      barrier.await(10, TimeUnit.SECONDS);
+      releaseFuture.complete(null);
+
+      for (Future<PendingLockPromise> f : futures) {
+         PendingLockPromise promise = f.get(10, TimeUnit.SECONDS);
+         if (promise != PendingLockPromise.NO_OP) {
+            assertThat(promise.isReady()).isTrue();
+            assertThat(promise.hasTimedOut()).isFalse();
+         }
+      }
+   }
+
+   public void testIndependentKeysHaveIndependentSignals() {
+      CompletableFuture<Void> release1 = new CompletableFuture<>();
+      CompletableFuture<Void> release2 = new CompletableFuture<>();
+      GlobalTransaction blockerGtx = newGlobalTransaction();
+      transactions.add(pendingTransaction(blockerGtx, "key-1", release1));
+      transactions.add(pendingTransaction(blockerGtx, "key-2", release2));
+
+      GlobalTransaction requester = newGlobalTransaction();
+      PendingLockPromise p1 = manager.checkPendingTransactionsForKey(
+            context(requester), "key-1", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+      PendingLockPromise p2 = manager.checkPendingTransactionsForKey(
+            context(requester), "key-2", LOCK_TIMEOUT, TimeUnit.MILLISECONDS);
+
+      release1.complete(null);
+      assertThat(p1.isReady()).isTrue();
+      assertThat(p2.isReady()).isFalse();
+
+      release2.complete(null);
+      assertThat(p2.isReady()).isTrue();
+   }
+
+   private void fireLastScheduledTimeout() {
+      Runnable last = null;
+      for (Runnable r : scheduledTimeouts) {
+         last = r;
+      }
+      if (last != null) {
+         last.run();
+      }
+   }
+
+   private ScheduledExecutorService createMockTimeoutExecutor() {
+      ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+      when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+            .thenAnswer(inv -> {
+               scheduledTimeouts.add(inv.getArgument(0));
+               ScheduledFuture<?> future = mock(ScheduledFuture.class);
+               when(future.isDone()).thenReturn(true);
+               return future;
+            });
+      return executor;
+   }
+
+   @SuppressWarnings("unchecked")
+   private static TxInvocationContext<?> context(GlobalTransaction gtx) {
+      TxInvocationContext<?> ctx = mock(TxInvocationContext.class);
+      when(ctx.getGlobalTransaction()).thenReturn(gtx);
+      when(ctx.isOriginLocal()).thenReturn(false);
+      return ctx;
+   }
+
+   private static GlobalTransaction newGlobalTransaction() {
+      return new GlobalTransaction(null, false);
+   }
+
+   private static CacheTransaction pendingTransaction(GlobalTransaction gtx, Object key,
+                                                       CompletableFuture<Void> releaseFuture) {
+      return transactionAt(gtx, OLD_TOPOLOGY, key, releaseFuture);
+   }
+
+   private static CacheTransaction transactionAt(GlobalTransaction gtx, int topologyId, Object key,
+                                                   CompletableFuture<Void> releaseFuture) {
+      CacheTransaction tx = Mockito.mock(CacheTransaction.class);
+      when(tx.getGlobalTransaction()).thenReturn(gtx);
+      when(tx.getTopologyId()).thenReturn(topologyId);
+      when(tx.getReleaseFutureForKey(key)).thenReturn(releaseFuture);
+      when(tx.getLockedKeys()).thenReturn(Collections.singleton(key));
+      return tx;
+   }
+}


### PR DESCRIPTION
* Avoid creating objects for already completed TXs.
* Create a shared instance to avoid unnecessary allocation per request.

I've collected some traces with async profiler for alloc events.
Here is a before:

```text
$ awk '/^---/{h=$0;next} /DefaultPendingLockManager/ && !s[h]++{print h}' historic/allocation-profile/logs/ispn-*/profile.traces | sort -t'(' -k2 -rn
--- 59244431 bytes (6.80%), 113 samples
--- 51380126 bytes (5.90%), 98 samples
--- 50331552 bytes (5.78%), 96 samples
--- 47185830 bytes (5.42%), 90 samples
--- 31981507 bytes (3.67%), 61 samples
--- 28835785 bytes (3.31%), 55 samples
--- 27787211 bytes (3.19%), 53 samples
--- 25165776 bytes (2.89%), 48 samples
--- 24641489 bytes (2.83%), 47 samples
--- 24117202 bytes (2.77%), 46 samples
--- 23592915 bytes (2.71%), 45 samples
--- 22544341 bytes (2.59%), 43 samples
--- 20971480 bytes (2.41%), 40 samples
--- 19922906 bytes (2.29%), 38 samples
--- 19398619 bytes (2.23%), 37 samples
--- 18350045 bytes (2.11%), 35 samples
--- 17825758 bytes (2.05%), 34 samples
--- 17301471 bytes (1.99%), 33 samples
--- 15204323 bytes (1.75%), 29 samples
--- 14155749 bytes (1.63%), 27 samples
--- 13631462 bytes (1.57%), 26 samples
--- 12058601 bytes (1.38%), 23 samples
--- 11534314 bytes (1.32%), 22 samples
--- 11010027 bytes (1.26%), 21 samples
--- 8912879 bytes (1.02%), 17 samples
--- 7864305 bytes (0.90%), 15 samples
--- 3145722 bytes (0.36%), 6 samples
--- 2621435 bytes (0.30%), 5 samples
--- 2097148 bytes (0.24%), 4 samples
--- 1572861 bytes (0.18%), 3 samples
--- 1048574 bytes (0.12%), 2 samples
--- 524287 bytes (0.06%), 1 sample
```

This seems to sum up to:

```
$ awk '/^---/{h=$0;next} /DefaultPendingLockManager/ && !seen[h]++ {
    match(h,/([0-9]+) bytes/,a); s+=a[1]
  } END {printf "%.1f MB\n",s/1048576}' historic/allocation-profile/logs/ispn-*/profile.traces
606.5 MB
```
My test has an Xmx of 600 and something. The container has 1Gb, and the java use the ergonomics for Xmx.
The after:

```text
$ grep -l "DefaultPendingLockManager" logs/*/profile.traces
```

There are no traces in the profile with the changes applied in any of the 5 nodes.

Closes: #17687

---

Author Checklist (all must be checked):
- [X] Commit message includes a reference to the corresponding [GitHub issue](https://github.com/infinispan/infinispan/issues) (e.g. commit message: "[#00000] Issue title...") and is formatted according to our [git message template](https://github.com/infinispan/infinispan/blob/main/.gitmessage).
- [X] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [X] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification **MUST** be provided.
- [ ] ~The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification **MUST** be provided.~
- [ ] ~Log messages of level `INFO` and above have been internationalized.~
- [ ] ~If the PR affects performance, include before/after benchmarks.~
- [ ] ~If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot).~
- [ ] ~If the PR requires a followup or is part of a larger body of work, ensure that relevant [GitHub issues](https://github.com/infinispan/infinispan/issues) have been created to track the additional work.~

Reviewer Checklist (all must be checked):
- [ ] Code review
  - Are the changes reasonable?
  - Are there any use cases, integrations, inputs that haven't been considered in the implementation?
  - Is the code understandable? (KISS, comments)
  - Is there a better way to implement/write the functionality, code pieces?
  - Is formatting in line with the rest of the project? (checkstyle and spotless)
- [ ] Test review
  - Is the new test coverage rich enough to cover all the changes and considerations above?
  - Does the base functionality works as expected in the build project?
  - Does it behave as expected when given various inputs? (Valid and invalid, missing, partial)
  - Are there integrations to be considered? (Does the new functionality work well with the rest of the project, environment)
  -  Even if all above works as expected, are there weird behaviors to be improved on?
- [ ] Documentation review
  - Does the new/changed documentation cover the PR in sufficient matter?
  - For public API, are JavaDocs included for every new/changed class/method ?
  - For new features, does the documentation add/amend any usage examples ?
  - Grammar and syntax checks 
  - Does AsciiDoc generation report any WARN messages ?
