### PR TITLE
[16.2.x] [#17771] Fixes clustered locks schema link

### DIFF
--- a/documentation/src/main/asciidoc/topics/proc_configuring_internal_caches_locks.adoc
+++ b/documentation/src/main/asciidoc/topics/proc_configuring_internal_caches_locks.adoc
@@ -41,4 +41,4 @@ include::xml/clustered_lock_manager.xml[]
 .Reference
 
 * link:../../apidocs/org/infinispan/lock/configuration/ClusteredLockManagerConfiguration.html[ClusteredLockManagerConfiguration]
-* link:{configdocroot}infinispan-clustered-locks-config-{schemaversion}.html[{brandname} Clustered Locks Configuration Schema]
+* link:../../configuration-schema/infinispan-clustered-locks-config-{schemaversion}.html[{brandname} Clustered Locks Configuration Schema]


### PR DESCRIPTION
**Backport:** https://github.com/infinispan/infinispan/pull/17659

Fixes documentation link for clustered locks
Closes #17771 fix-clustered-lock-schema-config