### PR TITLE
bump images release to main like 16.0.x

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -1,8 +1,5 @@
 name: Release Images
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -51,25 +48,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch }}
 
       -  name: Generate Image Tags
          run: echo "IMAGE_TAGS=$(./.github/scripts/image_tags.sh)" >> "$GITHUB_ENV"
          env:
-            VERSION: ${{ inputs.version }}
-            TYPE: ${{ inputs.type }}
+           VERSION: ${{ inputs.version }}
+           TYPE: ${{ inputs.type }}
 
       - name: Log in to Docker Hub
-        uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
+        uses: redhat-actions/podman-login@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: docker.io
 
       - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
+        uses: redhat-actions/podman-login@v2
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
@@ -82,7 +79,7 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@719e3c40d8af9790c23eca13f7daa339f2867034 # v2
+        uses: redhat-actions/buildah-build@v3
         with:
           build-args: |
             BRAND_VERSION=${{ inputs.version }}
@@ -98,7 +95,7 @@ jobs:
       - name: Push to Docker Hub
         id: push-to-docker
         if: ${{ inputs.push }}
-        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 # v2
+        uses: redhat-actions/push-to-registry@v3
         with:
           registry: docker.io/infinispan
           image: server
@@ -110,7 +107,7 @@ jobs:
       - name: Push to Quay.io
         id: push-to-quay
         if: ${{ inputs.push }}
-        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 # v2
+        uses: redhat-actions/push-to-registry@v3
         with:
           registry: quay.io/infinispan
           image: server

--- a/.github/workflows/snapshot_image.yml
+++ b/.github/workflows/snapshot_image.yml
@@ -1,8 +1,5 @@
 name: Snapshot Images
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -39,7 +36,7 @@ jobs:
 
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8.0.1
         with:
           run-id: '${{ inputs.runId }}'
           name: infinispan-dist
@@ -50,7 +47,7 @@ jobs:
         run: |
           unzip -q infinispan-*-src.zip
           SRCROOT=$(find . -maxdepth 1 -type d -name '*src')
-          echo "srcroot=$SRCROOT" >> "$GITHUB_OUTPUT"
+          echo "srcroot=$SRCROOT" >> $GITHUB_OUTPUT
           mv infinispan-server-*.zip "$SRCROOT"/server/image/infinispan-server.zip
 
       - name: Install qemu
@@ -60,7 +57,7 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@719e3c40d8af9790c23eca13f7daa339f2867034 # v2
+        uses: redhat-actions/buildah-build@v3
         with:
           build-args: |
             BRAND_VERSION=${{ inputs.runId }}
@@ -74,7 +71,7 @@ jobs:
           tags: ${{ inputs.tag }}
 
       - name: Log in to Quay.io
-        uses: redhat-actions/podman-login@50c2d9a331bb67c8fdab99b86455fad05e2e3252 # v2.0
+        uses: redhat-actions/podman-login@v2
         with:
           username: ${{ secrets.QUAY_USERNAME_TEST }}
           password: ${{ secrets.QUAY_TOKEN_TEST }}
@@ -82,7 +79,7 @@ jobs:
 
       - name: Push to Quay.io
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@94ade333c38ecc0e60e94785125d9a52ca423b37 # v2
+        uses: redhat-actions/push-to-registry@v3
         with:
           registry: quay.io/infinispan-test
           image: server


### PR DESCRIPTION
snapshot image release does not work
release might be broken too

updated to 16.0.x config 