### PR TITLE
[#17959] Spring Boot integration Java Serialization

### DIFF
--- a/spring/common/pom.xml
+++ b/spring/common/pom.xml
@@ -31,6 +31,16 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/spring/common/src/main/java/org/infinispan/spring/common/marshalling/JacksonSessionFallbackMarshaller.java
+++ b/spring/common/src/main/java/org/infinispan/spring/common/marshalling/JacksonSessionFallbackMarshaller.java
@@ -1,0 +1,58 @@
+package org.infinispan.spring.common.marshalling;
+
+import java.io.IOException;
+
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.commons.marshall.AbstractMarshaller;
+import org.infinispan.spring.common.session.SessionFallbackResolver;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Session attribute fallback marshaller that uses Jackson with Spring Security modules.
+ * <p>
+ * This marshaller supports Spring Security types commonly stored in sessions
+ * (like Authentication objects) via Jackson serialization.
+ * <p>
+ * <strong>Usage Note:</strong> This utility class is available for configurable session fallback
+ * serialization but is not automatically wired into the Spring Boot auto-configuration layer
+ * in the current implementation. The default session fallback remains {@link SpringJavaSerializationMarshaller}.
+ * This class can be used via {@link SessionFallbackResolver#resolve(String, ClassLoader)} or by custom
+ * configurations.
+ *
+ * @since 16.3
+ */
+public class JacksonSessionFallbackMarshaller extends AbstractMarshaller {
+
+   private final ObjectMapper objectMapper;
+
+   public JacksonSessionFallbackMarshaller(ClassLoader classLoader) {
+      this.objectMapper = new ObjectMapper();
+      this.objectMapper.registerModules(SecurityJackson2Modules.getModules(classLoader));
+   }
+
+   @Override
+   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException {
+      byte[] bytes = objectMapper.writeValueAsBytes(o);
+      return ByteBufferImpl.create(bytes, 0, bytes.length);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length)
+         throws IOException, ClassNotFoundException {
+      return objectMapper.readValue(buf, offset, length, Object.class);
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) {
+      return o != null;
+   }
+
+   @Override
+   public MediaType mediaType() {
+      return MediaType.APPLICATION_JSON;
+   }
+}

--- a/spring/common/src/main/java/org/infinispan/spring/common/marshalling/MarshallerResolver.java
+++ b/spring/common/src/main/java/org/infinispan/spring/common/marshalling/MarshallerResolver.java
@@ -1,0 +1,60 @@
+package org.infinispan.spring.common.marshalling;
+
+import static org.infinispan.spring.common.marshalling.MarshallerResolver.MarshallerAlias.JAVA;
+import static org.infinispan.spring.common.marshalling.MarshallerResolver.MarshallerAlias.PROTOSTREAM;
+
+import java.lang.invoke.MethodHandles;
+import java.util.logging.Logger;
+
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+
+/**
+ * Resolves marshaller instances based on configuration shortcuts or FQCN.
+ */
+public final class MarshallerResolver {
+
+   public enum MarshallerAlias {
+      JAVA, PROTOSTREAM
+   }
+
+   private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+
+   private MarshallerResolver() {}
+
+   /**
+    * Resolves a marshaller based on the given value.
+    *
+    * @param value the marshaller value: null/empty (defaults to Java Serialization), "java" (Java Serialization),
+    *              "protostream" (ProtoStream), or a fully qualified class name
+    * @return the resolved marshaller instance
+    */
+   public static Marshaller resolve(String value) {
+      if (value == null || value.isEmpty()) {
+         logger.warning("ISPN-17959: Infinispan Spring Boot is defaulting to Java Serialization " +
+               "for cache marshalling. JavaSerializationMarshaller class is deprecated and will be removed in a " +
+               "future version. To use the recommended ProtoStream marshaller, add @Proto annotations " +
+               "to your cached types and set infinispan.remote.marshaller=protostream (or " +
+               "infinispan.embedded.marshaller=protostream). To continue using Java Serialization and " +
+               "suppress this warning, set the marshaller property to 'java'.");
+         return new SpringJavaSerializationMarshaller();
+      }
+
+      return switch (value) {
+         case JAVA -> new SpringJavaSerializationMarshaller();
+         case PROTOSTREAM -> new ProtoStreamMarshaller();
+         default -> instantiateByClassName(value);
+      };
+   }
+
+   private static Marshaller instantiateByClassName(String className) {
+      try {
+         Class<?> clazz = Class.forName(className);
+         return (Marshaller) clazz.getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
+         throw new IllegalArgumentException(
+               "Cannot instantiate marshaller class '" + className + "'. Ensure the class " +
+               "implements org.infinispan.commons.marshall.Marshaller and has a no-arg constructor.", e);
+      }
+   }
+}

--- a/spring/common/src/main/java/org/infinispan/spring/common/marshalling/SchemaRegistration.java
+++ b/spring/common/src/main/java/org/infinispan/spring/common/marshalling/SchemaRegistration.java
@@ -1,4 +1,4 @@
-package org.infinispan.spring.remote.provider;
+package org.infinispan.spring.common.marshalling;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;

--- a/spring/common/src/main/java/org/infinispan/spring/common/marshalling/SpringJavaSerializationMarshaller.java
+++ b/spring/common/src/main/java/org/infinispan/spring/common/marshalling/SpringJavaSerializationMarshaller.java
@@ -1,0 +1,71 @@
+package org.infinispan.spring.common.marshalling;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Collections;
+
+import org.infinispan.commons.configuration.ClassAllowList;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+import org.infinispan.commons.io.LazyByteArrayOutputStream;
+import org.infinispan.commons.marshall.AbstractMarshaller;
+import org.infinispan.commons.marshall.CheckedInputStream;
+
+/**
+ * Spring-owned Java serialization marshaller that decouples the Spring integration
+ * from the core which will be deprecated {@code JavaSerializationMarshaller}.
+ * <p>
+ * The allow list is populated via {@link #initialize(ClassAllowList)} during
+ * cache manager startup, matching the behavior of the core marshaller.
+ */
+public class SpringJavaSerializationMarshaller extends AbstractMarshaller {
+
+   private final ClassAllowList allowList;
+
+   public SpringJavaSerializationMarshaller() {
+      this.allowList = new ClassAllowList(Collections.emptyList());
+   }
+
+   public SpringJavaSerializationMarshaller(ClassAllowList allowList) {
+      this.allowList = allowList;
+   }
+
+   @Override
+   public void initialize(ClassAllowList classAllowList) {
+      this.allowList.read(classAllowList);
+   }
+
+   @Override
+   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException {
+      LazyByteArrayOutputStream baos = new LazyByteArrayOutputStream();
+      ObjectOutput out = new ObjectOutputStream(baos);
+      out.writeObject(o);
+      out.close();
+      baos.close();
+      return ByteBufferImpl.create(baos.getRawBuffer(), 0, baos.size());
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length)
+         throws IOException, ClassNotFoundException {
+      try (ObjectInputStream ois = new CheckedInputStream(
+            new ByteArrayInputStream(buf, offset, length), allowList)) {
+         return ois.readObject();
+      }
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) {
+      return o instanceof Serializable;
+   }
+
+   @Override
+   public MediaType mediaType() {
+      return MediaType.APPLICATION_SERIALIZED_OBJECT;
+   }
+}

--- a/spring/common/src/main/java/org/infinispan/spring/common/session/MapSessionProtoAdapter.java
+++ b/spring/common/src/main/java/org/infinispan/spring/common/session/MapSessionProtoAdapter.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.ProtoStreamTypeIds;
 import org.infinispan.protostream.BaseMarshallerDelegate;
 import org.infinispan.protostream.GeneratedMarshallerBase;
@@ -123,19 +123,19 @@ public class MapSessionProtoAdapter {
    }
 
    /**
-    * Generated with protostream-processor and then adapted to use {@code JavaSerializationMarshaller}.
+    * Generated with protostream-processor and then adapted to use a fallback marshaller.
     *
-    * <p>A raw marshaller is necessary because we need a {@code JavaSerializationMarshaller} instance,
+    * <p>A raw marshaller is necessary because we need a {@code Marshaller} instance,
     * and {@link MapSessionProtoAdapter} must be stateless.</p>
     */
    public static final class SessionAttributeRawMarshaller extends GeneratedMarshallerBase
          implements ProtobufTagMarshaller<SessionAttribute> {
 
-      private final JavaSerializationMarshaller javaSerializationMarshaller;
+      private final Marshaller fallbackMarshaller;
       private BaseMarshallerDelegate<WrappedMessage> wrappedMessageDelegate;
 
-      public SessionAttributeRawMarshaller(JavaSerializationMarshaller javaSerializationMarshaller) {
-         this.javaSerializationMarshaller = javaSerializationMarshaller;
+      public SessionAttributeRawMarshaller(Marshaller fallbackMarshaller) {
+         this.fallbackMarshaller = fallbackMarshaller;
       }
 
       @Override
@@ -215,7 +215,7 @@ public class MapSessionProtoAdapter {
       private byte[] serializeValue(Object value) throws IOException {
          final byte[] serializedBytes;
          try {
-            serializedBytes = javaSerializationMarshaller.objectToByteBuffer(value);
+            serializedBytes = fallbackMarshaller.objectToByteBuffer(value);
          } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new CacheException(e);
@@ -225,7 +225,7 @@ public class MapSessionProtoAdapter {
 
       private Object deserializeValue(byte[] serializedBytes) {
          try {
-            return javaSerializationMarshaller.objectFromByteBuffer(serializedBytes);
+            return fallbackMarshaller.objectFromByteBuffer(serializedBytes);
          } catch (IOException | ClassNotFoundException e) {
             throw new CacheException(e);
          }

--- a/spring/common/src/main/java/org/infinispan/spring/common/session/SessionFallbackResolver.java
+++ b/spring/common/src/main/java/org/infinispan/spring/common/session/SessionFallbackResolver.java
@@ -1,0 +1,70 @@
+package org.infinispan.spring.common.session;
+
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.spring.common.marshalling.JacksonSessionFallbackMarshaller;
+import org.infinispan.spring.common.marshalling.SpringJavaSerializationMarshaller;
+
+/**
+ * Resolves the fallback marshaller for session attributes that cannot be
+ * serialized using ProtoStream.
+ * <p>
+ * Supports three modes:
+ * <ul>
+ *   <li>{@code null}, empty, or {@code "java"} - uses Java serialization with Spring-specific allow patterns</li>
+ *   <li>{@code "jackson"} - uses Jackson with Spring Security modules (requires spring-security-jackson2 on classpath)</li>
+ *   <li>Fully qualified class name - instantiates a custom marshaller via reflection</li>
+ * </ul>
+ * <p>
+ * <strong>Usage Note:</strong> This utility class is available for configurable session fallback
+ * serialization but is not automatically wired into the Spring Boot auto-configuration layer
+ * in the current implementation. The default session fallback remains {@link SpringJavaSerializationMarshaller}.
+ * This class can be used by custom configurations or future auto-configuration enhancements.
+ *
+ * @since 16.3
+ */
+public final class SessionFallbackResolver {
+
+   private SessionFallbackResolver() {}
+
+   /**
+    * Resolves a marshaller based on the given value.
+    *
+    * @param value the fallback serializer name or FQCN
+    * @param classLoader the class loader to use for loading classes
+    * @return the resolved marshaller
+    * @throws IllegalStateException if "jackson" is requested but spring-security-jackson2 is not on the classpath
+    * @throws IllegalArgumentException if a custom class name cannot be instantiated
+    */
+   public static Marshaller resolve(String value, ClassLoader classLoader) {
+      if (value == null || value.isEmpty() || "java".equals(value)) {
+         return new SpringJavaSerializationMarshaller();
+      }
+
+      if ("jackson".equals(value)) {
+         return createJacksonMarshaller(classLoader);
+      }
+
+      return instantiateByClassName(value);
+   }
+
+   private static Marshaller createJacksonMarshaller(ClassLoader classLoader) {
+      try {
+         Class.forName("org.springframework.security.jackson2.SecurityJackson2Modules", false, classLoader);
+      } catch (ClassNotFoundException e) {
+         throw new IllegalStateException(
+               "Session fallback serializer 'jackson' requires spring-security-jackson2 on the classpath. " +
+               "Add the dependency or use 'java' as the fallback.", e);
+      }
+      return new JacksonSessionFallbackMarshaller(classLoader);
+   }
+
+   private static Marshaller instantiateByClassName(String className) {
+      try {
+         Class<?> clazz = Class.forName(className);
+         return (Marshaller) clazz.getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
+         throw new IllegalArgumentException(
+               "Cannot instantiate session fallback serializer class '" + className + "'.", e);
+      }
+   }
+}

--- a/spring/common/src/test/java/org/infinispan/spring/common/session/MarshallerResolverTest.java
+++ b/spring/common/src/test/java/org/infinispan/spring/common/session/MarshallerResolverTest.java
@@ -1,0 +1,45 @@
+package org.infinispan.spring.common.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.infinispan.spring.common.marshalling.MarshallerResolver;
+import org.infinispan.spring.common.marshalling.SpringJavaSerializationMarshaller;
+import org.testng.annotations.Test;
+
+@Test(testName = "spring.common.session.MarshallerResolverTest", groups = "unit")
+public class MarshallerResolverTest {
+
+   @Test
+   public void testDefaultReturnsJavaSerialization() {
+      assertThat(MarshallerResolver.resolve(null)).isInstanceOf(SpringJavaSerializationMarshaller.class);
+   }
+
+   @Test
+   public void testEmptyStringReturnsJavaSerialization() {
+      assertThat(MarshallerResolver.resolve("")).isInstanceOf(SpringJavaSerializationMarshaller.class);
+   }
+
+   @Test
+   public void testJavaShortcut() {
+      assertThat(MarshallerResolver.resolve("java")).isInstanceOf(SpringJavaSerializationMarshaller.class);
+   }
+
+   @Test
+   public void testProtostreamShortcut() {
+      assertThat(MarshallerResolver.resolve("protostream")).isInstanceOf(ProtoStreamMarshaller.class);
+   }
+
+   @Test
+   public void testInvalidClassName() {
+      assertThatThrownBy(() -> MarshallerResolver.resolve("com.nonexistent.FakeMarshaller"))
+            .isInstanceOf(IllegalArgumentException.class);
+   }
+
+   @Test
+   public void testValidFQCN() {
+      assertThat(MarshallerResolver.resolve("org.infinispan.commons.marshall.ProtoStreamMarshaller"))
+            .isInstanceOf(ProtoStreamMarshaller.class);
+   }
+}

--- a/spring/common/src/test/java/org/infinispan/spring/common/session/SessionFallbackResolverTest.java
+++ b/spring/common/src/test/java/org/infinispan/spring/common/session/SessionFallbackResolverTest.java
@@ -1,0 +1,32 @@
+package org.infinispan.spring.common.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.infinispan.spring.common.marshalling.SpringJavaSerializationMarshaller;
+import org.testng.annotations.Test;
+
+@Test(testName = "spring.common.session.SessionFallbackResolverTest", groups = "unit")
+public class SessionFallbackResolverTest {
+
+   public void testResolveNull() {
+      assertThat(SessionFallbackResolver.resolve(null, getClass().getClassLoader()))
+            .isInstanceOf(SpringJavaSerializationMarshaller.class);
+   }
+
+   public void testResolveEmpty() {
+      assertThat(SessionFallbackResolver.resolve("", getClass().getClassLoader()))
+            .isInstanceOf(SpringJavaSerializationMarshaller.class);
+   }
+
+   public void testResolveJava() {
+      assertThat(SessionFallbackResolver.resolve("java", getClass().getClassLoader()))
+            .isInstanceOf(SpringJavaSerializationMarshaller.class);
+   }
+
+   public void testResolveInvalidClassName() {
+      assertThatThrownBy(() -> SessionFallbackResolver.resolve("com.example.NonExistentMarshaller", getClass().getClassLoader()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot instantiate session fallback serializer class");
+   }
+}

--- a/spring/common/src/test/java/org/infinispan/spring/common/session/SpringJavaSerializationMarshallerTest.java
+++ b/spring/common/src/test/java/org/infinispan/spring/common/session/SpringJavaSerializationMarshallerTest.java
@@ -1,0 +1,34 @@
+package org.infinispan.spring.common.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.infinispan.commons.configuration.ClassAllowList;
+import org.infinispan.commons.dataconversion.MediaType;
+import org.infinispan.spring.common.marshalling.SpringJavaSerializationMarshaller;
+import org.testng.annotations.Test;
+
+@Test(groups = "unit", testName = "spring.common.session.SpringJavaSerializationMarshallerTest")
+public class SpringJavaSerializationMarshallerTest {
+
+   public void testRoundTrip() throws Exception {
+      ClassAllowList allowList = new ClassAllowList(Collections.emptyList());
+      allowList.addRegexps("java.util\\..*", "java.lang\\..*");
+      SpringJavaSerializationMarshaller marshaller = new SpringJavaSerializationMarshaller(allowList);
+      String original = "test-value";
+      byte[] bytes = marshaller.objectToByteBuffer(original);
+      Object result = marshaller.objectFromByteBuffer(bytes);
+      assertThat(result).isEqualTo(original);
+   }
+
+   public void testMediaType() {
+      SpringJavaSerializationMarshaller marshaller = new SpringJavaSerializationMarshaller();
+      assertThat(marshaller.mediaType()).isEqualTo(MediaType.APPLICATION_SERIALIZED_OBJECT);
+   }
+
+   public void testIsMarshallable() {
+      SpringJavaSerializationMarshaller marshaller = new SpringJavaSerializationMarshaller();
+      assertThat(marshaller.isMarshallable("hello")).isTrue();
+   }
+}

--- a/spring/embedded/src/main/java/org/infinispan/spring/embedded/SpringEmbeddedModule.java
+++ b/spring/embedded/src/main/java/org/infinispan/spring/embedded/SpringEmbeddedModule.java
@@ -5,7 +5,6 @@ import static org.infinispan.marshall.protostream.impl.SerializationContextRegis
 
 import org.infinispan.commons.configuration.ClassAllowList;
 import org.infinispan.commons.logging.Log;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.commons.util.NullValue;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -13,6 +12,7 @@ import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
 import org.infinispan.protostream.BaseMarshaller;
+import org.infinispan.spring.common.marshalling.SpringJavaSerializationMarshaller;
 import org.infinispan.spring.common.session.MapSessionProtoAdapter;
 import org.springframework.session.MapSession;
 
@@ -30,14 +30,14 @@ public class SpringEmbeddedModule implements ModuleLifecycle {
       ClassAllowList serializationAllowList = gcr.getCacheManager().getClassAllowList();
       serializationAllowList.addClasses(NullValue.class);
       serializationAllowList.addRegexps("java.util\\..*", "org.springframework\\..*");
-      JavaSerializationMarshaller serializationMarshaller = new JavaSerializationMarshaller(serializationAllowList);
+      SpringJavaSerializationMarshaller serializationMarshaller = new SpringJavaSerializationMarshaller(serializationAllowList);
 
       SerializationContextRegistry ctxRegistry = gcr.getComponent(SerializationContextRegistry.class);
       addSessionContextInitializerAndMarshaller(ctxRegistry, serializationMarshaller);
    }
 
    private void addSessionContextInitializerAndMarshaller(SerializationContextRegistry ctxRegistry,
-                                                          JavaSerializationMarshaller serializationMarshaller) {
+                                                          SpringJavaSerializationMarshaller serializationMarshaller) {
       // Skip registering the marshallers if the MapSession class is not available
       try {
          new MapSession();

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -64,6 +64,11 @@
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>${version.jakarta.annotation-api}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>6.4.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <modules>

--- a/spring/remote/src/main/java/org/infinispan/spring/remote/provider/SpringRemoteCacheManager.java
+++ b/spring/remote/src/main/java/org/infinispan/spring/remote/provider/SpringRemoteCacheManager.java
@@ -11,6 +11,7 @@ import org.infinispan.commons.configuration.ClassAllowList;
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 import org.infinispan.commons.util.NullValue;
 import org.infinispan.protostream.BaseMarshaller;
@@ -18,6 +19,7 @@ import org.infinispan.protostream.SerializationContext;
 import org.infinispan.protostream.SerializationContextInitializer;
 import org.infinispan.spring.common.provider.SpringCache;
 import org.infinispan.spring.common.session.MapSessionProtoAdapter;
+import org.infinispan.spring.common.marshalling.SpringJavaSerializationMarshaller;
 import org.springframework.session.MapSession;
 import org.springframework.util.Assert;
 
@@ -170,12 +172,13 @@ public class SpringRemoteCacheManager implements org.springframework.cache.Cache
       if (protoMarshaller != null) {
          // Apply our own serialization context initializers
          SerializationContext ctx = protoMarshaller.getSerializationContext();
-         addSessionContextInitializerAndMarshaller(ctx, serializationMarshaller);
+         SpringJavaSerializationMarshaller sessionFallback = new SpringJavaSerializationMarshaller(serializationAllowList);
+         addSessionContextInitializerAndMarshaller(ctx, sessionFallback);
       }
    }
 
    private void addSessionContextInitializerAndMarshaller(SerializationContext ctx,
-                                                          JavaSerializationMarshaller serializationMarshaller) {
+                                                          Marshaller sessionFallbackMarshaller) {
       // Skip registering the marshallers if the MapSession class is not available
       try {
          new MapSession();
@@ -189,7 +192,7 @@ public class SpringRemoteCacheManager implements org.springframework.cache.Cache
       sessionSci.register(ctx);
 
       BaseMarshaller sessionAttributeMarshaller =
-            new MapSessionProtoAdapter.SessionAttributeRawMarshaller(serializationMarshaller);
+            new MapSessionProtoAdapter.SessionAttributeRawMarshaller(sessionFallbackMarshaller);
       ctx.registerMarshaller(sessionAttributeMarshaller);
    }
 }

--- a/spring/spring-boot-3/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
+++ b/spring/spring-boot-3/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
@@ -1,24 +1,34 @@
 package org.infinispan.spring.starter.embedded;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.spring.common.marshalling.MarshallerResolver;
+import org.infinispan.spring.common.marshalling.SchemaRegistration;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
@@ -39,6 +49,12 @@ public class InfinispanEmbeddedAutoConfiguration {
 
    @Autowired
    private InfinispanEmbeddedConfigurationProperties infinispanProperties;
+
+   @Autowired
+   private ApplicationContext ctx;
+
+   @Autowired(required = false)
+   private List<SerializationContextInitializer> contextInitializers;
 
    @Autowired(required = false)
    private final List<InfinispanCacheConfigurer> configurers = Collections.emptyList();
@@ -70,14 +86,18 @@ public class InfinispanEmbeddedAutoConfiguration {
          if (globalConfigurationBuilder.serialization().getMarshaller() == null) {
             // spring session needs does not work with protostream right now, easy users to configure the marshaller
             // and the classes we need for spring embedded
-            globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+            Marshaller marshaller = MarshallerResolver.resolve(infinispanProperties.getMarshaller());
+            globalConfigurationBuilder.serialization().marshaller(marshaller);
          }
          globalConfigurationCustomizers.forEach(customizer -> customizer.customize(globalConfigurationBuilder));
+         addSchemaAutoDiscovery(globalConfigurationBuilder);
          allowInternalClasses(globalConfigurationBuilder);
          manager = new DefaultCacheManager(holder, false);
       } else {
          GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
-         globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+         Marshaller marshaller = MarshallerResolver.resolve(infinispanProperties.getMarshaller(),
+               "java.util\\..*", "org.springframework\\..*");
+         globalConfigurationBuilder.serialization().marshaller(marshaller);
          allowInternalClasses(globalConfigurationBuilder);
 
          if (infinispanGlobalConfigurer != null) {
@@ -88,6 +108,7 @@ public class InfinispanEmbeddedAutoConfiguration {
          }
 
          globalConfigurationCustomizers.forEach(customizer -> customizer.customize(globalConfigurationBuilder));
+         addSchemaAutoDiscovery(globalConfigurationBuilder);
          manager = new DefaultCacheManager(globalConfigurationBuilder.build(), false);
 
          ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
@@ -105,5 +126,36 @@ public class InfinispanEmbeddedAutoConfiguration {
    private void allowInternalClasses(GlobalConfigurationBuilder globalConfigurationBuilder) {
       globalConfigurationBuilder.serialization().allowList().addClass("org.springframework.session.MapSession");
       globalConfigurationBuilder.serialization().allowList().addRegexp("java.util.*");
+   }
+
+   private void addSchemaAutoDiscovery(GlobalConfigurationBuilder globalConfigurationBuilder) {
+      // Auto discover and register schemas
+      List<GeneratedSchema> discoveredSchemas = new ArrayList<>();
+      try {
+         List<String> packages = AutoConfigurationPackages.get((BeanFactory) ctx);
+         discoveredSchemas = SchemaRegistration.discoverSchemas(ctx.getClassLoader(), packages);
+      } catch (IllegalStateException e) {
+         // Auto-configuration packages not available, skipping schema classpath scanning
+      }
+
+      // Collect user defined SerializationContextInitializer beans
+      Set<String> registeredClasses = new HashSet<>();
+      if (contextInitializers != null) {
+         for (SerializationContextInitializer sci : contextInitializers) {
+            if (sci instanceof GeneratedSchema gs && !discoveredSchemas.contains(gs)) {
+               discoveredSchemas.add(gs);
+            }
+            globalConfigurationBuilder.serialization().addContextInitializer(sci);
+            registeredClasses.add(sci.getClass().getName());
+         }
+      }
+
+      // Register classpath-discovered schemas with the builder
+      // Skipping those already registered as beans
+      for (GeneratedSchema schema : discoveredSchemas) {
+         if (!registeredClasses.contains(schema.getClass().getName())) {
+            globalConfigurationBuilder.serialization().addContextInitializer(schema);
+         }
+      }
    }
 }

--- a/spring/spring-boot-3/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedConfigurationProperties.java
+++ b/spring/spring-boot-3/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedConfigurationProperties.java
@@ -28,6 +28,13 @@ public class InfinispanEmbeddedConfigurationProperties {
     */
    private String clusterName = DEFAULT_CLUSTER_NAME;
 
+   /**
+    * The marshaller to use for cache serialization.
+    * Shortcuts: "java" (deprecated Java Serialization), "protostream" (recommended).
+    * Can also be a fully qualified class name.
+    */
+   private String marshaller;
+
    public String getConfigXml() {
       return configXml;
    }
@@ -66,5 +73,13 @@ public class InfinispanEmbeddedConfigurationProperties {
 
    public boolean isReactive() {
       return reactive;
+   }
+
+   public String getMarshaller() {
+      return marshaller;
+   }
+
+   public void setMarshaller(String marshaller) {
+      this.marshaller = marshaller;
    }
 }

--- a/spring/spring-boot-3/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteAutoConfiguration.java
+++ b/spring/spring-boot-3/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteAutoConfiguration.java
@@ -14,10 +14,11 @@ import java.util.logging.Logger;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.SerializationContextInitializer;
-import org.infinispan.spring.remote.provider.SchemaRegistration;
+import org.infinispan.spring.common.marshalling.MarshallerResolver;
+import org.infinispan.spring.common.marshalling.SchemaRegistration;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -88,7 +89,8 @@ public class InfinispanRemoteAutoConfiguration {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       //by default, add java white list and marshaller
       builder.addJavaSerialAllowList("java.util.*", "java.time.*", "org.springframework.*", "org.infinispan.spring.common.*", "org.infinispan.spring.remote.*");
-      builder.marshaller(new JavaSerializationMarshaller());
+      Marshaller marshaller = MarshallerResolver.resolve(infinispanProperties.getMarshaller());
+      builder.marshaller(marshaller);
 
       if (hasConfigurer) {
          builder.read(Objects.requireNonNull(infinispanRemoteConfigurer.getRemoteConfiguration()));

--- a/spring/spring-boot-3/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteConfigurationProperties.java
+++ b/spring/spring-boot-3/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteConfigurationProperties.java
@@ -50,6 +50,13 @@ public class InfinispanRemoteConfigurationProperties extends org.infinispan.clie
     */
    private boolean useSchemaRegistration = true;
 
+   /**
+    * The marshaller to use for cache serialization.
+    * Shortcuts: "java" (Java Serialization), "protostream" (recommended).
+    * Can also be a fully qualified class name.
+    */
+   private String marshaller;
+
    public String getClientProperties() {
       return clientProperties;
    }
@@ -163,5 +170,13 @@ public class InfinispanRemoteConfigurationProperties extends org.infinispan.clie
 
    public void setUseSchemaRegistration(boolean useSchemaRegistration) {
       this.useSchemaRegistration = useSchemaRegistration;
+   }
+
+   public String getMarshaller() {
+      return marshaller;
+   }
+
+   public void setMarshaller(String marshaller) {
+      this.marshaller = marshaller;
    }
 }

--- a/spring/spring-boot-4/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
+++ b/spring/spring-boot-4/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedAutoConfiguration.java
@@ -1,23 +1,33 @@
 package org.infinispan.spring.starter.embedded;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.SerializationContextInitializer;
+import org.infinispan.spring.common.marshalling.MarshallerResolver;
+import org.infinispan.spring.common.marshalling.SchemaRegistration;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Conditional;
@@ -38,6 +48,12 @@ public class InfinispanEmbeddedAutoConfiguration {
 
    @Autowired
    private InfinispanEmbeddedConfigurationProperties infinispanProperties;
+
+   @Autowired
+   private ApplicationContext ctx;
+
+   @Autowired(required = false)
+   private List<SerializationContextInitializer> contextInitializers;
 
    @Autowired(required = false)
    private final List<InfinispanCacheConfigurer> configurers = Collections.emptyList();
@@ -66,14 +82,18 @@ public class InfinispanEmbeddedAutoConfiguration {
          if (globalConfigurationBuilder.serialization().getMarshaller() == null) {
             // spring session needs does not work with protostream right now, easy users to configure the marshaller
             // and the classes we need for spring embedded
-            globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+            Marshaller marshaller = MarshallerResolver.resolve(infinispanProperties.getMarshaller());
+            globalConfigurationBuilder.serialization().marshaller(marshaller);
          }
          globalConfigurationCustomizers.forEach(customizer -> customizer.customize(globalConfigurationBuilder));
+         addSchemaAutoDiscovery(globalConfigurationBuilder);
          allowInternalClasses(globalConfigurationBuilder);
          manager = new DefaultCacheManager(holder, false);
       } else {
          GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
-         globalConfigurationBuilder.serialization().marshaller(new JavaSerializationMarshaller());
+         Marshaller marshaller = MarshallerResolver.resolve(infinispanProperties.getMarshaller(),
+               "java.util\\..*", "org.springframework\\..*");
+         globalConfigurationBuilder.serialization().marshaller(marshaller);
          allowInternalClasses(globalConfigurationBuilder);
 
          if (infinispanGlobalConfigurer != null) {
@@ -84,6 +104,7 @@ public class InfinispanEmbeddedAutoConfiguration {
          }
 
          globalConfigurationCustomizers.forEach(customizer -> customizer.customize(globalConfigurationBuilder));
+         addSchemaAutoDiscovery(globalConfigurationBuilder);
          manager = new DefaultCacheManager(globalConfigurationBuilder.build(), false);
       }
 
@@ -97,5 +118,36 @@ public class InfinispanEmbeddedAutoConfiguration {
    private void allowInternalClasses(GlobalConfigurationBuilder globalConfigurationBuilder) {
       globalConfigurationBuilder.serialization().allowList().addClass("org.springframework.session.MapSession");
       globalConfigurationBuilder.serialization().allowList().addRegexp("java.util.*");
+   }
+
+   private void addSchemaAutoDiscovery(GlobalConfigurationBuilder globalConfigurationBuilder) {
+      // Auto discover and register schemas
+      List<GeneratedSchema> discoveredSchemas = new ArrayList<>();
+      try {
+         List<String> packages = AutoConfigurationPackages.get((BeanFactory) ctx);
+         discoveredSchemas = SchemaRegistration.discoverSchemas(ctx.getClassLoader(), packages);
+      } catch (IllegalStateException e) {
+         // Auto-configuration packages not available, skipping schema classpath scanning
+      }
+
+      // Collect user defined SerializationContextInitializer beans
+      Set<String> registeredClasses = new HashSet<>();
+      if (contextInitializers != null) {
+         for (SerializationContextInitializer sci : contextInitializers) {
+            if (sci instanceof GeneratedSchema gs && !discoveredSchemas.contains(gs)) {
+               discoveredSchemas.add(gs);
+            }
+            globalConfigurationBuilder.serialization().addContextInitializer(sci);
+            registeredClasses.add(sci.getClass().getName());
+         }
+      }
+
+      // Register classpath-discovered schemas with the builder
+      // Skipping those already registered as beans
+      for (GeneratedSchema schema : discoveredSchemas) {
+         if (!registeredClasses.contains(schema.getClass().getName())) {
+            globalConfigurationBuilder.serialization().addContextInitializer(schema);
+         }
+      }
    }
 }

--- a/spring/spring-boot-4/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedConfigurationProperties.java
+++ b/spring/spring-boot-4/embedded/src/main/java/org/infinispan/spring/starter/embedded/InfinispanEmbeddedConfigurationProperties.java
@@ -28,6 +28,13 @@ public class InfinispanEmbeddedConfigurationProperties {
     */
    private String clusterName = DEFAULT_CLUSTER_NAME;
 
+   /**
+    * The marshaller to use for cache serialization.
+    * Shortcuts: "java" (deprecated Java Serialization), "protostream" (recommended).
+    * Can also be a fully qualified class name.
+    */
+   private String marshaller;
+
    public String getConfigXml() {
       return configXml;
    }
@@ -66,5 +73,13 @@ public class InfinispanEmbeddedConfigurationProperties {
 
    public boolean isReactive() {
       return reactive;
+   }
+
+   public String getMarshaller() {
+      return marshaller;
+   }
+
+   public void setMarshaller(String marshaller) {
+      this.marshaller = marshaller;
    }
 }

--- a/spring/spring-boot-4/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteAutoConfiguration.java
+++ b/spring/spring-boot-4/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteAutoConfiguration.java
@@ -14,10 +14,11 @@ import java.util.logging.Logger;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.protostream.GeneratedSchema;
 import org.infinispan.protostream.SerializationContextInitializer;
-import org.infinispan.spring.remote.provider.SchemaRegistration;
+import org.infinispan.spring.common.marshalling.MarshallerResolver;
+import org.infinispan.spring.common.marshalling.SchemaRegistration;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -91,7 +92,8 @@ public class InfinispanRemoteAutoConfiguration {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       //by default, add java white list and marshaller
       builder.addJavaSerialAllowList("java.util.*", "java.time.*", "org.springframework.*", "org.infinispan.spring.common.*", "org.infinispan.spring.remote.*");
-      builder.marshaller(new JavaSerializationMarshaller());
+      Marshaller marshaller = MarshallerResolver.resolve(infinispanProperties.getMarshaller());
+      builder.marshaller(marshaller);
 
       if (hasConfigurer) {
          builder.read(Objects.requireNonNull(infinispanRemoteConfigurer.getRemoteConfiguration()));

--- a/spring/spring-boot-4/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteConfigurationProperties.java
+++ b/spring/spring-boot-4/remote/src/main/java/org/infinispan/spring/starter/remote/InfinispanRemoteConfigurationProperties.java
@@ -50,6 +50,13 @@ public class InfinispanRemoteConfigurationProperties extends org.infinispan.clie
     */
    private boolean useSchemaRegistration = true;
 
+   /**
+    * The marshaller to use for cache serialization.
+    * Shortcuts: "java" (Java Serialization), "protostream" (recommended).
+    * Can also be a fully qualified class name.
+    */
+   private String marshaller;
+
    public String getClientProperties() {
       return clientProperties;
    }
@@ -171,5 +178,13 @@ public class InfinispanRemoteConfigurationProperties extends org.infinispan.clie
 
    public void setUseSchemaRegistration(boolean useSchemaRegistration) {
       this.useSchemaRegistration = useSchemaRegistration;
+   }
+
+   public String getMarshaller() {
+      return marshaller;
+   }
+
+   public void setMarshaller(String marshaller) {
+      this.marshaller = marshaller;
    }
 }


### PR DESCRIPTION
* Moves to a Java Serializer in the Spring module only - for future deprecation / removal of the Java serialization marshaller
* Explores attribute fallback for json marshalling
* adds alias for java / protostream so we don't force users to know which is the class, still being able to provide their own marshaller 
* adds warnings so spring boot users move out from java marshaller in commons if they use it explicitly in they config to anticipate a future removal


This is still DRAFT

Closes #17959 