### PR TITLE
[#17946] Make StatsEnvelope.unpack defensive

### DIFF
--- a/core/src/main/java/org/infinispan/functional/impl/StatsEnvelope.java
+++ b/core/src/main/java/org/infinispan/functional/impl/StatsEnvelope.java
@@ -52,11 +52,16 @@ public class StatsEnvelope<T> {
 
 
    public static Object unpack(InvocationContext ctx, VisitableCommand command, Object o) {
-      return ((StatsEnvelope<?>) o).value;
+      // Value may arrive unwrapped from a non-owner RPC response
+      return o instanceof StatsEnvelope<?> envelope ? envelope.value : o;
    }
 
    public static Object unpackCollection(InvocationContext ctx, VisitableCommand command, Object o) {
-      return ((Collection<StatsEnvelope<?>>) o).stream().map(StatsEnvelope::value).collect(Collectors.toList());
+      Collection<?> collection = (Collection<?>) o;
+      if (collection.isEmpty() || !(collection.iterator().next() instanceof StatsEnvelope)) {
+         return collection;
+      }
+      return collection.stream().map(c -> ((StatsEnvelope<?>) c).value()).collect(Collectors.toList());
    }
 
    public static Object unpackStream(InvocationContext ctx, VisitableCommand command, Object o) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheMgmtInterceptor.java
@@ -306,7 +306,9 @@ public final class CacheMgmtInterceptor extends JmxStatsCommandInterceptor imple
 
       long start = timeService.time();
       return invokeNextThenApply(ctx, command, (rCtx, rCommand, rv) -> {
-         StatsEnvelope<?> envelope = (StatsEnvelope<?>) rv;
+         if (!(rv instanceof StatsEnvelope<?> envelope)) {
+            return rv;
+         }
          if (envelope.isDelete()) {
             trackRemoveHit(start, getWriteOwnership(rCommand.getSegment()));
          } else if ((envelope.flags() & (StatsEnvelope.CREATE | StatsEnvelope.UPDATE)) != 0) {
@@ -336,7 +338,9 @@ public final class CacheMgmtInterceptor extends JmxStatsCommandInterceptor imple
          if (rv == null && !rCommand.isSuccessful() && rCommand.hasAnyFlag(FlagBitSets.FAIL_SILENTLY))
             return null;
 
-         StatsEnvelope<?> envelope = (StatsEnvelope<?>) rv;
+         if (!(rv instanceof StatsEnvelope<?> envelope)) {
+            return rv;
+         }
          if (envelope.isDelete()) {
             trackRemoveHit(start, getWriteOwnership(rCommand.getSegment()));
          } else if ((envelope.flags() & (StatsEnvelope.CREATE | StatsEnvelope.UPDATE)) != 0) {
@@ -387,8 +391,13 @@ public final class CacheMgmtInterceptor extends JmxStatsCommandInterceptor imple
          int stores = 0;
          int removals = 0;
          int numResults = rCommand.getAffectedKeys().size();
+         Collection<?> collection = (Collection<?>) rv;
+         if (collection.isEmpty() || !(collection.iterator().next() instanceof StatsEnvelope)) {
+            return rv instanceof List ? rv : new ArrayList<>(collection);
+         }
          List<Object> results = new ArrayList<>(numResults);
-         for (StatsEnvelope<?> envelope : ((Collection<StatsEnvelope<?>>) rv)) {
+         for (Object item : collection) {
+            StatsEnvelope<?> envelope = (StatsEnvelope<?>) item;
             if (envelope.isDelete()) {
                removals++;
             } else if ((envelope.flags() & (StatsEnvelope.CREATE | StatsEnvelope.UPDATE)) != 0) {

--- a/core/src/test/java/org/infinispan/functional/FunctionalStatsNonOwnerTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalStatsNonOwnerTest.java
@@ -1,0 +1,84 @@
+package org.infinispan.functional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.functional.FunctionalMap.ReadWriteMap;
+import org.infinispan.functional.FunctionalMap.WriteOnlyMap;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestDataSCI;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that functional commands executed on a non-owner node in DIST_SYNC
+ * do not throw ClassCastException when statistics are enabled.
+ *
+ * @see <a href="https://github.com/infinispan/infinispan/issues/17946">#17946</a>
+ */
+@Test(groups = "functional", testName = "functional.FunctionalStatsNonOwnerTest")
+public class FunctionalStatsNonOwnerTest extends MultipleCacheManagersTest {
+   private ReadWriteMap<Object, Object> rwNonOwner;
+   private WriteOnlyMap<Object, Object> woNonOwner;
+   private MagicKey key;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      builder.clustering().hash().numOwners(1);
+      builder.statistics().enable();
+      createCluster(TestDataSCI.INSTANCE, builder, 3);
+      waitForClusterToForm();
+
+      key = new MagicKey(cache(0));
+      FunctionalMap<Object, Object> fmapNonOwner = FunctionalMap.create(cache(2).getAdvancedCache());
+      rwNonOwner = fmapNonOwner.toReadWriteMap();
+      woNonOwner = fmapNonOwner.toWriteOnlyMap();
+   }
+
+   public void testWriteOnlyKeyFromNonOwner() {
+      woNonOwner.eval(key, wo -> wo.set("wo-value")).join();
+      assertEquals("wo-value", cache(0).get(key));
+   }
+
+   public void testWriteOnlyKeyValueFromNonOwner() {
+      woNonOwner.eval(key, "wo-kv", (v, wo) -> wo.set(v)).join();
+      assertEquals("wo-kv", cache(0).get(key));
+   }
+
+   public void testReadWriteKeyFromNonOwner() {
+      cache(0).put(key, "existing");
+      Object result = rwNonOwner.eval(key, rw -> rw.find().orElse(null)).join();
+      assertEquals("existing", result);
+   }
+
+   public void testReadWriteKeyValueFromNonOwner() {
+      Object result = rwNonOwner.eval(key, "new-val", (v, rw) -> {
+         Object prev = rw.find().orElse(null);
+         rw.set(v);
+         return prev;
+      }).join();
+      assertNull(result);
+      assertEquals("new-val", cache(0).get(key));
+   }
+
+   public void testReadWriteManyFromNonOwner() {
+      cache(0).put(key, "multi-existing");
+      rwNonOwner.evalMany(Set.of(key), rw -> rw.find().orElse(null)).forEach(result ->
+            assertEquals("multi-existing", result)
+      );
+   }
+
+   public void testReadWriteManyEntriesFromNonOwner() {
+      rwNonOwner.evalMany(Map.of(key, "multi-val"), (v, rw) -> {
+         rw.set(v);
+         return v;
+      }).forEach(result -> assertEquals("multi-val", result));
+      assertEquals("multi-val", cache(0).get(key));
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/impl/StatsEnvelopeTest.java
+++ b/core/src/test/java/org/infinispan/functional/impl/StatsEnvelopeTest.java
@@ -1,0 +1,39 @@
+package org.infinispan.functional.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "functional.impl.StatsEnvelopeTest")
+public class StatsEnvelopeTest {
+
+   public void testUnpackWrappedValue() {
+      StatsEnvelope<String> envelope = StatsEnvelope.create("value", false);
+      assertEquals("value", StatsEnvelope.unpack(null, null, envelope));
+   }
+
+   public void testUnpackAlreadyUnwrappedValue() {
+      Object raw = "raw-unwrapped-value";
+      assertSame(raw, StatsEnvelope.unpack(null, null, raw));
+   }
+
+   public void testUnpackCollectionOfWrappedValues() {
+      StatsEnvelope<String> a = StatsEnvelope.create("a", false);
+      StatsEnvelope<String> b = StatsEnvelope.create("b", false);
+      Object result = StatsEnvelope.unpackCollection(null, null, List.of(a, b));
+      assertEquals(List.of("a", "b"), result);
+   }
+
+   public void testUnpackCollectionOfAlreadyUnwrappedValues() {
+      List<String> raw = List.of("a", "b");
+      assertSame(raw, StatsEnvelope.unpackCollection(null, null, raw));
+   }
+
+   public void testUnpackCollectionOfEmptyCollection() {
+      Object result = StatsEnvelope.unpackCollection(null, null, List.of());
+      assertEquals(List.of(), result);
+   }
+}


### PR DESCRIPTION
﻿<!--- Closes: #17946 -->

Fixes a ClassCastException reported in #17946: CacheMgmtInterceptor.updateStatisticsReadWrite/updateStatisticsWriteOnly cast the interceptor chain's return value to StatsEnvelope unconditionally, via StatsEnvelope.unpack()/unpackCollection(). That assumption breaks for a non-owner write in a DIST_SYNC cache with owners less than cluster size: UnorderedDistributionInterceptor's non-owner branch returns the remote owning node's raw RPC response as-is, and on that remote node ctx.isOriginLocal() is false, so its own CacheMgmtInterceptor correctly skips wrapping in the first place. The value that reaches unpack() back on the originating node is therefore unwrapped, and the unconditional cast throws.

unpack() and unpackCollection() now check whether the value is actually a StatsEnvelope before unwrapping it, passing it through unchanged otherwise. This is a shared utility used by every affected visit method (WriteOnlyKey, WriteOnlyKeyValue, ReadWriteKey, ReadWriteKeyValue, ReadWriteMany, ReadWriteManyEntries), so the one change covers all of them. unpackStream() is intentionally left untouched -- it is only used by the read-only-many path, which is not implicated by this issue, and a safe defensive fix there is not as straightforward given Stream laziness.

Added StatsEnvelopeTest with 5 cases covering both unpack() and unpackCollection(), for both the already-wrapped and already-unwrapped inputs, plus an empty-collection edge case.

Verified with a decisive negative control: reverting only the source fix (keeping the new test) reproduces the exact reported exception -- ClassCastException: class java.lang.String cannot be cast to class org.infinispan.functional.impl.StatsEnvelope -- on the two tests that exercise the unwrapped-value path, at StatsEnvelope.unpack/unpackCollection, matching the original stack trace in the issue.

Author Checklist (all must be checked):
- [x] Commit message includes a reference to the corresponding GitHub issue (e.g. commit message: "[#00000] Issue title...") and is formatted according to our git message template.
- [x] Commits have been squashed into self-contained units of work (e.g. 'WIP'- and 'Implements feedback'-style messages have been removed).
- [x] The PR includes new/modified unit and integration tests that exercise the changes. Include additional manual testing instructions if necessary. If the PR does not include tests, clear justification MUST be provided.
- [x] The PR includes new/modified documentation. If the PR does not require documentation changes, clear justification MUST be provided. -- N/A: internal defensive fix to an existing internal utility, no public API or user-facing behavior changed.
- [x] Log messages of level INFO and above have been internationalized. -- N/A: no new log messages were added.
- [x] If the PR affects performance, include before/after benchmarks. -- N/A: adds a single instanceof check on an already-executed hot path; not expected to be measurable.
- [x] If the PR affects output (such as logs, CLI, Console), provide an example (text snippet/screenshot). -- N/A: no such output is affected.
- [x] If the PR requires a followup or is part of a larger body of work, ensure that relevant GitHub issues have been created to track the additional work. -- N/A: self-contained fix.
