### PR TITLE
[#17962] Fix NPE when streaming entries from a cache 

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/EncoderEntryMapper.java
+++ b/core/src/main/java/org/infinispan/cache/impl/EncoderEntryMapper.java
@@ -6,6 +6,7 @@ import org.infinispan.commands.functional.functions.InjectableComponent;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.impl.InternalEntryFactory;
+import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.encoding.DataConversion;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
@@ -73,7 +74,9 @@ public class EncoderEntryMapper<K, V, T extends Map.Entry<K, V>> implements Enco
       if (key != newKey || value != newValue) {
          if (e instanceof CacheEntry) {
             CacheEntry<K, V> ce = (CacheEntry<K, V>) e;
-            return (T) entryFactory.create(newKey, newValue, ce.getMetadata().version(), ce.getCreated(),
+            // Metadata can be null for entries loaded through RemoteStore (Hot Rod migration)
+            EntryVersion version = ce.getMetadata() == null ? null : ce.getMetadata().version();
+            return (T) entryFactory.create(newKey, newValue, version, ce.getCreated(),
                   ce.getLifespan(), ce.getLastUsed(), ce.getMaxIdle());
          } else {
             return (T) entryFactory.create(newKey, newValue, (Metadata) null);

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -205,6 +205,9 @@ public class PersistenceManagerImpl implements PersistenceManager {
       segmentCount = configuration.clustering().hash().numSegments();
 
       isInvalidationCache = configuration.clustering().cacheMode().isInvalidation();
+      // Initialize even when no stores are configured at startup, as stores can be added dynamically (e.g. Hot Rod migration)
+      TIMEOUT_FLOWABLE = Flowable.error(log.storeTimeoutBetweenEntries(configuration.clustering().remoteTimeout()));
+      rxTimeoutScheduler = Schedulers.from(timeoutExecutor);
       if (!enabled)
          return;
       // Blocks here waiting for stores and availability task to start if needed
@@ -212,9 +215,6 @@ public class PersistenceManagerImpl implements PersistenceManager {
                   __ -> startManagerAndStores(configuration.persistence().stores()),
                   this::releaseWriteLock)
             .blockingAwait();
-
-      TIMEOUT_FLOWABLE = Flowable.error(log.storeTimeoutBetweenEntries(configuration.clustering().remoteTimeout()));
-      rxTimeoutScheduler = Schedulers.from(timeoutExecutor);
    }
 
    @GuardedBy("lock#writeLock")

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/AddSourceRemoteStoreTask.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/AddSourceRemoteStoreTask.java
@@ -60,6 +60,7 @@ public class AddSourceRemoteStoreTask implements Function<EmbeddedCacheManager, 
       PersistenceManager persistenceManager = cr.getComponent(PersistenceManager.class);
       try {
          if (persistenceManager.getStores(RemoteStore.class).isEmpty()) {
+             storeConfiguration.properties().setProperty(RemoteStore.MIGRATION, "true");
              return CompletionStages.join(persistenceManager.addStore(storeConfiguration));
          }
          return null;

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicEncodingsTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicEncodingsTest.java
@@ -2,7 +2,6 @@ package org.infinispan.persistence.remote.upgrade;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StorageType;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -33,7 +32,7 @@ public class HotRodUpgradeDynamicEncodingsTest extends HotRodUpgradeEncodingsTes
    protected void connectTargetCluster() {
       ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
       RemoteStoreConfigurationBuilder store = configurationBuilder.persistence().addStore(RemoteStoreConfigurationBuilder.class);
-      store.remoteCacheName(CACHE_NAME).shared(true).segmented(false).addServer().host("localhost").port(sourceCluster.getHotRodPort()).addProperty(RemoteStore.MIGRATION, "true");
+      store.remoteCacheName(CACHE_NAME).shared(true).segmented(false).addServer().host("localhost").port(sourceCluster.getHotRodPort());
 
       targetCluster.connectSource(CACHE_NAME, configurationBuilder.build().persistence().stores().get(0));
    }

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicPojoTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicPojoTest.java
@@ -4,7 +4,6 @@ import static org.infinispan.transaction.TransactionMode.TRANSACTIONAL;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Factory;
@@ -41,7 +40,7 @@ public class HotRodUpgradeDynamicPojoTest extends HotRodUpgradePojoTest {
       ConfigurationBuilder cfg = new ConfigurationBuilder();
       RemoteStoreConfigurationBuilder storeBuilder = cfg.persistence().addStore(RemoteStoreConfigurationBuilder.class);
       storeBuilder.marshaller(GenericJBossMarshaller.class).remoteCacheName(CACHE_NAME).segmented(false).shared(true)
-            .addServer().host("localhost").port(sourceCluster.getHotRodPort()).addProperty(RemoteStore.MIGRATION, "true");
+            .addServer().host("localhost").port(sourceCluster.getHotRodPort());
       targetCluster.connectSource(CACHE_NAME, cfg.build().persistence().stores().get(0));
    }
 }

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicStoreTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicStoreTest.java
@@ -3,7 +3,6 @@ package org.infinispan.persistence.remote.upgrade;
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StoreConfiguration;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.testng.annotations.Test;
 
@@ -32,7 +31,7 @@ public class HotRodUpgradeDynamicStoreTest extends HotRodUpgradeSynchronizerTest
       ConfigurationBuilder builder = new ConfigurationBuilder();
       RemoteStoreConfigurationBuilder storeBuilder = builder.persistence().addStore(RemoteStoreConfigurationBuilder.class);
       storeBuilder.remoteCacheName(cacheName).protocolVersion(version).shared(true).segmented(false)
-            .addServer().host("localhost").port(sourceCluster.getHotRodPort()).addProperty(RemoteStore.MIGRATION, "true");
+            .addServer().host("localhost").port(sourceCluster.getHotRodPort());
       return storeBuilder.build().persistence().stores().get(0);
    }
 }

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicWithSSLTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicWithSSLTest.java
@@ -2,7 +2,6 @@ package org.infinispan.persistence.remote.upgrade;
 
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.infinispan.testing.security.TestCertificates;
 import org.testng.annotations.Test;
@@ -39,7 +38,7 @@ public class HotRodUpgradeDynamicWithSSLTest extends HotRodUpgradeWithSSLTest {
       storeBuilder.remoteCacheName(cacheName).protocolVersion(version).shared(true).segmented(false)
             .remoteSecurity().ssl().enable().trustStoreFileName(TestCertificates.certificate("ca")).trustStorePassword(TestCertificates.KEY_PASSWORD)
             .keyStoreFileName(TestCertificates.certificate("client")).keyStorePassword(TestCertificates.KEY_PASSWORD).sniHostName("server")
-            .addServer().host("localhost").port(sourceCluster.getHotRodPort()).addProperty(RemoteStore.MIGRATION, "true");
+            .addServer().host("localhost").port(sourceCluster.getHotRodPort());
 
       return builder;
    }

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicWithStoreTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgradeDynamicWithStoreTest.java
@@ -4,7 +4,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.IsolationLevel;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.testng.annotations.Test;
 
@@ -32,7 +31,7 @@ public class HotRodUpgradeDynamicWithStoreTest extends HotRodUpgradeWithStoreTes
       RemoteStoreConfigurationBuilder storeBuilder = builder.persistence().addStore(RemoteStoreConfigurationBuilder.class);
 
       storeBuilder.shared(true).segmented(false).remoteCacheName(CACHE_NAME).addServer()
-            .host("localhost").port(sourceCluster.getHotRodPort()).addProperty(RemoteStore.MIGRATION, "true");
+            .host("localhost").port(sourceCluster.getHotRodPort());
 
       targetCluster.connectSource(CACHE_NAME, builder.build().persistence().stores().get(0));
    }

--- a/server/tests/src/test/java/org/infinispan/server/functional/ClusterMigrationDynamicStoreIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/ClusterMigrationDynamicStoreIT.java
@@ -19,7 +19,6 @@ import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.commons.internal.InternalCacheNames;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteServerConfiguration;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
@@ -198,8 +197,7 @@ public class ClusterMigrationDynamicStoreIT extends AbstractMultiClusterIT {
             .shared(true)
             .addServer()
             .host(source.driver.getServerAddress(0).getHostAddress())
-            .port(11222)
-            .addProperty(RemoteStore.MIGRATION, "true");
+            .port(11222);
       final KeyValuePair<String, String> credentials = getCredentials();
       if (getCredentials() != null) {
          storeConfigurationBuilder.remoteSecurity()

--- a/server/tests/src/test/java/org/infinispan/server/functional/ClusterMigrationStreamEntriesIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/ClusterMigrationStreamEntriesIT.java
@@ -18,7 +18,6 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteServerConfiguration;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
@@ -61,6 +60,38 @@ public class ClusterMigrationStreamEntriesIT extends AbstractMultiClusterIT {
    public void after() throws Exception {
       stopTargetCluster();
       stopSourceCluster();
+   }
+
+   @Test
+   public void testStreamEntriesAfterMigration() throws Exception {
+      RestClient restClientSource = source.getClient();
+      RestClient restClientTarget = target.getClient();
+
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      builder.encoding().mediaType(MediaType.APPLICATION_PROTOSTREAM);
+      createCache(CACHE_NAME, builder, restClientSource);
+      createCache(CACHE_NAME, builder, restClientTarget);
+
+      RestCacheClient sourceCache = restClientSource.cache(CACHE_NAME);
+      for (int i = 0; i < ENTRIES; i++) {
+         String key = "{\"_type\":\"string\",\"_value\":\"" + i + "\"}";
+         RestEntity value = RestEntity.create(MediaType.APPLICATION_JSON, "{\"_type\":\"string\",\"_value\":\"value-" + i + "\"}");
+         assertStatus(NO_CONTENT, sourceCache.put(key, MediaType.APPLICATION_JSON_TYPE, value));
+      }
+      assertEquals(ENTRIES, getCacheSize(CACHE_NAME, restClientSource));
+
+      connectTargetCluster(CACHE_NAME);
+      assertSourceConnected(CACHE_NAME);
+
+      migrate(CACHE_NAME, restClientTarget);
+      disconnectSource(CACHE_NAME, restClientTarget);
+
+      try (RestResponse response = sync(restClientTarget.cache(CACHE_NAME).entries())) {
+         assertEquals(OK, response.status());
+         Collection<?> entries = (Collection<?>) Json.read(response.body()).getValue();
+         assertEquals(ENTRIES, entries.size());
+      }
    }
 
    @Test
@@ -116,6 +147,14 @@ public class ClusterMigrationStreamEntriesIT extends AbstractMultiClusterIT {
       assertStatus(OK, target.getClient().cache(cacheName).sourceConnected());
    }
 
+   protected void migrate(String cacheName, RestClient client) {
+      assertStatus(OK, client.cache(cacheName).synchronizeData());
+   }
+
+   protected void disconnectSource(String cacheName, RestClient client) {
+      assertStatus(NO_CONTENT, client.cache(cacheName).disconnectSource());
+   }
+
    void addRemoteStore(String cacheName, ConfigurationBuilder builder) {
       RemoteStoreConfigurationBuilder storeConfigurationBuilder = builder.clustering()
             .cacheMode(CacheMode.DIST_SYNC).persistence().addStore(RemoteStoreConfigurationBuilder.class);
@@ -125,8 +164,7 @@ public class ClusterMigrationStreamEntriesIT extends AbstractMultiClusterIT {
             .shared(true)
             .addServer()
             .host(source.driver.getServerAddress(0).getHostAddress())
-            .port(11222)
-            .addProperty(RemoteStore.MIGRATION, "true");
+            .port(11222);
       final KeyValuePair<String, String> credentials = getCredentials();
       if (credentials != null) {
          storeConfigurationBuilder.remoteSecurity()

--- a/server/tests/src/test/java/org/infinispan/server/functional/ClusterMigrationStreamEntriesIT.java
+++ b/server/tests/src/test/java/org/infinispan/server/functional/ClusterMigrationStreamEntriesIT.java
@@ -1,0 +1,139 @@
+package org.infinispan.server.functional;
+
+import static org.infinispan.client.rest.RestResponse.NO_CONTENT;
+import static org.infinispan.client.rest.RestResponse.OK;
+import static org.infinispan.server.test.core.Common.assertStatus;
+import static org.infinispan.server.test.core.Common.sync;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.infinispan.client.rest.RestCacheClient;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestEntity;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.persistence.remote.RemoteStore;
+import org.infinispan.persistence.remote.configuration.RemoteServerConfiguration;
+import org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration;
+import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
+import org.infinispan.persistence.remote.upgrade.SerializationUtils;
+import org.infinispan.util.KeyValuePair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces NPE in EncoderEntryMapper when streaming entries from a cache
+ * with a dynamically added RemoteStore (rolling upgrade scenario).
+ *
+ * @since 16.3
+ */
+public class ClusterMigrationStreamEntriesIT extends AbstractMultiClusterIT {
+
+   protected static final String CACHE_NAME = "stream-test";
+   protected static final int ENTRIES = 10;
+
+   @Override
+   protected void startSourceCluster() {
+      source = new Cluster(new ClusterConfiguration(config, 1, 0, mavenArtifacts), getCredentials());
+      source.start(this.getClass().getName() + "-source");
+   }
+
+   @Override
+   protected void startTargetCluster() {
+      target = new Cluster(new ClusterConfiguration(config, 1, 1000, mavenArtifacts), getCredentials());
+      target.start(this.getClass().getName() + "-target");
+   }
+
+   @BeforeEach
+   public void before() {
+      startSourceCluster();
+      startTargetCluster();
+   }
+
+   @AfterEach
+   public void after() throws Exception {
+      stopTargetCluster();
+      stopSourceCluster();
+   }
+
+   @Test
+   public void testStreamEntriesWithRemoteStore() throws Exception {
+      RestClient restClientSource = source.getClient();
+      RestClient restClientTarget = target.getClient();
+
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      createCache(CACHE_NAME, builder, restClientSource);
+      createCache(CACHE_NAME, builder, restClientTarget);
+
+      RestCacheClient sourceCache = restClientSource.cache(CACHE_NAME);
+      for (int i = 0; i < ENTRIES; i++) {
+         assertStatus(NO_CONTENT, sourceCache.put(String.valueOf(i), "value-" + i));
+      }
+      assertEquals(ENTRIES, getCacheSize(CACHE_NAME, restClientSource));
+
+      connectTargetCluster(CACHE_NAME);
+      assertSourceConnected(CACHE_NAME);
+
+      // Stream entries from the target while RemoteStore is active.
+      // Before the fix, this throws NPE in EncoderEntryMapper because
+      // entries from RemoteStore have null metadata.
+      try (RestResponse response = sync(restClientTarget.cache(CACHE_NAME).entries())) {
+         assertEquals(OK, response.status());
+         Collection<?> entries = (Collection<?>) Json.read(response.body()).getValue();
+         assertEquals(ENTRIES, entries.size());
+      }
+   }
+
+   protected void connectTargetCluster(String cacheName) throws IOException {
+      RestCacheClient client = target.getClient().cache(cacheName);
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      addRemoteStore(cacheName, builder);
+
+      RemoteStoreConfiguration remoteStore = (RemoteStoreConfiguration) builder.build().persistence().stores().iterator().next();
+
+      RestEntity restEntity = RestEntity.create(MediaType.APPLICATION_JSON, SerializationUtils.toJson(remoteStore));
+      assertStatus(NO_CONTENT, client.connectSource(restEntity));
+
+      String json = assertStatus(OK, client.sourceConnection());
+      RemoteStoreConfiguration remoteStoreConfiguration = SerializationUtils.fromJson(json);
+
+      List<RemoteServerConfiguration> servers = remoteStoreConfiguration.servers();
+      assertEquals(1, servers.size());
+      RemoteServerConfiguration initialConfig = remoteStore.servers().iterator().next();
+      assertEquals(initialConfig.host(), servers.get(0).host());
+      assertEquals(initialConfig.port(), servers.get(0).port());
+   }
+
+   protected void assertSourceConnected(String cacheName) {
+      assertStatus(OK, target.getClient().cache(cacheName).sourceConnected());
+   }
+
+   void addRemoteStore(String cacheName, ConfigurationBuilder builder) {
+      RemoteStoreConfigurationBuilder storeConfigurationBuilder = builder.clustering()
+            .cacheMode(CacheMode.DIST_SYNC).persistence().addStore(RemoteStoreConfigurationBuilder.class);
+      storeConfigurationBuilder
+            .remoteCacheName(cacheName)
+            .segmented(false)
+            .shared(true)
+            .addServer()
+            .host(source.driver.getServerAddress(0).getHostAddress())
+            .port(11222)
+            .addProperty(RemoteStore.MIGRATION, "true");
+      final KeyValuePair<String, String> credentials = getCredentials();
+      if (credentials != null) {
+         storeConfigurationBuilder.remoteSecurity()
+               .authentication().enable().saslMechanism("PLAIN")
+               .username(credentials.getKey())
+               .password(credentials.getValue())
+               .realm("default");
+      }
+   }
+}


### PR DESCRIPTION
* Fixes streaming endpoint null pointer when remote store is in
* Fixes the migration=true flag that is not part of a public api, to avoid sync issues with the REST API between caches migration

Closes #17962 