### PR TITLE
[16.2.x] [#17691] Restore APPLICATION_UNKNOWN and APPLICATION_OCTET_STREAM transcoding support

### DIFF
--- a/core/src/main/java/org/infinispan/encoding/impl/StorageConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/encoding/impl/StorageConfigurationManager.java
@@ -1,7 +1,5 @@
 package org.infinispan.encoding.impl;
 
-import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_UNKNOWN;
-
 import org.infinispan.commons.dataconversion.ByteArrayWrapper;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.Wrapper;
@@ -82,7 +80,7 @@ public class StorageConfigurationManager {
       this.valueStorageMediaType = getStorageMediaType(configuration, embeddedMode, internalCache, userMarshaller,
                                                      false);
 
-      if(keyStorageMediaType.equals(APPLICATION_UNKNOWN) || valueStorageMediaType.equals(APPLICATION_UNKNOWN)) {
+      if(keyStorageMediaType.equals(MediaType.APPLICATION_UNKNOWN) || valueStorageMediaType.equals(MediaType.APPLICATION_UNKNOWN)) {
          LOG.unknownEncoding(cacheName);
       }
    }
@@ -107,7 +105,7 @@ public class StorageConfigurationManager {
          return canStoreReferences ? MediaType.APPLICATION_OBJECT : mediaType;
       }
 
-      return APPLICATION_UNKNOWN;
+      return MediaType.APPLICATION_UNKNOWN;
    }
 
    /**

--- a/integrationtests/endpoints-interop-it/src/test/java/org/infinispan/it/endpoints/EndpointInteroperabilityTest.java
+++ b/integrationtests/endpoints-interop-it/src/test/java/org/infinispan/it/endpoints/EndpointInteroperabilityTest.java
@@ -345,6 +345,27 @@ public class EndpointInteroperabilityTest extends AbstractInfinispanTest {
    }
 
    @Test
+   public void testJsonValueInDefaultCache() {
+      // Write JSON via REST to the default cache (no explicit encoding)
+      String key = "json-1";
+      String jsonValue = "{\"name\":\"test\",\"value\":42}";
+
+      new RestRequest().cache(DEFAULT_CACHE_NAME)
+            .key(key).value(jsonValue, APPLICATION_JSON)
+            .write();
+
+      // Read back via REST as JSON
+      RestResponse response = new RestRequest().cache(DEFAULT_CACHE_NAME)
+            .key(key).accept(APPLICATION_OCTET_STREAM)
+            .read();
+      assertEquals(jsonValue, response.body());
+
+      // Read via Hot Rod (raw bytes)
+      byte[] hrValue = defaultRemoteCache.get(key.getBytes(UTF_8));
+      assertEquals(jsonValue, new String(hrValue, UTF_8));
+   }
+
+   @Test
    public void testCustomKeysAndByteValues() throws Exception {
       CustomKey objectKey = new CustomKey("a", 1.0d, 1.0f, true);
       ProtoStreamMarshaller marshaller = new ProtoStreamMarshaller();

--- a/server/core/src/main/java/org/infinispan/server/core/dataconversion/JsonTranscoder.java
+++ b/server/core/src/main/java/org/infinispan/server/core/dataconversion/JsonTranscoder.java
@@ -88,6 +88,10 @@ public class JsonTranscoder extends OneToManyTranscoder {
 
    @Override
    public Object doTranscode(Object content, MediaType contentType, MediaType destinationType) {
+      if (destinationType.match(APPLICATION_OCTET_STREAM) || destinationType.match(APPLICATION_UNKNOWN)) {
+         if (content instanceof byte[]) return content;
+         return content.toString().getBytes(contentType.getCharset());
+      }
       boolean outputString = destinationType.hasStringType();
       Charset contentCharset = contentType.getCharset();
       Charset destinationCharset = destinationType.getCharset();

--- a/server/core/src/main/java/org/infinispan/server/core/dataconversion/XMLTranscoder.java
+++ b/server/core/src/main/java/org/infinispan/server/core/dataconversion/XMLTranscoder.java
@@ -93,6 +93,10 @@ public class XMLTranscoder extends OneToManyTranscoder {
             return xmlString.getBytes(destinationType.getCharset());
          }
       }
+      if (destinationType.match(APPLICATION_OCTET_STREAM) || destinationType.match(APPLICATION_UNKNOWN)) {
+         if (content instanceof byte[]) return content;
+         return content.toString().getBytes(contentType.getCharset());
+      }
       if (destinationType.match(TEXT_PLAIN)) {
          return StandardConversions.convertCharset(content, contentType.getCharset(), destinationType.getCharset());
       }

--- a/server/core/src/main/java/org/infinispan/server/core/iteration/DefaultIterationManager.java
+++ b/server/core/src/main/java/org/infinispan/server/core/iteration/DefaultIterationManager.java
@@ -151,7 +151,9 @@ public class DefaultIterationManager implements IterationManager {
       Function<Object, Object> unmarshaller = p -> encoderRegistry.convert(p, requestValueType, APPLICATION_OBJECT);
 
       // The iterator converts from the request type to the storage type. The filter will receive the data already converted.
-      MediaType storageMediaType = valueDataConversion.getRequestMediaType() != null && valueDataConversion.getRequestMediaType() != MediaType.APPLICATION_UNKNOWN
+      MediaType storageMediaType = valueDataConversion.getRequestMediaType() != null
+            && valueDataConversion.getRequestMediaType() != MediaType.APPLICATION_UNKNOWN
+            && valueDataConversion.getRequestMediaType() != MediaType.APPLICATION_OCTET_STREAM
             ? valueDataConversion.getRequestMediaType()
             : valueDataConversion.getStorageMediaType();
 

--- a/server/core/src/main/java/org/infinispan/server/core/query/impl/BaseRemoteQueryManager.java
+++ b/server/core/src/main/java/org/infinispan/server/core/query/impl/BaseRemoteQueryManager.java
@@ -45,7 +45,8 @@ abstract class BaseRemoteQueryManager implements RemoteQueryManager {
       StorageConfigurationManager storageConfigurationManager = cr.getComponent(StorageConfigurationManager.class);
       this.storageType = storageConfigurationManager.getValueStorageMediaType();
       this.cacheQueryable = storageConfigurationManager.isQueryable();
-      this.unknownMediaType = storageType.match(MediaType.APPLICATION_UNKNOWN);
+      this.unknownMediaType = storageType.match(MediaType.APPLICATION_UNKNOWN)
+            || storageType.match(MediaType.APPLICATION_OCTET_STREAM);
    }
 
    @Override

--- a/server/core/src/test/java/org/infinispan/server/core/dataconversion/JsonTranscoderTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/dataconversion/JsonTranscoderTest.java
@@ -114,6 +114,20 @@ public class JsonTranscoderTest extends AbstractTranscoderTest {
       assertTextToJsonConversion("\"test\"");
    }
 
+   @Test
+   public void testJsonToOctetStream() {
+      byte[] json = "{\"key\":\"value\"}".getBytes(UTF_8);
+      byte[] result = (byte[]) transcoder.transcode(json, APPLICATION_JSON, APPLICATION_OCTET_STREAM);
+      assertArrayEquals(json, result);
+   }
+
+   @Test
+   public void testJsonToUnknown() {
+      byte[] json = "{\"key\":\"value\"}".getBytes(UTF_8);
+      byte[] result = (byte[]) transcoder.transcode(json, APPLICATION_JSON, APPLICATION_UNKNOWN);
+      assertArrayEquals(json, result);
+   }
+
    @Test(expectedExceptions = EncodingException.class)
    public void testPreventInvalidJson() {
       byte[] invalidContent = "\"field\" : value".getBytes(UTF_8);

--- a/server/core/src/test/java/org/infinispan/server/core/dataconversion/XMLTranscoderTest.java
+++ b/server/core/src/test/java/org/infinispan/server/core/dataconversion/XMLTranscoderTest.java
@@ -3,6 +3,8 @@ package org.infinispan.server.core.dataconversion;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OBJECT;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_OCTET_STREAM;
+import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_UNKNOWN;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_WWW_FORM_URLENCODED;
 import static org.infinispan.commons.dataconversion.MediaType.APPLICATION_XML;
 import static org.infinispan.commons.dataconversion.MediaType.TEXT_PLAIN;
@@ -39,6 +41,18 @@ public class XMLTranscoderTest {
    public void testWWWFormUrlEncoded() {
       byte[] transcoded = (byte[]) xmlTranscoder.transcode("%3Cstring%3EHello%20World%21%3C%2Fstring%3E", APPLICATION_WWW_FORM_URLENCODED, APPLICATION_XML);
       assertEquals("<string>Hello World!</string>", new String(transcoded));
+   }
+
+   public void testXmlToOctetStream() {
+      byte[] xml = "<root><key>value</key></root>".getBytes(UTF_8);
+      byte[] result = (byte[]) xmlTranscoder.transcode(xml, APPLICATION_XML, APPLICATION_OCTET_STREAM);
+      assertArrayEquals(xml, result);
+   }
+
+   public void testXmlToUnknown() {
+      byte[] xml = "<root><key>value</key></root>".getBytes(UTF_8);
+      byte[] result = (byte[]) xmlTranscoder.transcode(xml, APPLICATION_XML, APPLICATION_UNKNOWN);
+      assertArrayEquals(xml, result);
    }
 
    public void testTextToXML() {

--- a/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
+++ b/server/rest/src/main/java/org/infinispan/rest/resources/CacheResourceV2.java
@@ -806,7 +806,8 @@ public class CacheResourceV2 extends BaseCacheResource implements ResourceHandle
 
    private MediaType negotiateEntryMediaType(MediaType storage, boolean protoStreamEncoding) {
       EncoderRegistry encoderRegistry = invocationHelper.getEncoderRegistry();
-      boolean encodingDefined = !MediaType.APPLICATION_UNKNOWN.equals(storage);
+      boolean encodingDefined = !MediaType.APPLICATION_UNKNOWN.equals(storage)
+            && !MediaType.APPLICATION_OCTET_STREAM.equals(storage);
       boolean jsonSupported = encodingDefined && encoderRegistry.isConversionSupported(storage, APPLICATION_JSON);
       boolean textSupported = encodingDefined && encoderRegistry.isConversionSupported(storage, TEXT_PLAIN);
 


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/17692

## Summary

- **JsonTranscoder / XMLTranscoder**: restore `APPLICATION_OCTET_STREAM` and `APPLICATION_UNKNOWN` destination handling removed in 48281f43b57
- **CacheResourceV2, BaseRemoteQueryManager, DefaultIterationManager**: treat `APPLICATION_OCTET_STREAM` the same as `APPLICATION_UNKNOWN`
- New unit tests for JSON/XML → octet-stream and unknown transcoding
- New integration test for JSON PUT/GET on caches without explicit encoding

Fixes #17691

Created with the assistance of an AI tool